### PR TITLE
chore: issue templates, labels, and auto-labeler workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug report
+description: Something works incorrectly but the app didn't crash (broken button, wrong number, UI glitch, etc.)
+title: "Bug: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. For app crashes (with a stack trace), please use the **Crash report** form instead — it has the right fields and dedup hints.
+
+        Quick checks:
+        - Is this already fixed in the latest version? See the [releases page](https://github.com/digital-grease/fauxx/releases).
+        - Is your question answered by the [FAQ](https://github.com/digital-grease/fauxx#faq)?
+
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      placeholder: Google Pixel 7 Pro
+    validations:
+      required: true
+
+  - type: input
+    id: android_version
+    attributes:
+      label: Android version
+      placeholder: "14"
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: Fauxx version
+      placeholder: 0.2.7 (207)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: flavor
+    attributes:
+      label: Build flavor
+      options:
+        - Full
+        - Play
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Best guess of what part of the app this affects. The auto-labeler reads this to tag the issue.
+      options:
+        - engine
+        - ui
+        - location
+        - targeting
+        - network
+        - other
+    validations:
+      required: false
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      placeholder: Describe what you saw.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: Describe what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can someone else reproduce this? Numbered steps are great.
+      placeholder: |
+        1. Open Fauxx
+        2. Tap …
+        3. …
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# Disable the empty "Open a blank issue" link so users land on a structured form.
+# An "Other" Markdown fallback is still available for genuinely unusual issues.
+blank_issues_enabled: false
+
+# Links shown alongside the issue forms. Helps users self-resolve before filing.
+contact_links:
+  - name: FAQ (README)
+    url: https://github.com/digital-grease/fauxx#faq
+    about: Common questions and known issues (tap-to-resume notification, Wi-Fi-only mode, mock location setup, etc.)
+  - name: Latest release & changelog
+    url: https://github.com/digital-grease/fauxx/releases/latest
+    about: If the bug you hit was already fixed in a newer version, that'll save us both a round trip.

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,0 +1,78 @@
+name: Crash report
+description: Fauxx crashed (e.g. an unexpected stop, a "Fauxx has stopped" dialog, or a notification gone red)
+title: "Crash: "
+labels: ["bug", "crash", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a crash. Before you file:
+
+        - **Have you checked the [FAQ](https://github.com/digital-grease/fauxx#faq)?** It explains the most common crash scenario (Android 14+ `dataSync` foreground-service timeout) — fixed in v0.2.7+.
+        - **Are you running v0.2.7 or later?** If you're on an older version, please update first; the most common overnight crash is already fixed.
+        - **Filing from the app's "File a GitHub Issue" button?** Most of these fields will be pre-filled for you. You only need to paste the stack trace and (optionally) say what you were doing.
+
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      description: Manufacturer + model (the in-app reporter fills this from `Build.MANUFACTURER` + `Build.MODEL`)
+      placeholder: Google Pixel 7 Pro
+    validations:
+      required: true
+
+  - type: input
+    id: android_version
+    attributes:
+      label: Android version
+      description: Major OS version. API level is fine if that's what you know.
+      placeholder: "14"
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: Fauxx version
+      description: From Settings → About, or pre-filled by the in-app reporter
+      placeholder: 0.2.7 (207)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: flavor
+    attributes:
+      label: Build flavor
+      description: Where did you install Fauxx from? (F-Droid / sideload = "Full", Play Store = "Play")
+      options:
+        - Full
+        - Play
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: stack_trace
+    attributes:
+      label: Stack trace / crash log
+      description: |
+        Paste the crash report here. The in-app reporter will pre-fill this section if it fits;
+        if the trace is too long for a URL, the in-app reporter copies the full log to your
+        clipboard for you to paste.
+      placeholder: |
+        === Fauxx Crash Report ===
+        Time: 2026-05-13 ...
+        Thread: main
+        ...
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What were you doing when it crashed?
+      description: Optional. Anything that helps reproduce, or "I just opened the app and saw the crash notification" is fine.
+      placeholder: I opened the app this morning and got the crash dialog. Engine was running overnight.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest a new feature, setting, or behavior
+title: "Feature: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Quick checks first:
+        - Has someone else already requested this? Browse open `enhancement` issues.
+        - Is this actually a bug? Use the **Bug report** form instead.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What would you like to see?
+      placeholder: A short description of the feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why? What problem does it solve?
+      description: Use case, motivation, or the workaround you're currently doing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Any other approaches you thought about?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,16 @@
+---
+name: Something else
+about: Use this only if none of the structured forms fit your issue
+title: ""
+labels: ["triage"]
+---
+
+<!--
+If your issue fits one of the structured templates (crash, bug, feature, question),
+please use that one instead — it helps with triage and lets the auto-labeler tag
+your issue correctly.
+
+Use this template only as a fallback for unusual cases.
+-->
+
+

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,29 @@
+name: Question / Help
+description: How does X work, what does Y mean, why is Z happening?
+title: "Question: "
+labels: ["question", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, please check:
+        - The [README](https://github.com/digital-grease/fauxx#readme) and [FAQ](https://github.com/digital-grease/fauxx#faq).
+        - The in-app FAQ (Help button → FAQ in the app).
+
+        For app crashes, please use the **Crash report** form instead.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      placeholder: What are you trying to do, or what's confusing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Optional but very helpful — saves us asking "did you check X?"
+    validations:
+      required: false

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,88 @@
+name: Issue Labeler
+
+# Adds labels to new issues based on content signals (crash markers, flavor, area).
+# Belt-and-suspenders for the form-applied labels: covers issues filed via the API,
+# `gh issue create`, the "Other" Markdown fallback, or that bypass the forms.
+#
+# Idempotent — re-running on the same issue doesn't error (gh issue edit --add-label
+# is a no-op if the label is already applied).
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  label:
+    name: Apply content-based labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels from issue title + body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TITLE: ${{ github.event.issue.title }}
+          BODY: ${{ github.event.issue.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          labels_to_add=()
+
+          # --- Crash signals ---
+          # The dataSync FGS timeout is the dominant crash class. Detect from the
+          # exception name or the FQCN — both survive copy-paste cleanly.
+          if echo "$TITLE" | grep -qiE 'crash|crashed|crashing'; then
+            labels_to_add+=("crash")
+          fi
+          if echo "$BODY" | grep -qE 'ForegroundServiceDidNotStopInTimeException|PhantomForegroundService|dataSync'; then
+            labels_to_add+=("crash" "area:engine")
+          fi
+
+          # --- Flavor detection ---
+          # `com.fauxx.full` always indicates the full build; bare `com.fauxx` (when
+          # not followed by `.full`) is the play build. Order matters here.
+          if echo "$BODY" | grep -q 'com\.fauxx\.full'; then
+            labels_to_add+=("flavor:full")
+          elif echo "$BODY" | grep -qE 'com\.fauxx([^.]|$)'; then
+            labels_to_add+=("flavor:play")
+          fi
+
+          # --- Area signals (content-based fallback for the bug-report dropdown) ---
+          if echo "$BODY" | grep -qE 'mock location|Developer Options|ACCESS_MOCK_LOCATION|LocationSpoof'; then
+            labels_to_add+=("area:location")
+          fi
+          if echo "$BODY" | grep -qE 'Scrape Now|Layer 2|adversarial scraper|PlatformProfile'; then
+            labels_to_add+=("area:targeting")
+          fi
+          if echo "$BODY" | grep -qiE 'wifi.only|wi-fi only|mobile data|paused.*wifi'; then
+            labels_to_add+=("area:ui")
+          fi
+          if echo "$BODY" | grep -qE 'User-Agent|user agent|OkHttp|DNS noise'; then
+            labels_to_add+=("area:network")
+          fi
+
+          # --- Bug-report `area` dropdown ---
+          # GitHub renders dropdown answers as a "### Area\n\nvalue" section in body.
+          # Match the line that follows a "### Area" header to derive area:<value>.
+          area_value=$(printf '%s\n' "$BODY" \
+            | awk '/^### Area$/{flag=1; next} flag && NF{print; flag=0}' \
+            | tr '[:upper:]' '[:lower:]' \
+            | tr -d '[:space:]' \
+            | head -c 32 || true)
+          case "$area_value" in
+            engine|ui|location|targeting|network)
+              labels_to_add+=("area:$area_value")
+              ;;
+          esac
+
+          # --- Dedup + apply ---
+          if [ "${#labels_to_add[@]}" -eq 0 ]; then
+            echo "No content-based labels matched; nothing to add."
+            exit 0
+          fi
+          unique_labels=$(printf '%s\n' "${labels_to_add[@]}" | sort -u | tr '\n' ',' | sed 's/,$//')
+          echo "Applying labels: $unique_labels"
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$unique_labels"


### PR DESCRIPTION
Adds:                                                          
                                                    
  - `.github/ISSUE_TEMPLATE/crash_report.yml`, `bug_report.yml`, `feature_request.yml`, `question.yml` — structured forms. Form-applied labels work for   
  public filers (URL-param labels do not).                                                                                                                
  - `.github/ISSUE_TEMPLATE/other.md` — Markdown fallback for unusual issues.
  - `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, surfaces FAQ + latest release as contact links.                                          
  - `.github/workflows/issue-labeler.yml` — applies `crash`, `flavor:*`, `area:*` labels from title/body signals so issues filed via the API or "Other"
  fallback still get categorised.                                                                                                                         
                                                      
  Custom labels created separately via `gh label create` (see commit body).                                                                               
                                                                                                                                                          
  In-app `LogExportSheet` pre-fill that lands users on the crash form with device/version/flavor already populated is deferred to a follow-up — it rides  
  an app release, not this repo-config PR.                                                                                                                
                                                                                                                                                          
  ## Test plan                                                                                                                                            
                                                                                                                                                          
  - [x] All YAML parses (`python3 -c "import yaml; yaml.safe_load(open(f))"`).                                                                            
  - [ ] After merge: file a test issue via each form, confirm labels apply and required-field validation works.                                           
  - [ ] After merge: verify auto-labeler fires on a manually-filed "Other" issue with `dataSync` in the body.