### PR TITLE
fix(engine): unify the allowed-hours predicate the engine and scheduler disagreed on (#124)

### DIFF
--- a/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
+++ b/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
@@ -32,6 +32,7 @@ import com.fauxx.engine.modules.FingerprintModule
 import com.fauxx.engine.modules.Module
 import com.fauxx.engine.modules.SearchPoisonModule
 import com.fauxx.engine.scheduling.ActionDispatcher
+import com.fauxx.engine.scheduling.AllowedHours
 import com.fauxx.engine.scheduling.PoissonScheduler
 import com.fauxx.targeting.TargetingEngine
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -100,6 +101,15 @@ private const val RATE_LIMIT_PAUSE_MS = 15_000L
 
 /** Maximum time to wait for all modules to finish stop() before giving up. */
 private const val MODULE_STOP_TIMEOUT_MS = 2_000L
+
+/**
+ * Maximum chunk of the inter-action sleep before constraints are re-checked. Bounds how
+ * long the engine can sit in a scheduled delay while a constraint (quiet hours entered,
+ * WiFi dropped, battery sank) goes unnoticed — and, as defense in depth for issue #124,
+ * caps the damage of any future oversized delay to one minute of unwarranted ACTIVE state
+ * instead of hours of silent stall.
+ */
+private const val SLEEP_CONSTRAINT_RECHECK_MS = 60_000L
 
 /**
  * Threshold for a "long pause" — wifi/battery pauses past this duration trigger the
@@ -529,7 +539,26 @@ class PoisonEngine @Inject constructor(
             if (logEntry.success) lastCategory = category
             val effectiveDelay = maxOf(0L, scheduledMs - execElapsed)
             Timber.d("Action: $moduleName/$category exec=${execElapsed}ms scheduled=${scheduledMs}ms effective=${effectiveDelay}ms")
-            delay(effectiveDelay)
+            sleepRespectingConstraints(effectiveDelay)
+        }
+    }
+
+    /**
+     * Sleep [totalMs] in chunks of at most [SLEEP_CONSTRAINT_RECHECK_MS], re-reading the
+     * profile and re-checking constraints between chunks. Returns early when a constraint
+     * trips so the main loop's pause/resign handling reacts within a minute instead of
+     * after the full inter-action delay, which can legitimately reach tens of minutes at
+     * LOW intensity — and reached 9-21 hours when issue #124 made the scheduler return a
+     * quiet-hours-sized delay the engine slept through while reporting ACTIVE. The chunk
+     * sum equals [totalMs] exactly when nothing trips, so the Poisson pacing is preserved.
+     */
+    private suspend fun sleepRespectingConstraints(totalMs: Long) {
+        var remaining = totalMs
+        while (remaining > 0) {
+            val chunk = minOf(remaining, SLEEP_CONSTRAINT_RECHECK_MS)
+            delay(chunk)
+            remaining -= chunk
+            if (remaining > 0 && checkConstraints(profile.getProfile()) != null) return
         }
     }
 
@@ -575,18 +604,10 @@ class PoisonEngine @Inject constructor(
     }
 
     /** Returns true if the current local hour falls within the profile's allowed window.
-     *  Handles midnight-wrap (e.g., start=22, end=6 means 22:00 to 06:00). */
-    internal fun isWithinAllowedHours(profile: PoisonProfile, nowHour: Int = currentHourOfDay()): Boolean {
-        val start = profile.allowedHoursStart
-        val end = profile.allowedHoursEnd
-        return if (start == end) {
-            true // degenerate: treat as always allowed
-        } else if (start < end) {
-            nowHour in start until end
-        } else {
-            nowHour >= start || nowHour < end
-        }
-    }
+     *  Delegates to [AllowedHours], the same predicate [PoissonScheduler] uses, so the
+     *  constraint gate and the delay computation can never disagree (issue #124). */
+    internal fun isWithinAllowedHours(profile: PoisonProfile, nowHour: Int = currentHourOfDay()): Boolean =
+        AllowedHours.isWithin(nowHour, profile.allowedHoursStart, profile.allowedHoursEnd)
 
     /** Returns the constraint-check retry interval scaled by intensity.
      *  HIGH (200/hr) → ~3.6s, MEDIUM (60/hr) → ~12s, LOW (12/hr) → 60s. */

--- a/app/src/main/java/com/fauxx/engine/scheduling/AllowedHours.kt
+++ b/app/src/main/java/com/fauxx/engine/scheduling/AllowedHours.kt
@@ -1,0 +1,34 @@
+package com.fauxx.engine.scheduling
+
+/**
+ * Single source of truth for the active-hours predicate, shared by
+ * [com.fauxx.engine.PoisonEngine] (the constraint gate that decides whether an action may
+ * execute right now) and [PoissonScheduler] (the next-action delay computation).
+ *
+ * Window semantics:
+ * - `start == end` — degenerate window, treated as ALWAYS active (a 24h window). This is
+ *   how a user expresses "midnight to midnight" (0-0) on the sliders, and it is the
+ *   engine's long-documented and unit-tested behavior.
+ * - `start < end` — active during `[start, end)`, e.g. 7-23 means 07:00 through 22:59.
+ *   The End slider reaches 24 (issue #128), so 0-24 is also a full-day window.
+ * - `start > end` — wraps midnight, e.g. 22-6 means 22:00 through 05:59.
+ *
+ * Issue #124: the engine and scheduler previously carried separate private copies of this
+ * predicate that disagreed on `start == end`. The engine treated it as always active, so
+ * actions executed at any hour, while the scheduler's `hour in start until end` saw an
+ * empty range (never active) and routed every call through its quiet-hours branch,
+ * scheduling the next action at the next `start` hour boundary. For the 0-0 window users
+ * set to mean "always on", that surfaced in the field as exactly one action per engine
+ * start followed by a delay landing at local midnight (the attached debug logs show
+ * scheduled delays of 9h-21h, every one expiring at 24:00:00). A single shared
+ * implementation makes that divergence structurally impossible.
+ */
+object AllowedHours {
+
+    /** Returns true when [hour] (0-23) falls inside the window `[start, end)`. */
+    fun isWithin(hour: Int, start: Int, end: Int): Boolean = when {
+        start == end -> true // degenerate: treat as always allowed
+        start < end -> hour in start until end
+        else -> hour >= start || hour < end // wraps midnight
+    }
+}

--- a/app/src/main/java/com/fauxx/engine/scheduling/PoissonScheduler.kt
+++ b/app/src/main/java/com/fauxx/engine/scheduling/PoissonScheduler.kt
@@ -14,9 +14,10 @@ import kotlin.random.Random
  * Generates next-action timestamps following a Poisson process with human-like circadian patterns.
  *
  * Behavioral properties:
- * - Active 7am–11pm local time (configurable via [allowedHoursStart]/[allowedHoursEnd])
+ * - Active 7am–11pm local time by default (configurable via the allowedStart/allowedEnd
+ *   parameters of [nextDelayMs]; window semantics live in [AllowedHours])
  * - Produces bursts of 3-7 actions close together, then gaps of 5-20 minutes
- * - Near-zero activity between 11pm-7am
+ * - Near-zero activity outside the allowed window
  * - Inter-arrival times follow exponential distribution (Poisson process property)
  *
  * Cross-niche dwell time:
@@ -68,7 +69,8 @@ class PoissonScheduler @Inject constructor(
      * @param prev Previously executed category, or null for the first action this run.
      * @param next Category about to be executed.
      * @param allowedStart Hour of day (0-23) when activity may begin.
-     * @param allowedEnd Hour of day (0-23) when activity must stop.
+     * @param allowedEnd Hour of day (0-24) when activity must stop. Equal to [allowedStart]
+     *   means a 24h window — see [AllowedHours] for the shared semantics (issue #124).
      * @return Delay in milliseconds. May be large if currently in quiet hours.
      */
     fun nextDelayMs(
@@ -81,8 +83,11 @@ class PoissonScheduler @Inject constructor(
         val now = Calendar.getInstance().apply { timeInMillis = clock.currentTimeMillis() }
         val currentHour = now.get(Calendar.HOUR_OF_DAY)
 
-        // If in quiet hours, delay until allowed start
-        if (!isWithinAllowedHours(currentHour, allowedStart, allowedEnd)) {
+        // If in quiet hours, delay until allowed start. Uses the SAME predicate as the
+        // engine's constraint gate (AllowedHours) so the two can never disagree about
+        // whether "now" is active — the divergence that caused issue #124, where the
+        // engine executed an action but this branch then slept until local midnight.
+        if (!AllowedHours.isWithin(currentHour, allowedStart, allowedEnd)) {
             return msUntilHour(now, allowedStart)
         }
 
@@ -158,15 +163,6 @@ class PoissonScheduler @Inject constructor(
         val u = random.nextDouble()
         val delayMs = (-ln(1.0 - u) / ratePerMs).toLong()
         return delayMs.coerceIn(1_000L, maxDelayMs)
-    }
-
-    private fun isWithinAllowedHours(currentHour: Int, start: Int, end: Int): Boolean {
-        return if (start <= end) {
-            currentHour in start until end
-        } else {
-            // Wraps midnight: e.g., start=22, end=6 means 22:00 to 06:00
-            currentHour >= start || currentHour < end
-        }
     }
 
     private fun msUntilHour(now: Calendar, targetHour: Int): Long {

--- a/app/src/test/java/com/fauxx/AllowedHoursTest.kt
+++ b/app/src/test/java/com/fauxx/AllowedHoursTest.kt
@@ -1,0 +1,63 @@
+package com.fauxx
+
+import com.fauxx.engine.scheduling.AllowedHours
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Contract tests for the shared active-hours predicate (issue #124).
+ *
+ * [AllowedHours] is the single implementation behind both the engine's constraint gate
+ * and the scheduler's quiet-hours branch; these tests pin the three window shapes so a
+ * future "simplification" of one branch can't silently reintroduce the divergence.
+ */
+class AllowedHoursTest {
+
+    @Test
+    fun `normal window is active from start inclusive to end exclusive`() {
+        assertTrue(AllowedHours.isWithin(hour = 7, start = 7, end = 23))
+        assertTrue(AllowedHours.isWithin(hour = 15, start = 7, end = 23))
+        assertTrue(AllowedHours.isWithin(hour = 22, start = 7, end = 23))
+        assertFalse(AllowedHours.isWithin(hour = 23, start = 7, end = 23))
+        assertFalse(AllowedHours.isWithin(hour = 3, start = 7, end = 23))
+        assertFalse(AllowedHours.isWithin(hour = 6, start = 7, end = 23))
+    }
+
+    @Test
+    fun `midnight wrap window is active across the boundary`() {
+        assertTrue(AllowedHours.isWithin(hour = 22, start = 22, end = 6))
+        assertTrue(AllowedHours.isWithin(hour = 23, start = 22, end = 6))
+        assertTrue(AllowedHours.isWithin(hour = 0, start = 22, end = 6))
+        assertTrue(AllowedHours.isWithin(hour = 5, start = 22, end = 6))
+        assertFalse(AllowedHours.isWithin(hour = 6, start = 22, end = 6))
+        assertFalse(AllowedHours.isWithin(hour = 12, start = 22, end = 6))
+        assertFalse(AllowedHours.isWithin(hour = 21, start = 22, end = 6))
+    }
+
+    @Test
+    fun `equal start and end means every hour is active - issue 124`() {
+        // The degenerate window is how a user expresses "always on" (0-0 = midnight to
+        // midnight). The scheduler's old private copy evaluated it as `hour in 0 until 0`,
+        // an empty range, and slept until the next start-hour boundary.
+        (0..24).forEach { boundary ->
+            (0..23).forEach { hour ->
+                assertTrue(
+                    "hour $hour must be active in a $boundary-$boundary window",
+                    AllowedHours.isWithin(hour = hour, start = boundary, end = boundary)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `full 0 to 24 window is always active`() {
+        // Issue #128: the End slider reaches 24, the sanctioned full-day window.
+        (0..23).forEach { hour ->
+            assertTrue(
+                "hour $hour must be active in a 0-24 window",
+                AllowedHours.isWithin(hour = hour, start = 0, end = 24)
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/fauxx/PoisonEngineLoopTest.kt
+++ b/app/src/test/java/com/fauxx/PoisonEngineLoopTest.kt
@@ -3,6 +3,8 @@ package com.fauxx
 import com.fauxx.data.crawllist.CrawlListManager
 import com.fauxx.data.crawllist.DomainBlocklist
 import com.fauxx.data.db.ActionLogDao
+import com.fauxx.data.db.ActionLogEntity
+import com.fauxx.data.model.ActionType
 import com.fauxx.data.location.CityCoord
 import com.fauxx.data.location.CityDatabase
 import com.fauxx.data.model.IntensityLevel
@@ -24,6 +26,7 @@ import com.fauxx.support.FakeClock
 import com.fauxx.targeting.TargetingEngine
 import com.fauxx.util.Clock
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineDispatcher
@@ -40,6 +43,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import kotlin.random.Random
 
 /**
  * Integration test for [PoisonEngine.start] / `runLoop` under virtual time.
@@ -137,6 +141,56 @@ class PoisonEngineLoopTest {
         assertEquals(androidx.work.NetworkType.UNMETERED, whenConstraint.network)
     }
 
+    @Test
+    fun `runLoop keeps executing actions in an always-on window with the real scheduler`() = runTest {
+        // Issue #124 end-to-end regression. Active hours 0-0 is the degenerate
+        // "midnight to midnight" window the engine documents as always allowed. The bug
+        // lived in the REAL PoissonScheduler's divergent copy of that predicate (the
+        // other tests in this file mock the scheduler, which is why it was never caught):
+        // the engine's constraint gate allowed the action, then nextDelayMs treated the
+        // same instant as quiet hours and returned ms-until-local-midnight. Net effect in
+        // the field: exactly ONE action per engine start, at any hour of the day.
+        val clock = FakeClock(threeAmEpochMs())
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val searchModule: SearchPoisonModule = mockk(relaxed = true) {
+            every { isEnabled() } returns true
+            coEvery { onAction(any()) } returns ActionLogEntity(
+                actionType = ActionType.SEARCH_QUERY,
+                category = CategoryPool.GAMING,
+                detail = "ok",
+                success = true
+            )
+        }
+        engine = buildEngine(
+            clock,
+            profile = baseProfile.copy(allowedHoursStart = 0, allowedHoursEnd = 0),
+            loopDispatcher = dispatcher,
+            scheduler = PoissonScheduler(clock, Random(42)),
+            searchModule = searchModule
+        )
+
+        var resignedWith: ResumeSpec? = null
+        engine.setOnLongPause { spec -> resignedWith = spec }
+        engine.start()
+
+        // Two simulated hours starting at 3 AM. LOW (12/hr) bounds same-topic delays to
+        // max(60s, 3x300s) = 15 min, so a healthy loop must fire several actions; the
+        // pre-fix loop fired one and then slept until midnight.
+        advanceVirtualTime(clock, scheduler = testScheduler, by = 2 * 60 * 60 * 1000)
+
+        assertNull("an always-on window must never resign for quiet hours", resignedWith)
+        coVerify(atLeast = 3) { searchModule.onAction(any()) }
+
+        // Unlike the resign tests above, this engine is (by design) still alive and
+        // mid-delay on the test scheduler. Cancel it INSIDE the runTest body and drain
+        // its async cleanup coroutine — a foreign-scope task left pending at body end
+        // would make the post-body drain advance virtual time forever, because an
+        // always-on engine never goes idle.
+        engine.destroy()
+        testScheduler.advanceTimeBy(5_000)
+        testScheduler.runCurrent()
+    }
+
     /**
      * Step time forward in small increments so `runTest`'s scheduler can fire
      * each `delay()` resumption. The fake clock advances together with the
@@ -194,16 +248,17 @@ class PoisonEngineLoopTest {
         clock: Clock,
         profile: PoisonProfile,
         moduleFails: Boolean = false,
-        loopDispatcher: CoroutineDispatcher
+        loopDispatcher: CoroutineDispatcher,
+        scheduler: PoissonScheduler = mockk {
+            every { nextDelayMs(any(), any(), any(), any(), any()) } returns 1000L
+        },
+        searchModule: SearchPoisonModule? = null
     ): PoisonEngine {
         val profileRepo: PoisonProfileRepository = mockk {
             every { getProfile() } returns profile
         }
         val dispatcher: ActionDispatcher = mockk {
             coEvery { selectCategory() } returns CategoryPool.GAMING
-        }
-        val scheduler: PoissonScheduler = mockk {
-            every { nextDelayMs(any(), any(), any(), any(), any()) } returns 1000L
         }
         val actionLogDao: ActionLogDao = mockk(relaxed = true)
         val blocklist: DomainBlocklist = mockk {
@@ -221,7 +276,7 @@ class PoisonEngineLoopTest {
                 CityCoord("B", 1.0, 1.0, "X")
             )
         }
-        val searchModule: SearchPoisonModule = mockk(relaxed = true) {
+        val search: SearchPoisonModule = searchModule ?: mockk(relaxed = true) {
             every { isEnabled() } returns true
             if (moduleFails) {
                 coEvery { onAction(any()) } throws RuntimeException("forced failure")
@@ -243,7 +298,7 @@ class PoisonEngineLoopTest {
         return PoisonEngine(
             context, profileRepo, targetingEngine, dispatcher, scheduler, actionLogDao,
             blocklist, queryBankManager, crawlListManager, cityDatabase,
-            searchModule,
+            search,
             adModule = noopModule,
             locationModule = noopModule,
             fingerprintModule = mockk<FingerprintModule>(relaxed = true) {

--- a/app/src/test/java/com/fauxx/PoissonSchedulerTest.kt
+++ b/app/src/test/java/com/fauxx/PoissonSchedulerTest.kt
@@ -2,6 +2,7 @@ package com.fauxx
 
 import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.engine.scheduling.PoissonScheduler
+import com.fauxx.support.FakeClock
 import com.fauxx.util.SystemClockImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -188,6 +189,79 @@ class PoissonSchedulerTest {
             }
         }
     }
+
+    // --- Degenerate (start == end) allowed-hours window (issue #124) ---
+    //
+    // The scheduler's old private predicate evaluated start==end as `hour in start until
+    // end`, an empty range, so EVERY call fell into the quiet-hours branch and returned
+    // "ms until the next `start` hour boundary". For the 0-0 window users set to mean
+    // "always on" (the engine's constraint gate documents start==end as always allowed),
+    // that meant one action per engine start, then a sleep landing at local midnight —
+    // the field logs in #124 show scheduled delays of 9h-21h, every one expiring at
+    // exactly 24:00:00.
+
+    @Test
+    fun `equal start and end behaves as a 24h window at every hour of the day`() {
+        // Same-topic delays are bounded by the Poisson clamp max(60s, 3x mean) = 180s at
+        // MEDIUM (60/hr), so anything above that means the quiet-hours branch fired.
+        (0..23).forEach { hour ->
+            val pinned = PoissonScheduler(FakeClock(epochAtLocalHour(hour)))
+            repeat(20) {
+                val delay = pinned.nextDelayMs(
+                    actionsPerHour = 60,
+                    prev = CategoryPool.GAMING,
+                    next = CategoryPool.GAMING,
+                    allowedStart = 0,
+                    allowedEnd = 0
+                )
+                assertTrue(
+                    "hour=$hour: a 0-0 window must be always-active; got ${delay}ms " +
+                        "which looks like a delay-until-hour-boundary",
+                    delay <= 180_000L
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `nonzero equal start and end also behaves as a 24h window`() {
+        // 13-13 at 3 AM: pre-fix this returned ~10h (sleep until 13:00).
+        val pinned = PoissonScheduler(FakeClock(epochAtLocalHour(3)))
+        repeat(20) {
+            val delay = pinned.nextDelayMs(
+                actionsPerHour = 60,
+                prev = CategoryPool.GAMING,
+                next = CategoryPool.GAMING,
+                allowedStart = 13,
+                allowedEnd = 13
+            )
+            assertTrue("13-13 window must be always-active at 3 AM, got ${delay}ms", delay <= 180_000L)
+        }
+    }
+
+    @Test
+    fun `outside a normal window still delays until the window opens`() {
+        // The quiet-hours branch itself must keep working for genuinely-outside hours:
+        // at 3 AM with a 7-23 window the next action belongs at 07:00, i.e. 4h out.
+        val pinned = PoissonScheduler(FakeClock(epochAtLocalHour(3)))
+        val delay = pinned.nextDelayMs(
+            actionsPerHour = 60,
+            prev = CategoryPool.GAMING,
+            next = CategoryPool.GAMING,
+            allowedStart = 7,
+            allowedEnd = 23
+        )
+        assertEquals(4 * 60 * 60 * 1000L, delay)
+    }
+
+    /** Epoch ms for today at [hour]:00:00.000 local time. */
+    private fun epochAtLocalHour(hour: Int): Long =
+        java.util.Calendar.getInstance().apply {
+            set(java.util.Calendar.HOUR_OF_DAY, hour)
+            set(java.util.Calendar.MINUTE, 0)
+            set(java.util.Calendar.SECOND, 0)
+            set(java.util.Calendar.MILLISECOND, 0)
+        }.timeInMillis
 
     @Test
     fun `null previous category behaves like same-topic and allows bursts`() {


### PR DESCRIPTION
## Problem

Issue #124: the engine executes exactly one action per protection toggle, then stalls indefinitely while the dashboard and notification report it as active. Confirmed by two reporters on unrelated devices (Pixel 9 Pro XL / GrapheneOS and Redmi Note 9S / custom Android 16), and not fixed by the v0.3.1 WebView pool change.

## Root cause

`PoisonEngine` and `PoissonScheduler` each carried a private copy of the "is the current hour inside the active window" predicate, and the copies disagree on a window where `start == end`:

- the engine's constraint gate treats `start == end` as **always allowed** (documented and unit-tested), so the action executes at any hour
- the scheduler's copy evaluated it as `hour in start until end`, an **empty range**, so every call fell into the quiet-hours branch and scheduled the next action at the next `start`-hour boundary

For the `0:00 – 0:00` window both reporters set (the natural "midnight to midnight = 24/7" reading; the Settings sliders allow it freely), that means: one action runs, then the engine sleeps until exactly local midnight. Every `scheduled=` delay in both reporters' debug logs lands on 24:00:00 to the millisecond (9h–21h delays depending on time of day). At midnight it wakes inside hour 0, hits the same branch, and sleeps another 24h: one action per day, plus one per toggle.

## Fix

- **`AllowedHours` (new):** single shared predicate with the engine's documented semantics (`start == end` → always active, `start < end` → `[start, end)`, `start > end` → midnight wrap). Both the engine and the scheduler delegate to it, so they can never diverge again. Existing `0–0` profiles start meaning 24/7 everywhere, which is what those users intended.
- **Defense in depth:** the inter-action sleep in `runLoop` now runs in 60s chunks with a constraint re-check between chunks, so a mid-sleep constraint change (or any future oversized delay) is handled within a minute instead of wedging the engine in ACTIVE for hours.

## Tests

Three layers, the last one being the one that could have caught this originally:

- `AllowedHoursTest`: pins all three window shapes, including all 25 degenerate `start == end` values x all 24 hours
- `PoissonSchedulerTest`: `0–0` and `13–13` windows must return normal Poisson-bounded delays at every hour of the day (fails on pre-fix code at 23 of 24 hours); plus a guard that a genuine quiet-hours delay (3 AM, 7–23 window → exactly 4h) still works
- `PoisonEngineLoopTest`: end-to-end with a **real** `PoissonScheduler` — every existing engine test mocks the scheduler, which is exactly why this bug survived. An always-on profile at 3 AM must execute multiple actions over two simulated hours and never resign; pre-fix it executes exactly one.

## Verification

- Full unit suite, both flavors: 374 tests / 66 classes, 0 failures
- `koverVerifyPlayDebug`, `lintFullDebug`, `lintPlayDebug` all green locally

## Release plan

Addresses #124 — intentionally **not** `Closes`: the issue stays open for reporter confirmation against `v0.3.2-rc1` (no-version-bump prerelease tag cut from this branch; the version code stays 301 so F-Droid's `Tags`-mode update checker doesn't ship the RC). Final `v0.3.2` with the 302 bump + changelogs follows confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)