### PR TITLE
feat(phantom): log main-frame load errors in PhantomWebViewClient

### DIFF
--- a/app/src/main/java/com/fauxx/engine/webview/PhantomWebViewClient.kt
+++ b/app/src/main/java/com/fauxx/engine/webview/PhantomWebViewClient.kt
@@ -7,6 +7,7 @@ import androidx.annotation.RequiresApi
 import timber.log.Timber
 import android.webkit.SafeBrowsingResponse
 import android.webkit.SslErrorHandler
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
@@ -67,6 +68,18 @@ class PhantomWebViewClient(
         }
 
         return null
+    }
+
+    override fun onReceivedError(
+        view: WebView,
+        request: WebResourceRequest?,
+        error: WebResourceError?
+    ) {
+        super.onReceivedError(view, request, error)
+        if (request?.isForMainFrame != true) return
+        val description = error?.description ?: "unknown error"
+        val code = error?.errorCode ?: 0
+        Timber.w("WebView load error on ${request.url} (code=$code): $description")
     }
 
     override fun onReceivedSslError(view: WebView, handler: SslErrorHandler, error: SslError) {


### PR DESCRIPTION
Closes #57.

`PhantomWebViewClient` overrides `onPageStarted`, `onPageFinished`, `shouldInterceptRequest`, `onReceivedSslError`, `onSafeBrowsingHit` and `shouldOverrideUrlLoading`, but not `onReceivedError`. When a scraper main load fails for a non-TLS reason (DNS, `ERR_CONNECTION_REFUSED`, `ERR_TIMED_OUT`, ...), nothing in the log explains it. The scraper just times out at 30 seconds and resumes with an empty set, which is hard to tell apart from "page loaded but the DOM selectors did not match".

### Change

Override `onReceivedError`. Log main-frame failures with the URL, error code and description. Skip sub-frame errors so the log signal stays useful on third-party pages that pull dozens of off-host sub-resources:

```kotlin
override fun onReceivedError(
    view: WebView,
    request: WebResourceRequest?,
    error: WebResourceError?
) {
    super.onReceivedError(view, request, error)
    if (request?.isForMainFrame != true) return
    val description = error?.description ?: "unknown error"
    val code = error?.errorCode ?: 0
    Timber.w("WebView load error on ${request.url} (code=$code): $description")
}
```

This is pure telemetry, no behavioural change. The scraper still times out and resumes with `emptySet()` the way it does today. The next time a user reports "scrape returns nothing on my network" the log will show whether the WebView ever got past the network layer.
