### PR TITLE
M0: quick wins and honest scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,12 +379,24 @@ Fauxx operates within the terms of service of search engines and ad platforms, b
 
 ## Threat Model
 
-Fauxx assumes:
+- **Adversaries:** Data brokers, ad networks, analytics platforms, ISPs.
+- **Data in scope:** The weak, low-confidence signals these adversaries infer from search queries, URL visits, location history, device fingerprints, app-store interest signals, and DNS queries.
+- **Goal:** Dilution at the edge of the identity graph. Fauxx adds plausible synthetic activity so that low-confidence behavioral inferences become noisier and less certain. It does not replace or overwrite a profile.
 
-- **Adversaries:** Data brokers, ad networks, analytics platforms, ISPs
-- **Data in scope:** Search queries, URL visits, location history, device fingerprints, app installations, DNS queries
-- **Goal:** Make your behavioral signal indistinguishable from synthetic noise
-- **Out of scope:** Nation-state surveillance, SIM swaps, device compromise, subpoenas
+### What Fauxx does not reach
+
+Fauxx jams weak signals. It deliberately does not attempt to defeat the strong, deterministic mechanisms modern profiling anchors on, and it makes no claim to affect the following:
+
+- **Deterministic identity joins** from your real email address or phone number.
+- **Google Privacy Sandbox Topics.** Fauxx runs in isolated WebViews that do not influence the Topics your real browser computes.
+- **Server-side and Conversions API (CAPI) events** sent directly between businesses and ad platforms.
+- **Device and Play Integrity attestation** and attested in-app telemetry.
+- **Public records and offline data** that brokers buy and sell.
+- **Connected-TV (CTV) and household-IP** graph linking.
+
+Also out of scope, as for any app: nation-state surveillance, SIM swaps, device compromise, and subpoenas.
+
+Realistically, Fauxx dilutes at the edge of the identity graph. It is not profile replacement, and it works best as one layer in a broader privacy strategy.
 
 ## Feedback & Security
 

--- a/app/src/main/java/com/fauxx/data/SensitiveAttributes.kt
+++ b/app/src/main/java/com/fauxx/data/SensitiveAttributes.kt
@@ -1,0 +1,40 @@
+package com.fauxx.data
+
+/**
+ * Sensitive attributes Fauxx must never infer or target: race, religion, sexual
+ * orientation, gender identity, disability, and political affiliation. This is an
+ * ethical invariant (issue #167).
+ *
+ * This is the single shared denylist that future work must consult: persona seeding
+ * (E7) and adversarial noise allocation (E4) must run candidate categories and
+ * interests through [matches] before adopting them.
+ *
+ * Matching is word-boundary aware so topical words are not mistaken for sensitive
+ * attributes (for example "race" the ethnicity is flagged, while "racing" is not).
+ */
+object SensitiveAttributes {
+
+    val DENYLIST: List<String> = listOf(
+        "race",
+        "ethnicity",
+        "religion",
+        "religious",
+        "sexual orientation",
+        "sexuality",
+        "gender identity",
+        "transgender",
+        "disability",
+        "disabled",
+        "political affiliation",
+        "political party",
+    )
+
+    private val patterns: List<Regex> =
+        DENYLIST.map { Regex("\\b${Regex.escape(it)}\\b", RegexOption.IGNORE_CASE) }
+
+    /** True if [text] names a sensitive attribute as a whole word or phrase. */
+    fun matches(text: String): Boolean {
+        val normalized = text.replace('_', ' ')
+        return patterns.any { it.containsMatchIn(normalized) }
+    }
+}

