### PR TITLE
fix: labeler parses form Build flavor dropdown

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -41,9 +41,27 @@ jobs:
             labels_to_add+=("crash" "area:engine")
           fi
 
-          # --- Flavor detection ---
-          # `com.fauxx.full` always indicates the full build; bare `com.fauxx` (when
-          # not followed by `.full`) is the play build. Order matters here.
+          # --- Flavor detection (form dropdown) ---
+          # Crash/bug forms write the user's "Build flavor" choice as a
+          # "### Build flavor\n\nFull" section. Parse that first — it's the most
+          # reliable signal and works even when the body has no crash trace.
+          flavor_value=$(printf '%s\n' "$BODY" \
+            | awk '/^### Build flavor$/{flag=1; next} flag && NF{print; flag=0}' \
+            | tr '[:upper:]' '[:lower:]' \
+            | tr -d '[:space:]' \
+            | head -c 32 || true)
+          case "$flavor_value" in
+            full) labels_to_add+=("flavor:full") ;;
+            play) labels_to_add+=("flavor:play") ;;
+            # "Not sure" or anything else: don't guess, fall through to content check.
+          esac
+
+          # --- Flavor detection (content-based fallback) ---
+          # For "Other" template or API-filed issues without the form dropdown:
+          # `com.fauxx.full` always indicates the full build; bare `com.fauxx`
+          # (when not followed by `.full`) is the play build. Order matters.
+          # Safe to run even if the dropdown already labeled — gh issue edit
+          # --add-label is idempotent and dedup happens in the apply step.
           if echo "$BODY" | grep -q 'com\.fauxx\.full'; then
             labels_to_add+=("flavor:full")
           elif echo "$BODY" | grep -qE 'com\.fauxx([^.]|$)'; then


### PR DESCRIPTION
Tested on issue #42 (filed via the new crash form): the form had `###     
  Build flavor\n\nFull` in the body but the labeler missed it because it only matched `com.fauxx.full` from stack-trace content, and the test trace had no
   real component info.                                                                                                                                   
                                                                                   
  Adds a section parser for `### Build flavor` ahead of the content-regex fallback. Both paths run idempotently so form-filed and "Other"-template issues
  both get the right flavor label.                    
                                                                                                                                                          
  ## Test plan                                        
                                                                                                                                                          
  - [x] YAML parses                                                                                                                                       
  - [ ] Merge, then edit #42 (append a space) to retrigger labeler. Confirm `flavor:full` lands.