### PR TITLE
test: engine + BootReceiver integration coverage, CI permissions, dead-import cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Test (${{ matrix.flavor }})

--- a/app/src/androidTest/java/com/fauxx/ui/DashboardScreenTest.kt
+++ b/app/src/androidTest/java/com/fauxx/ui/DashboardScreenTest.kt
@@ -81,20 +81,11 @@ class DashboardScreenTest {
         composeRule.onNodeWithText("NOISE RATIO").assertIsDisplayed()
     }
 
-    @Test
-    fun toggleProtectionOn_changesStatusToActive() {
-        composeRule.setContent {
-            FauxxTheme {
-                DashboardScreen()
-            }
-        }
-        // Initially inactive
-        composeRule.onNodeWithText("INACTIVE").assertIsDisplayed()
-
-        // Toggle the switch (it's the only Switch on this screen)
-        composeRule.onNodeWithText("Engine stopped").assertIsDisplayed()
-        // Note: toggling the engine starts a ForegroundService which requires
-        // FOREGROUND_SERVICE permission — the UI state update is still testable
-        composeRule.onNodeWithText("INACTIVE").assertIsDisplayed()
-    }
+    // toggleProtectionOn_changesStatusToActive removed 2026-05-13: it claimed to
+    // test the off→on transition but its body asserted "INACTIVE" twice without
+    // ever invoking the toggle. The remaining tests in this file cover the
+    // structural rendering. A real toggle test is deferred to the Phase 2 emulator
+    // smoke suite — it needs FOREGROUND_SERVICE permission handling and a
+    // foreground-service-startable context that instrumented unit tests don't
+    // reliably provide. See .devloop/spikes/integration-testing-audit.md.
 }