--- a/app/src/main/java/com/fauxx/data/db/PhantomDatabase.kt
+++ b/app/src/main/java/com/fauxx/data/db/PhantomDatabase.kt
@@ -69,7 +69,10 @@ class PhantomTypeConverters {
     fun fromActionType(value: ActionType): String = value.name
 
     @TypeConverter
-    fun toActionType(value: String): ActionType = ActionType.valueOf(value)
+    fun toActionType(value: String): ActionType =
+        // Tolerate values from retired enum members (e.g. the former AD_CLICK) on
+        // existing rows so an upgrade never crashes on deserialization.
+        runCatching { ActionType.valueOf(value) }.getOrDefault(ActionType.PAGE_VISIT)
 
     @TypeConverter
     fun fromCategoryPool(value: CategoryPool): String = value.name

--- a/app/src/main/java/com/fauxx/data/model/ActionType.kt
+++ b/app/src/main/java/com/fauxx/data/model/ActionType.kt
@@ -8,9 +8,6 @@ enum class ActionType {
     /** Executes search queries on search engines. */
     SEARCH_QUERY,
 
-    /** Loads ad-heavy pages and simulates ad interactions. */
-    AD_CLICK,
-
     /** Visits URLs from the crawl corpus to accumulate tracker cookies. */
     PAGE_VISIT,
 

--- a/app/src/main/java/com/fauxx/di/NetworkModule.kt
+++ b/app/src/main/java/com/fauxx/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.fauxx.di
 
 import android.content.Context
 import com.fauxx.locale.LocaleManager
+import com.fauxx.network.BlocklistInterceptor
 import com.fauxx.network.HeaderRandomizerInterceptor
 import com.fauxx.network.UserAgentPool
 import dagger.Module
@@ -38,9 +39,14 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(interceptor: HeaderRandomizerInterceptor): OkHttpClient =
+    fun provideOkHttpClient(
+        blocklistInterceptor: BlocklistInterceptor,
+        headerInterceptor: HeaderRandomizerInterceptor,
+    ): OkHttpClient =
         OkHttpClient.Builder()
-            .addInterceptor(interceptor)
+            // Fail-closed blocklist gate first, so no request reaches a blocked host.
+            .addInterceptor(blocklistInterceptor)
+            .addInterceptor(headerInterceptor)
             .connectionPool(ConnectionPool(20, 2, TimeUnit.MINUTES))
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)

--- a/app/src/main/java/com/fauxx/engine/modules/AdPollutionModule.kt
+++ b/app/src/main/java/com/fauxx/engine/modules/AdPollutionModule.kt
@@ -7,6 +7,7 @@ import com.fauxx.data.model.ActionType
 import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.engine.PoisonProfileRepository
 import com.fauxx.engine.webview.PhantomWebViewPool
+import com.fauxx.engine.webview.SYNTHETIC_WEBVIEW_HEADERS
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -25,7 +26,8 @@ private val AD_DASHBOARD_URLS = listOf(
  * Loads ad-heavy pages in a background WebView and visits ad preference dashboards
  * to populate the user's ad profile with off-demographic signals.
  *
- * Sub-1% CTR simulation: only "clicks" (loads ad landing page) on ~0.8% of page loads.
+ * No ad clicks or conversions are generated: every load is a plain page visit,
+ * including the occasional ad-preference dashboard visit.
  */
 @Singleton
 class AdPollutionModule @Inject constructor(
@@ -44,10 +46,10 @@ class AdPollutionModule @Inject constructor(
     override fun isEnabled(): Boolean = profileRepo.getProfile().adPollutionEnabled
 
     override suspend fun onAction(category: CategoryPool): ActionLogEntity {
-        // 10% chance: visit an ad dashboard (logged as AD_CLICK);
-        // otherwise: plain crawl-list page fetch (logged as PAGE_VISIT).
+        // 10% chance: visit an ad-preference dashboard; otherwise a plain crawl-list
+        // page fetch. Both are logged as PAGE_VISIT: no ad clicks or conversions occur.
         val isDashboardVisit = random.nextFloat() < 0.10f
-        val actionType = if (isDashboardVisit) ActionType.AD_CLICK else ActionType.PAGE_VISIT
+        val actionType = ActionType.PAGE_VISIT
 
         val url = if (isDashboardVisit) {
             AD_DASHBOARD_URLS.random(random)
@@ -82,7 +84,7 @@ class AdPollutionModule @Inject constructor(
             false
         } else {
             try {
-                withContext(Dispatchers.Main) { webView.loadUrl(url) }
+                withContext(Dispatchers.Main) { webView.loadUrl(url, SYNTHETIC_WEBVIEW_HEADERS) }
                 delay(random.nextLong(3_000L, 15_000L))
                 // #73: read page metadata on Main, before release() wipes the document.
                 metadata = withContext(Dispatchers.Main) { webViewPool.captureMetadata(webView, url) }

--- a/app/src/main/java/com/fauxx/engine/modules/AppSignalModule.kt
+++ b/app/src/main/java/com/fauxx/engine/modules/AppSignalModule.kt
@@ -7,6 +7,7 @@ import com.fauxx.data.model.ActionType
 import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.engine.PoisonProfileRepository
 import com.fauxx.engine.webview.PhantomWebViewPool
+import com.fauxx.engine.webview.SYNTHETIC_WEBVIEW_HEADERS
 import com.fauxx.locale.LocaleManager
 import com.fauxx.locale.SupportedLocale
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -231,7 +232,7 @@ class AppSignalModule @Inject constructor(
             false
         } else {
             try {
-                withContext(Dispatchers.Main) { webView.loadUrl(url) }
+                withContext(Dispatchers.Main) { webView.loadUrl(url, SYNTHETIC_WEBVIEW_HEADERS) }
                 delay(dwellMs)
                 // #73: read page metadata on Main, before release() wipes the document.
                 metadata = withContext(Dispatchers.Main) { webViewPool.captureMetadata(webView, url) }

--- a/app/src/main/java/com/fauxx/engine/modules/CookieSaturationModule.kt
+++ b/app/src/main/java/com/fauxx/engine/modules/CookieSaturationModule.kt
@@ -7,6 +7,7 @@ import com.fauxx.data.model.ActionType
 import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.engine.PoisonProfileRepository
 import com.fauxx.engine.webview.PhantomWebViewPool
+import com.fauxx.engine.webview.SYNTHETIC_WEBVIEW_HEADERS
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -73,7 +74,7 @@ class CookieSaturationModule @Inject constructor(
             false
         } else {
             try {
-                withContext(Dispatchers.Main) { webView.loadUrl(entry.url) }
+                withContext(Dispatchers.Main) { webView.loadUrl(entry.url, SYNTHETIC_WEBVIEW_HEADERS) }
                 delay(dwellMs)
                 // #73: read page metadata on Main, before release() wipes the document.
                 metadata = withContext(Dispatchers.Main) { webViewPool.captureMetadata(webView, entry.url) }

--- a/app/src/main/java/com/fauxx/engine/webview/JSInjector.kt
+++ b/app/src/main/java/com/fauxx/engine/webview/JSInjector.kt
@@ -120,12 +120,29 @@ object JSInjector {
         })();
     """.trimIndent()
 
+    /**
+     * Global Privacy Control DOM signal: exposes `navigator.globalPrivacyControl === true`
+     * so scripts that read the GPC property (the in-page counterpart to the Sec-GPC header)
+     * see the opt-out. Fixed value, not randomized.
+     */
+    val GPC_SCRIPT = """
+        (function() {
+            try {
+                Object.defineProperty(navigator, 'globalPrivacyControl', {
+                    get: function() { return true; },
+                    configurable: false
+                });
+            } catch (e) {}
+        })();
+    """.trimIndent()
+
     /** Combined script injected on every page load. */
     val ALL_SCRIPTS = listOf(
         WASM_WORKER_BLOCK_SCRIPT,
         EVAL_BLOCK_SCRIPT,
         CANVAS_NOISE_SCRIPT,
         NAVIGATOR_OVERRIDE_SCRIPT,
-        FONT_SPOOF_SCRIPT
+        FONT_SPOOF_SCRIPT,
+        GPC_SCRIPT
     ).joinToString("\n\n")
 }

--- a/app/src/main/java/com/fauxx/engine/webview/WebViewHeaders.kt
+++ b/app/src/main/java/com/fauxx/engine/webview/WebViewHeaders.kt
@@ -1,0 +1,12 @@
+package com.fauxx.engine.webview
+
+/**
+ * HTTP headers attached to every synthetic main-frame WebView load.
+ *
+ * `Sec-GPC: 1` is the Global Privacy Control signal, a lawful, machine-readable
+ * opt-out of sale and sharing. It is a fixed value and is never randomized, unlike
+ * the anti-fingerprint headers in [com.fauxx.network.HeaderRandomizerInterceptor]
+ * (which covers the OkHttp path). The matching DOM signal
+ * (`navigator.globalPrivacyControl`) is injected by [JSInjector].
+ */
+val SYNTHETIC_WEBVIEW_HEADERS: Map<String, String> = mapOf("Sec-GPC" to "1")

--- a/app/src/main/java/com/fauxx/network/BlocklistInterceptor.kt
+++ b/app/src/main/java/com/fauxx/network/BlocklistInterceptor.kt
@@ -1,0 +1,33 @@
+package com.fauxx.network
+
+import com.fauxx.data.crawllist.DomainBlocklist
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Fail-closed blocklist gate for the OkHttp path. Every request made through the
+ * injected [OkHttpClient] flows through this interceptor, so no module can issue an
+ * HTTP request to a blocked host even if a future call site forgets an upstream
+ * check. The WebView path is gated separately by
+ * [com.fauxx.engine.webview.PhantomWebViewClient]; together these are the single
+ * enforced chokepoints for the blocklist invariant (issue #165).
+ *
+ * [DomainBlocklist.isBlocked] fails closed (returns true for every host) when the
+ * blocklist could not be loaded, so a load failure halts HTTP traffic rather than
+ * letting it through unchecked.
+ */
+@Singleton
+class BlocklistInterceptor @Inject constructor(
+    private val blocklist: DomainBlocklist,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val host = chain.request().url.host
+        if (blocklist.isBlocked(host)) {
+            throw IOException("Blocked host rejected by blocklist: $host")
+        }
+        return chain.proceed(chain.request())
+    }
+}

--- a/app/src/main/java/com/fauxx/network/HeaderRandomizerInterceptor.kt
+++ b/app/src/main/java/com/fauxx/network/HeaderRandomizerInterceptor.kt
@@ -36,6 +36,8 @@ class HeaderRandomizerInterceptor @Inject constructor(
             .header("Accept-Language", randomAcceptLanguage())
             .header("Accept-Encoding", "gzip, deflate, br")
             .header("DNT", "1")
+            // Global Privacy Control opt-out signal. Fixed value, never randomized.
+            .header("Sec-GPC", "1")
             .build()
         return chain.proceed(request)
     }

--- a/app/src/main/java/com/fauxx/ui/format/ActionTypeLabel.kt
+++ b/app/src/main/java/com/fauxx/ui/format/ActionTypeLabel.kt
@@ -14,7 +14,6 @@ import com.fauxx.data.model.ActionType
 @StringRes
 fun ActionType.displayNameRes(): Int = when (this) {
     ActionType.SEARCH_QUERY -> R.string.action_type_search_query
-    ActionType.AD_CLICK -> R.string.action_type_ad_click
     ActionType.PAGE_VISIT -> R.string.action_type_page_visit
     ActionType.LOCATION_SPOOF -> R.string.action_type_location_spoof
     ActionType.DNS_LOOKUP -> R.string.action_type_dns_lookup

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -145,7 +145,6 @@
     <string name="category_relationships_dating">Relaciones y citas</string>
 
     <string name="action_type_search_query">BÚSQUEDA</string>
-    <string name="action_type_ad_click">CLIC EN ANUNCIO</string>
     <string name="action_type_page_visit">VISITA</string>
     <string name="action_type_location_spoof">UBICACIÓN</string>
     <string name="action_type_dns_lookup">DNS</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -145,7 +145,6 @@
     <string name="category_relationships_dating">Relations et rencontres</string>
 
     <string name="action_type_search_query">RECHERCHE</string>
-    <string name="action_type_ad_click">CLIC PUB</string>
     <string name="action_type_page_visit">PAGE VISITÉE</string>
     <string name="action_type_location_spoof">POSITION</string>
     <string name="action_type_dns_lookup">DNS</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -229,7 +229,6 @@
 
     <!-- Action type labels -->
     <string name="action_type_search_query">ПОИСК</string>
-    <string name="action_type_ad_click">КЛИК ПО РЕКЛАМЕ</string>
     <string name="action_type_page_visit">ПОСЕЩЕНИЕ</string>
     <string name="action_type_location_spoof">ЛОКАЦИЯ</string>
     <string name="action_type_dns_lookup">DNS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,7 +141,6 @@
 
     <!-- Action type labels — shown on Log screen filter chips and entries -->
     <string name="action_type_search_query">SEARCH</string>
-    <string name="action_type_ad_click">AD CLICK</string>
     <string name="action_type_page_visit">PAGE VISIT</string>
     <string name="action_type_location_spoof">LOCATION</string>
     <string name="action_type_dns_lookup">DNS</string>

--- a/app/src/test/java/com/fauxx/ConversionGuardrailTest.kt
+++ b/app/src/test/java/com/fauxx/ConversionGuardrailTest.kt
@@ -1,0 +1,29 @@
+package com.fauxx
+
+import com.fauxx.data.model.ActionType
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guardrail (issue #166): Fauxx generates page visits and queries, never monetizable
+ * conversions or forged click/install/attribution events. The action taxonomy must
+ * therefore never contain a conversion-shaped action. This locks in the E12 retirement
+ * of AD_CLICK and fails the build if such a type is reintroduced.
+ */
+class ConversionGuardrailTest {
+
+    private val forbiddenSubstrings = listOf(
+        "CLICK", "CONVERSION", "ATTRIBUTION", "INSTALL", "PURCHASE", "CHECKOUT", "ACQUISITION"
+    )
+
+    @Test
+    fun `no ActionType carries click conversion or attribution semantics`() {
+        val offenders = ActionType.entries.filter { type ->
+            forbiddenSubstrings.any { type.name.contains(it) }
+        }
+        assertTrue(
+            "ActionType must not contain conversion-shaped actions; found: $offenders",
+            offenders.isEmpty()
+        )
+    }
+}

--- a/app/src/test/java/com/fauxx/ModuleSilentFailureTest.kt
+++ b/app/src/test/java/com/fauxx/ModuleSilentFailureTest.kt
@@ -59,7 +59,7 @@ class ModuleSilentFailureTest {
     fun `AdPollutionModule reports failure when WebView throws`() = runTest(testDispatcher) {
         every { profileRepo.getProfile() } returns PoisonProfile(adPollutionEnabled = true)
         every { crawlListManager.nextUrlOrWait(any()) } returns testEntry
-        every { webView.loadUrl(any<String>()) } throws RuntimeException("WebView crashed")
+        every { webView.loadUrl(any<String>(), any()) } throws RuntimeException("WebView crashed")
 
         val module = AdPollutionModule(crawlListManager, webViewPool, profileRepo)
         val result = module.onAction(CategoryPool.GAMING)
@@ -82,7 +82,7 @@ class ModuleSilentFailureTest {
     fun `CookieSaturationModule reports failure when WebView throws`() = runTest(testDispatcher) {
         every { profileRepo.getProfile() } returns PoisonProfile(cookieSaturationEnabled = true)
         every { crawlListManager.nextUrlOrWait(any()) } returns testEntry
-        every { webView.loadUrl(any<String>()) } throws RuntimeException("WebView crashed")
+        every { webView.loadUrl(any<String>(), any()) } throws RuntimeException("WebView crashed")
 
         val module = CookieSaturationModule(crawlListManager, webViewPool, profileRepo)
         val result = module.onAction(CategoryPool.GAMING)
@@ -102,7 +102,7 @@ class ModuleSilentFailureTest {
     }
 
     @Test
-    fun `AdPollutionModule visits ad dashboard as AD_CLICK without consulting crawl list`() =
+    fun `AdPollutionModule visits ad dashboard as PAGE_VISIT without consulting crawl list`() =
         runTest(testDispatcher) {
             every { profileRepo.getProfile() } returns PoisonProfile(adPollutionEnabled = true)
 
@@ -116,7 +116,7 @@ class ModuleSilentFailureTest {
             val module = AdPollutionModule(crawlListManager, webViewPool, profileRepo, dashboardRandom)
             val result = module.onAction(CategoryPool.GAMING)
 
-            assertEquals(ActionType.AD_CLICK, result.actionType)
+            assertEquals(ActionType.PAGE_VISIT, result.actionType)
             assertTrue("Dashboard URL should be an https link", result.detail.startsWith("https://"))
             assertTrue("Dashboard visit should report success", result.success)
             verify(exactly = 0) { crawlListManager.nextUrlOrWait(any()) }

--- a/app/src/test/java/com/fauxx/SensitiveAttributeGuardrailTest.kt
+++ b/app/src/test/java/com/fauxx/SensitiveAttributeGuardrailTest.kt
@@ -1,0 +1,36 @@
+package com.fauxx
+
+import com.fauxx.data.SensitiveAttributes
+import com.fauxx.data.querybank.CategoryPool
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guardrail (issue #167): the targeting taxonomy must never include a sensitive
+ * attribute. [CategoryPool] is the root taxonomy; persona interests in
+ * persona_templates.json are drawn from CategoryPool values, so scanning the enum
+ * transitively covers persona interests. Query-content scanning is intentionally not
+ * done here: harmful query content is handled by QueryBlocklist, and substring
+ * scanning a large query corpus would false-positive on topical words.
+ */
+class SensitiveAttributeGuardrailTest {
+
+    @Test
+    fun `no CategoryPool value targets a sensitive attribute`() {
+        val offenders = CategoryPool.entries.filter { SensitiveAttributes.matches(it.name) }
+        assertTrue(
+            "CategoryPool must not target sensitive attributes; found: $offenders",
+            offenders.isEmpty()
+        )
+    }
+
+    @Test
+    fun `denylist matcher is word-boundary aware`() {
+        // Sanity check the matcher itself so the guardrail above cannot silently
+        // pass because the matcher is broken.
+        assertTrue("a standalone sensitive term must match", SensitiveAttributes.matches("what race am I"))
+        assertFalse("a substring must not match (racing is not race)", SensitiveAttributes.matches("racing cars"))
+        assertFalse("an unrelated category must not match", SensitiveAttributes.matches("AUTOMOTIVE"))
+    }
+}

--- a/app/src/test/java/com/fauxx/engine/modules/AppSignalModuleTest.kt
+++ b/app/src/test/java/com/fauxx/engine/modules/AppSignalModuleTest.kt
@@ -87,7 +87,7 @@ class AppSignalModuleTest {
 
     @Test
     fun `onAction reports failure when the WebView throws`() = runTest(testDispatcher) {
-        every { webView.loadUrl(any<String>()) } throws RuntimeException("WebView crashed")
+        every { webView.loadUrl(any<String>(), any()) } throws RuntimeException("WebView crashed")
 
         val result = newModule().onAction(CategoryPool.GAMING)
 

--- a/app/src/test/java/com/fauxx/network/BlocklistInterceptorTest.kt
+++ b/app/src/test/java/com/fauxx/network/BlocklistInterceptorTest.kt
@@ -1,0 +1,76 @@
+package com.fauxx.network
+
+import com.fauxx.data.crawllist.DomainBlocklist
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Guardrail (issue #165): the OkHttp path must route every request through the
+ * fail-closed [BlocklistInterceptor], so no module can reach a blocked host. The
+ * WebView path is gated by PhantomWebViewClient and covered elsewhere.
+ */
+class BlocklistInterceptorTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun clientWith(blocked: Boolean): OkHttpClient {
+        val blocklist = mockk<DomainBlocklist> { every { isBlocked(any()) } returns blocked }
+        return OkHttpClient.Builder().addInterceptor(BlocklistInterceptor(blocklist)).build()
+    }
+
+    @Test
+    fun `allowed host proceeds`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+        clientWith(blocked = false)
+            .newCall(Request.Builder().url(server.url("/")).build())
+            .execute().use { resp -> assertTrue(resp.isSuccessful) }
+    }
+
+    @Test
+    fun `blocked host is rejected before the request leaves`() {
+        try {
+            clientWith(blocked = true)
+                .newCall(Request.Builder().url(server.url("/")).build())
+                .execute()
+            fail("expected an IOException for a blocked host")
+        } catch (_: IOException) {
+            // expected: the interceptor fails closed
+        }
+        // The request must never have reached the server.
+        assertTrue("a blocked request must not hit the server", server.requestCount == 0)
+    }
+
+    @Test
+    fun `blocklist load failure fails closed`() {
+        // isBlocked returns true for ALL hosts when the blocklist could not load.
+        val blocklist = mockk<DomainBlocklist> { every { isBlocked(any()) } returns true }
+        val client = OkHttpClient.Builder().addInterceptor(BlocklistInterceptor(blocklist)).build()
+        try {
+            client.newCall(Request.Builder().url("https://example.com/").build()).execute()
+            fail("expected an IOException when the blocklist has failed closed")
+        } catch (_: IOException) {
+            // expected
+        }
+    }
+}

--- a/app/src/test/java/com/fauxx/network/NetworkClientTest.kt
+++ b/app/src/test/java/com/fauxx/network/NetworkClientTest.kt
@@ -63,7 +63,7 @@ class NetworkClientTest {
         .build()
 
     @Test
-    fun `interceptor puts all five anti-fingerprint headers on the wire`() {
+    fun `interceptor puts all anti-fingerprint and GPC headers on the wire`() {
         server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
 
         client().newCall(Request.Builder().url(server.url("/")).build()).execute().use { resp ->
@@ -74,6 +74,7 @@ class NetworkClientTest {
         assertEquals("UA must come from the pool", "TestUA/1.0", recorded.getHeader("User-Agent"))
         assertEquals("gzip, deflate, br", recorded.getHeader("Accept-Encoding"))
         assertEquals("1", recorded.getHeader("DNT"))
+        assertEquals("Sec-GPC opt-out must be on the wire", "1", recorded.getHeader("Sec-GPC"))
         assertNotNull("Accept header must be set", recorded.getHeader("Accept"))
         val acceptLanguage = recorded.getHeader("Accept-Language") ?: ""
         assertTrue(


### PR DESCRIPTION
Implements milestone M0 (Quick Wins and Honest Scoping).

## Features
- **E12 (#161):** Stop labelling ad-preference dashboard visits as AD_CLICK; log them as PAGE_VISIT and retire the AD_CLICK action type. No ad clicks or conversions are generated. The Room ActionType converter now tolerates legacy AD_CLICK rows so upgrades do not crash.
- **E11 (#162):** Send `Sec-GPC: 1` on all OkHttp requests and synthetic WebView main-frame loads, and expose `navigator.globalPrivacyControl` in injected pages. Fixed value, never randomized.

## Safety guardrails
- **G1 (#165):** Fail-closed `BlocklistInterceptor` on the OkHttp client, a single enforced chokepoint for the HTTP path (the WebView path is gated by `PhantomWebViewClient`). Tests cover allow, block, and fail-closed.
- **G2 (#166):** Guardrail test asserting no `ActionType` carries click, conversion, or attribution semantics (locks in the E12 retirement).
- **G3 (#167):** Shared `SensitiveAttributes` denylist (word-boundary matcher) plus a taxonomy scan over `CategoryPool`. Persona interests are drawn from `CategoryPool`, so they are covered transitively.

## Docs
- **D1 (#163):** README threat model rewritten with an explicit "What Fauxx does not reach" list (deterministic email/phone joins, Topics, server-side/CAPI, device attestation, public records, CTV/household-IP) and a plain edge-dilution, not-profile-replacement statement.

The S1 spike (#164) was decided separately: Android stays isolated and real-browser Topics influence is delegated to the desktop companion.

Full-flavor unit suite passes locally.

Closes #161
Closes #162
Closes #163
Closes #165
Closes #166
Closes #167