--- a/app/src/androidTest/java/com/fauxx/ui/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/fauxx/ui/SettingsScreenTest.kt
@@ -1,6 +1,5 @@
 package com.fauxx.ui
 
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/androidTest/java/com/fauxx/ui/TargetingScreenTest.kt
+++ b/app/src/androidTest/java/com/fauxx/ui/TargetingScreenTest.kt
@@ -1,6 +1,5 @@
 package com.fauxx.ui
 
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/java/com/fauxx/EngineResumeSchedulerIntegrationTest.kt
+++ b/app/src/test/java/com/fauxx/EngineResumeSchedulerIntegrationTest.kt
@@ -1,0 +1,273 @@
+package com.fauxx
+
+import androidx.work.Configuration
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
+import com.fauxx.data.crawllist.CrawlListManager
+import com.fauxx.data.crawllist.DomainBlocklist
+import com.fauxx.data.db.ActionLogDao
+import com.fauxx.data.location.CityCoord
+import com.fauxx.data.location.CityDatabase
+import com.fauxx.data.model.IntensityLevel
+import com.fauxx.data.model.PoisonProfile
+import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.data.querybank.QueryBankManager
+import com.fauxx.engine.FgsBudgetTracker
+import com.fauxx.engine.PoisonEngine
+import com.fauxx.engine.PoisonProfileRepository
+import com.fauxx.engine.modules.AppSignalModule
+import com.fauxx.engine.modules.CookieSaturationModule
+import com.fauxx.engine.modules.DnsNoiseModule
+import com.fauxx.engine.modules.FingerprintModule
+import com.fauxx.engine.modules.Module
+import com.fauxx.engine.modules.SearchPoisonModule
+import com.fauxx.engine.scheduling.ActionDispatcher
+import com.fauxx.engine.scheduling.PoissonScheduler
+import com.fauxx.service.ResumeScheduler
+import com.fauxx.targeting.TargetingEngine
+import com.fauxx.util.Clock
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Integration test bridging two units that are individually well-tested but only
+ * tied together in production code: [PoisonEngine] (engine loop decisions, unit-
+ * tested in `PoisonEngineConstraintTest` and `PoisonEngineLoopTest`) and
+ * [ResumeScheduler] (WorkManager enqueue, indirectly exercised). The actual wire
+ * — engine signals `onLongPause` → `ResumeScheduler.schedule` runs → WorkManager
+ * gets a `fauxx_resume` job — has no test today; it's the exact gap noted in
+ * `.devloop/spikes/integration-testing-audit.md`.
+ *
+ * Test approach: real engine, real ResumeScheduler, real (test-mode) WorkManager.
+ * The engine's `onLongPause` callback is connected to `scheduler.schedule(spec)`
+ * exactly as `PhantomForegroundService` does in production. Drive the engine into
+ * PAUSED_QUIET_HOURS via a 3am `FakeClock`, advance virtual time to let `runLoop`
+ * fire, then assert WorkManager has an enqueued `fauxx_resume` entry.
+ *
+ * What a failure here would catch:
+ *  - Engine stops calling `onLongPause` (regression in `runLoop`'s resign branch).
+ *  - `ResumeScheduler.schedule` changes its unique-work name or policy and silently
+ *    drops the request.
+ *  - `ResumeSpec.AtTime.epochMs` is computed wrong and produces a malformed delay
+ *    that WorkManager rejects.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = android.app.Application::class)
+class EngineResumeSchedulerIntegrationTest {
+
+    private class FakeClock(var nowMs: Long) : Clock {
+        override fun currentTimeMillis(): Long = nowMs
+        override fun elapsedRealtime(): Long = nowMs
+    }
+
+    private lateinit var workManager: WorkManager
+    private lateinit var engine: PoisonEngine
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        val config = Configuration.Builder()
+            .setMinimumLoggingLevel(android.util.Log.DEBUG)
+            .setExecutor(SynchronousExecutor())
+            .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
+        workManager = WorkManager.getInstance(context)
+    }
+
+    @After
+    fun tearDown() {
+        if (::engine.isInitialized) engine.destroy()
+    }
+
+    @Test
+    fun `engine resigning during quiet hours enqueues a resume work item`() = runTest {
+        // 3am local — outside the 7-23 allowed window. First runLoop iteration will
+        // see PAUSED_QUIET_HOURS and invoke decidePauseAction → Resign.
+        val clock = FakeClock(threeAmEpochMs())
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val context = RuntimeEnvironment.getApplication()
+        val resumeScheduler = ResumeScheduler(context)
+
+        engine = buildEngine(clock, dispatcher)
+        // Wire identically to PhantomForegroundService.onStartCommand at line 92.
+        engine.setOnLongPause { spec -> resumeScheduler.schedule(spec) }
+        engine.start()
+
+        advanceVirtualTime(clock, scheduler = testScheduler, by = 500)
+
+        // Assertion the production wire promises: after the engine resigns, a
+        // fauxx_resume work item exists. Pre-fix runLoop would never reach this state.
+        val resumeWork = workManager.getWorkInfosForUniqueWork("fauxx_resume").get()
+        assertEquals("expected a single resume work item", 1, resumeWork.size)
+        val info = resumeWork[0]
+        // The TestWorkManager + SynchronousExecutor combo may run the worker
+        // immediately to SUCCEEDED; production WorkManager would leave it ENQUEUED
+        // or BLOCKED until the AtTime delay or constraint resolves. Accept any
+        // non-failure state — the wire we're testing is just "engine resign caused
+        // ResumeScheduler to enqueue work."
+        assertTrue(
+            "resume work shouldn't be in a failure state, got ${info.state}",
+            info.state != WorkInfo.State.FAILED && info.state != WorkInfo.State.CANCELLED
+        )
+    }
+
+    @Test
+    fun `engine resigning a second time replaces the prior resume work item`() = runTest {
+        // Drives two separate engine sessions and asserts the unique-work REPLACE policy
+        // holds — a fresh resign overwrites a stale one rather than queuing duplicates.
+        val clock = FakeClock(threeAmEpochMs())
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val context = RuntimeEnvironment.getApplication()
+        val resumeScheduler = ResumeScheduler(context)
+
+        engine = buildEngine(clock, dispatcher)
+        engine.setOnLongPause { spec -> resumeScheduler.schedule(spec) }
+        engine.start()
+        advanceVirtualTime(clock, scheduler = testScheduler, by = 500)
+
+        val firstWork = workManager.getWorkInfosForUniqueWork("fauxx_resume").get()
+        assertEquals(1, firstWork.size)
+        val firstId = firstWork[0].id
+
+        // Reset and restart with a fresh resign — should replace, not duplicate.
+        engine.destroy()
+        engine = buildEngine(clock, dispatcher)
+        engine.setOnLongPause { spec -> resumeScheduler.schedule(spec) }
+        engine.start()
+        advanceVirtualTime(clock, scheduler = testScheduler, by = 500)
+
+        val resumeWork = workManager.getWorkInfosForUniqueWork("fauxx_resume").get()
+        val active = resumeWork.firstOrNull { it.state != WorkInfo.State.CANCELLED }
+        assertNotNull("at least one active resume work item must exist", active)
+        // The active one should be a different UUID — REPLACE policy created fresh work.
+        // (Some replace strategies reuse the ID; either is acceptable as long as exactly
+        // one is active. Catch the truly broken case: multiple active entries.)
+        val activeCount = resumeWork.count { it.state != WorkInfo.State.CANCELLED }
+        assertEquals("REPLACE must leave exactly one active entry, not duplicates", 1, activeCount)
+    }
+
+    /**
+     * Step time forward in small increments so `runTest`'s scheduler can fire each
+     * `delay()` resumption. The fake clock advances together with the scheduler so
+     * `elapsedRealtime()` and coroutine virtual time agree.
+     */
+    private suspend fun advanceVirtualTime(
+        clock: FakeClock,
+        scheduler: kotlinx.coroutines.test.TestCoroutineScheduler,
+        by: Long
+    ) {
+        val step = 100L
+        var remaining = by
+        while (remaining > 0) {
+            val chunk = minOf(step, remaining)
+            clock.nowMs += chunk
+            scheduler.advanceTimeBy(chunk)
+            scheduler.runCurrent()
+            remaining -= chunk
+        }
+        delay(1)
+        scheduler.runCurrent()
+    }
+
+    private fun threeAmEpochMs(): Long {
+        val cal = java.util.Calendar.getInstance().apply {
+            set(java.util.Calendar.HOUR_OF_DAY, 3)
+            set(java.util.Calendar.MINUTE, 0)
+            set(java.util.Calendar.SECOND, 0)
+            set(java.util.Calendar.MILLISECOND, 0)
+        }
+        return cal.timeInMillis
+    }
+
+    private fun buildEngine(clock: Clock, loopDispatcher: CoroutineDispatcher): PoisonEngine {
+        val baseProfile = PoisonProfile(
+            enabled = true,
+            intensity = IntensityLevel.LOW,
+            wifiOnly = false,
+            batteryThreshold = 0,
+            allowedHoursStart = 7,
+            allowedHoursEnd = 23,
+            searchPoisonEnabled = true,
+            adPollutionEnabled = false,
+            locationSpoofEnabled = false,
+            fingerprintEnabled = false,
+            cookieSaturationEnabled = false,
+            appSignalEnabled = false,
+            dnsNoiseEnabled = false,
+            layer1Enabled = false,
+            layer2Enabled = false,
+            layer3Enabled = false
+        )
+        val profileRepo: PoisonProfileRepository = mockk { every { getProfile() } returns baseProfile }
+        val dispatcher: ActionDispatcher = mockk { coEvery { selectCategory() } returns CategoryPool.GAMING }
+        val scheduler: PoissonScheduler = mockk {
+            every { nextDelayMs(any(), any(), any(), any(), any()) } returns 1000L
+        }
+        val actionLogDao: ActionLogDao = mockk(relaxed = true)
+        val blocklist: DomainBlocklist = mockk { every { loadFailed } returns false }
+        val queryBankManager: QueryBankManager = mockk { every { getQueries(any()) } returns listOf("test") }
+        val crawlListManager: CrawlListManager = mockk { every { corpusSize() } returns 100 }
+        val cityDatabase: CityDatabase = mockk {
+            every { cities } returns listOf(
+                CityCoord("A", 0.0, 0.0, "X"),
+                CityCoord("B", 1.0, 1.0, "X")
+            )
+        }
+        val searchModule: SearchPoisonModule = mockk(relaxed = true) { every { isEnabled() } returns true }
+        val noopModule: Module = mockk(relaxed = true) { every { isEnabled() } returns false }
+        val targetingEngine: TargetingEngine = mockk(relaxed = true) {
+            every { setLayer1Enabled(any()) } answers { }
+            every { setLayer2Enabled(any()) } answers { }
+            every { setLayer3Enabled(any()) } answers { }
+        }
+        val connectivityManager: android.net.ConnectivityManager = mockk(relaxed = true)
+        val context: android.content.Context = mockk(relaxed = true) {
+            every { getSystemService(android.content.Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+        }
+        val budgetTracker: FgsBudgetTracker = mockk(relaxed = true) {
+            every { remainingBudgetMs() } returns FgsBudgetTracker.BUDGET_MS
+            every { nextWindowResetMs() } returns clock.currentTimeMillis() + 60 * 60 * 1000L
+        }
+        return PoisonEngine(
+            context, profileRepo, targetingEngine, dispatcher, scheduler, actionLogDao,
+            blocklist, queryBankManager, crawlListManager, cityDatabase,
+            searchModule,
+            adModule = noopModule,
+            locationModule = noopModule,
+            fingerprintModule = mockk<FingerprintModule>(relaxed = true) {
+                every { isEnabled() } returns false
+            },
+            cookieModule = mockk<CookieSaturationModule>(relaxed = true) {
+                every { isEnabled() } returns false
+            },
+            appSignalModule = mockk<AppSignalModule>(relaxed = true) {
+                every { isEnabled() } returns false
+            },
+            dnsModule = mockk<DnsNoiseModule>(relaxed = true) {
+                every { isEnabled() } returns false
+            },
+            clock = clock,
+            budgetTracker = budgetTracker,
+            loopDispatcher = loopDispatcher
+        )
+    }
+}

--- a/app/src/test/java/com/fauxx/service/BootReceiverTest.kt
+++ b/app/src/test/java/com/fauxx/service/BootReceiverTest.kt
@@ -1,0 +1,157 @@
+package com.fauxx.service
+
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import androidx.datastore.preferences.core.edit
+import com.fauxx.di.PreferenceKeys
+import com.fauxx.di.fauxxDataStore
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Integration test for [BootReceiver] — covers the path with zero existing test
+ * coverage flagged in `.devloop/spikes/integration-testing-audit.md`. Drives the
+ * full receiver flow end-to-end:
+ *
+ *   DataStore primed → ACTION_BOOT_COMPLETED → DataStore read in runBlocking →
+ *   conditional post via NotificationManagerCompat → notification appears.
+ *
+ * Pinned to API 32 (`@Config(sdk = [32])`) so the Android-13+ POST_NOTIFICATIONS
+ * runtime permission check in [postResumeNotification] doesn't gate the test —
+ * the receiver code itself is API-agnostic, only the helper's permission check
+ * is gated. Pre-Tiramisu doesn't require the runtime permission, so the
+ * notification posts without a Robolectric permission-grant dance.
+ *
+ * What a failure here would catch:
+ *  - Receiver wiring breaks (missing intent filter, wrong action handling).
+ *  - DataStore read inside `runBlocking { withTimeoutOrNull }` hangs or returns
+ *    wrong defaults.
+ *  - The conditional ("both flags must be true") gets inverted.
+ *  - [postResumeNotification] regresses in channel-creation or pending-intent setup.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [32], application = android.app.Application::class)
+class BootReceiverTest {
+
+    private lateinit var context: Context
+    private lateinit var notificationManager: NotificationManager
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.cancelAll()
+        // Reset the data store between tests since RuntimeEnvironment is per-class.
+        runBlocking {
+            context.fauxxDataStore.edit { prefs ->
+                prefs.remove(PreferenceKeys.ENABLED)
+                prefs.remove(PreferenceKeys.RESUME_ON_BOOT)
+            }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        notificationManager.cancelAll()
+    }
+
+    @Test
+    fun `posts resume notification when engine was enabled and resume-on-boot is true`() {
+        primeDataStore(enabled = true, resumeOnBoot = true)
+
+        BootReceiver().onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+
+        val active = notificationManager.activeNotifications
+        assertEquals("expected exactly one notification posted", 1, active.size)
+        assertEquals(
+            "notification must use the resume channel",
+            RESUME_CHANNEL_ID,
+            active[0].notification.channelId
+        )
+    }
+
+    @Test
+    fun `does not post when engine was disabled pre-reboot`() {
+        primeDataStore(enabled = false, resumeOnBoot = true)
+
+        BootReceiver().onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+
+        assertEquals(
+            "no notification should post when engine was disabled",
+            0,
+            notificationManager.activeNotifications.size
+        )
+    }
+
+    @Test
+    fun `does not post when resume-on-boot is disabled even if engine was enabled`() {
+        primeDataStore(enabled = true, resumeOnBoot = false)
+
+        BootReceiver().onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+
+        assertEquals(
+            "user opted out of resume-on-boot — no notification",
+            0,
+            notificationManager.activeNotifications.size
+        )
+    }
+
+    @Test
+    fun `responds to MY_PACKAGE_REPLACED the same as BOOT_COMPLETED`() {
+        primeDataStore(enabled = true, resumeOnBoot = true)
+
+        BootReceiver().onReceive(context, Intent(Intent.ACTION_MY_PACKAGE_REPLACED))
+
+        assertEquals(
+            "app updates should also surface the resume notification",
+            1,
+            notificationManager.activeNotifications.size
+        )
+    }
+
+    @Test
+    fun `ignores unrelated broadcasts`() {
+        primeDataStore(enabled = true, resumeOnBoot = true)
+
+        BootReceiver().onReceive(context, Intent(Intent.ACTION_BATTERY_LOW))
+
+        assertEquals(
+            "receiver must not act on broadcasts it didn't filter for",
+            0,
+            notificationManager.activeNotifications.size
+        )
+    }
+
+    @Test
+    fun `defaults when DataStore is empty match the safe fallback`() {
+        // Don't prime anything — DataStore returns null for both keys. Receiver
+        // falls back to (ENABLED=false, RESUME_ON_BOOT=true) per the runBlocking
+        // expression in BootReceiver.kt:42. Result: no notification (since enabled
+        // defaults to false).
+        BootReceiver().onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+
+        assertEquals(
+            "empty DataStore must not post on its own",
+            0,
+            notificationManager.activeNotifications.size
+        )
+    }
+
+    private fun primeDataStore(enabled: Boolean, resumeOnBoot: Boolean) {
+        runBlocking {
+            context.fauxxDataStore.edit { prefs ->
+                prefs[PreferenceKeys.ENABLED] = enabled
+                prefs[PreferenceKeys.RESUME_ON_BOOT] = resumeOnBoot
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary                  

  Test and CI hygiene. No production code changes — the diff lives entirely under `app/src/test/`, `app/src/androidTest/`, and `.github/workflows/`.      
   
  - **`EngineResumeSchedulerIntegrationTest`** — Robolectric test wiring a real `PoisonEngine` + real `ResumeScheduler` + WorkManager test impl. Asserts  
  that an engine resign during quiet hours produces a `fauxx_resume` work item via the production code path. 2 tests.
                                                                                                                                                          
  - **`BootReceiverTest`** — first test coverage for `BootReceiver`. 6 tests across `BOOT_COMPLETED`, `MY_PACKAGE_REPLACED`, both flag conditions         
  (`ENABLED` × `RESUME_ON_BOOT`), unrelated-broadcast no-op, empty-DataStore default. Pinned to API 32 so the Tiramisu+ POST_NOTIFICATIONS check does not
  gate the test.                                                                                                                                          
                                                                     
  - **Removed `DashboardScreenTest.toggleProtectionOn_changesStatusToActive`.** The name promised an off→on state transition; the body asserted the       
  initial state three times without ever invoking the toggle. Other tests in the file already cover the structural assertions.
                                                                                                                                                          
  - **`ci.yml` permissions block** — locks `GITHUB_TOKEN` to `contents: read`. Resolves the CodeQL alert for missing workflow permissions.                
   
  - **Dead import cleanup** in `SettingsScreenTest` and `TargetingScreenTest`. `androidx.compose.ui.test.assertDoesNotExist` is a method on               
  `SemanticsNodeInteraction`, not a top-level function; the stale imports caused the androidTest source set to fail to compile.
                                                                                                                                                          
  ## Test plan                                                       

  - [x] `testPlayDebugUnitTest` + `testFullDebugUnitTest` pass                                                                                            
  - [x] `lintPlayDebug` passes
  - [x] `compilePlayDebugAndroidTestKotlin` + `compileFullDebugAndroidTestKotlin` succeed (previously broken)                                             
  - [x] CodeQL alert about missing workflow permissions resolves on re-scan