### PR TITLE
M2: close the loop (measurement & feedback)

### DIFF
--- a/app/schemas/com.fauxx.data.db.PhantomDatabase/5.json
+++ b/app/schemas/com.fauxx.data.db.PhantomDatabase/5.json
@@ -1,0 +1,240 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "6d809d7308a9f8fbfac1598127bba9da",
+    "entities": [
+      {
+        "tableName": "action_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `actionType` TEXT NOT NULL, `category` TEXT NOT NULL, `detail` TEXT NOT NULL, `success` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionType",
+            "columnName": "actionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detail",
+            "columnName": "detail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "success",
+            "columnName": "success",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_action_log_timestamp_success",
+            "unique": false,
+            "columnNames": [
+              "timestamp",
+              "success"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_action_log_timestamp_success` ON `${TABLE_NAME}` (`timestamp`, `success`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_demographic_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ageRange` TEXT, `gender` TEXT, `profession` TEXT, `region` TEXT, `interestsJson` TEXT, `customInterestsJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ageRange",
+            "columnName": "ageRange",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "profession",
+            "columnName": "profession",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "region",
+            "columnName": "region",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interestsJson",
+            "columnName": "interestsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customInterestsJson",
+            "columnName": "customInterestsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "platform_profile_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platformName` TEXT NOT NULL, `scrapedCategoriesJson` TEXT NOT NULL, `lastScraped` INTEGER NOT NULL, PRIMARY KEY(`platformName`))",
+        "fields": [
+          {
+            "fieldPath": "platformName",
+            "columnName": "platformName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrapedCategoriesJson",
+            "columnName": "scrapedCategoriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastScraped",
+            "columnName": "lastScraped",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platformName"
+          ]
+        }
+      },
+      {
+        "tableName": "profile_snapshot",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `platformName` TEXT NOT NULL, `source` TEXT NOT NULL, `scrapedCategoriesJson` TEXT NOT NULL, `capturedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformName",
+            "columnName": "platformName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrapedCategoriesJson",
+            "columnName": "scrapedCategoriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_profile_snapshot_platformName_capturedAt",
+            "unique": false,
+            "columnNames": [
+              "platformName",
+              "capturedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_profile_snapshot_platformName_capturedAt` ON `${TABLE_NAME}` (`platformName`, `capturedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "persona_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `personaJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaJson",
+            "columnName": "personaJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6d809d7308a9f8fbfac1598127bba9da')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/fauxx/data/db/PhantomDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/fauxx/data/db/PhantomDatabaseMigrationTest.kt
@@ -47,12 +47,12 @@ class PhantomDatabaseMigrationTest {
     }
 
     @Test
-    fun migrate1To4_preservesSeededRows_andAppliesSchemaChanges() {
+    fun migrate1To5_preservesSeededRows_andAppliesSchemaChanges() {
         seedEncryptedV1Database()
 
         val db = buildRoomDatabase()
         try {
-            // First access runs the 1->2->3->4 migration chain and validates the result against v4.
+            // First access runs the 1->2->3->4->5 migration chain and validates the result against v5.
             val sdb = db.openHelper.writableDatabase
 
             // Rows written at v1 must survive the migration.
@@ -87,6 +87,12 @@ class PhantomDatabaseMigrationTest {
             sdb.query("SELECT metadata FROM action_log").use { c ->
                 assertTrue(c.moveToFirst())
                 assertTrue("metadata defaults to NULL on pre-existing rows", c.isNull(0))
+            }
+            // MIGRATION_4_5 created the profile_snapshot history table (issue #170 E1).
+            sdb.query(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='profile_snapshot'"
+            ).use { c ->
+                assertTrue("MIGRATION_4_5 must create profile_snapshot", c.moveToFirst())
             }
         } finally {
             db.close()
@@ -125,7 +131,7 @@ class PhantomDatabaseMigrationTest {
     private fun buildRoomDatabase(): PhantomDatabase =
         Room.databaseBuilder(context, PhantomDatabase::class.java, TEST_DB)
             .openHelperFactory(SupportOpenHelperFactory(passphrase))
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
             .build()
 
     /**

--- a/app/src/androidTest/java/com/fauxx/ui/DashboardScreenTest.kt
+++ b/app/src/androidTest/java/com/fauxx/ui/DashboardScreenTest.kt
@@ -78,14 +78,14 @@ class DashboardScreenTest {
     }
 
     @Test
-    fun noiseRatioCard_isDisplayed() {
+    fun syntheticActivityCard_isDisplayed() {
         composeRule.setContent {
             FauxxTheme {
                 DashboardScreen()
             }
         }
-        // NoiseRatioCard is the last element in the scroll Column — well below the fold.
-        composeRule.onNodeWithText("NOISE RATIO").performScrollTo().assertIsDisplayed()
+        // SyntheticActivityCard sits near the bottom of the scroll Column, below the fold.
+        composeRule.onNodeWithText("SYNTHETIC ACTIVITY").performScrollTo().assertIsDisplayed()
     }
 
     // toggleProtectionOn_changesStatusToActive removed 2026-05-13: it claimed to

--- a/app/src/main/java/com/fauxx/data/db/PhantomDatabase.kt
+++ b/app/src/main/java/com/fauxx/data/db/PhantomDatabase.kt
@@ -12,6 +12,9 @@ import com.fauxx.targeting.layer1.DemographicProfileDao
 import com.fauxx.targeting.layer1.UserDemographicProfile
 import com.fauxx.targeting.layer2.PlatformProfileCache
 import com.fauxx.targeting.layer2.PlatformProfileDao
+import com.fauxx.targeting.layer2.ProfileSnapshot
+import com.fauxx.targeting.layer2.ProfileSnapshotDao
+import com.fauxx.targeting.layer2.SnapshotSource
 import com.fauxx.targeting.layer3.PersonaHistoryDao
 import com.fauxx.targeting.layer3.PersonaHistoryEntity
 
@@ -29,9 +32,10 @@ import com.fauxx.targeting.layer3.PersonaHistoryEntity
         ActionLogEntity::class,
         UserDemographicProfile::class,
         PlatformProfileCache::class,
+        ProfileSnapshot::class,
         PersonaHistoryEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 @TypeConverters(PhantomTypeConverters::class)
@@ -39,6 +43,7 @@ abstract class PhantomDatabase : RoomDatabase() {
     abstract fun actionLogDao(): ActionLogDao
     abstract fun demographicProfileDao(): DemographicProfileDao
     abstract fun platformProfileDao(): PlatformProfileDao
+    abstract fun profileSnapshotDao(): ProfileSnapshotDao
     abstract fun personaHistoryDao(): PersonaHistoryDao
 }
 
@@ -63,6 +68,24 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
     }
 }
 
+/** Migration from v4 to v5: add the append-only profile_snapshot history table (issue #170 E1). */
+val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `profile_snapshot` (" +
+                "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                "`platformName` TEXT NOT NULL, " +
+                "`source` TEXT NOT NULL, " +
+                "`scrapedCategoriesJson` TEXT NOT NULL, " +
+                "`capturedAt` INTEGER NOT NULL)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_profile_snapshot_platformName_capturedAt` " +
+                "ON `profile_snapshot` (`platformName`, `capturedAt`)"
+        )
+    }
+}
+
 /** Room type converters for enum types. */
 class PhantomTypeConverters {
     @TypeConverter
@@ -79,4 +102,11 @@ class PhantomTypeConverters {
 
     @TypeConverter
     fun toCategoryPool(value: String): CategoryPool = CategoryPool.valueOf(value)
+
+    @TypeConverter
+    fun fromSnapshotSource(value: SnapshotSource): String = value.name
+
+    @TypeConverter
+    fun toSnapshotSource(value: String): SnapshotSource =
+        runCatching { SnapshotSource.valueOf(value) }.getOrDefault(SnapshotSource.IMPORT)
 }

--- a/app/src/main/java/com/fauxx/di/AppModule.kt
+++ b/app/src/main/java/com/fauxx/di/AppModule.kt
@@ -14,6 +14,7 @@ import com.fauxx.data.db.ActionLogDao
 import com.fauxx.data.db.MIGRATION_1_2
 import com.fauxx.data.db.MIGRATION_2_3
 import com.fauxx.data.db.MIGRATION_3_4
+import com.fauxx.data.db.MIGRATION_4_5
 import com.fauxx.data.db.PhantomDatabase
 import com.fauxx.targeting.layer1.DemographicProfileDao
 import com.fauxx.targeting.layer2.PlatformProfileDao
@@ -76,7 +77,7 @@ object AppModule {
             "phantom.db"
         )
             .openHelperFactory(factory)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
             .build()
     }
 
@@ -193,6 +194,11 @@ object AppModule {
     @Singleton
     fun providePlatformProfileDao(db: PhantomDatabase): PlatformProfileDao =
         db.platformProfileDao()
+
+    @Provides
+    @Singleton
+    fun provideProfileSnapshotDao(db: PhantomDatabase): com.fauxx.targeting.layer2.ProfileSnapshotDao =
+        db.profileSnapshotDao()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/fauxx/di/TargetingModule.kt
+++ b/app/src/main/java/com/fauxx/di/TargetingModule.kt
@@ -57,8 +57,11 @@ object TargetingModule {
 
     @Provides
     @Singleton
-    fun provideAdversarialScraperLayer(dao: PlatformProfileDao): AdversarialScraperLayer =
-        AdversarialScraperLayer(dao)
+    fun provideAdversarialScraperLayer(
+        dao: PlatformProfileDao,
+        snapshotDao: com.fauxx.targeting.layer2.ProfileSnapshotDao,
+        driftCalculator: com.fauxx.targeting.layer2.ProfileDriftCalculator,
+    ): AdversarialScraperLayer = AdversarialScraperLayer(dao, snapshotDao, driftCalculator)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/fauxx/service/RetentionWorker.kt
+++ b/app/src/main/java/com/fauxx/service/RetentionWorker.kt
@@ -8,6 +8,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.fauxx.data.db.ActionLogDao
 import com.fauxx.di.PreferenceKeys
+import com.fauxx.targeting.layer2.ProfileSnapshotDao
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.first
@@ -27,6 +28,7 @@ class RetentionWorker @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted params: WorkerParameters,
     private val actionLogDao: ActionLogDao,
+    private val profileSnapshotDao: ProfileSnapshotDao,
     private val dataStore: DataStore<Preferences>,
 ) : CoroutineWorker(context, params) {
 
@@ -39,7 +41,9 @@ class RetentionWorker @AssistedInject constructor(
                 .coerceIn(MIN_RETENTION_DAYS, MAX_RETENTION_DAYS)
             val cutoff = System.currentTimeMillis() - days * MILLIS_PER_DAY
             actionLogDao.deleteOlderThan(cutoff)
-            Timber.i("RetentionWorker: pruned action-log entries older than $days day(s)")
+            // Prune old profile snapshots too, but keep each platform's earliest (E2 KL baseline).
+            profileSnapshotDao.deleteOlderThanKeepingBaseline(cutoff)
+            Timber.i("RetentionWorker: pruned action-log + profile-snapshot entries older than $days day(s)")
             Result.success()
         } catch (e: Exception) {
             Timber.w(e, "RetentionWorker: prune failed; will retry")

--- a/app/src/main/java/com/fauxx/targeting/layer2/AdversarialScraperLayer.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/AdversarialScraperLayer.kt
@@ -14,6 +14,9 @@ import javax.inject.Singleton
 /** Weight for categories the platform has explicitly assigned to the user — suppress these. */
 private const val CONFIRMED_WEIGHT = 0.05f
 
+/** Weight for confirmed categories not moving across snapshots ("won't budge"): push harder. */
+private const val STICKY_CONFIRMED_WEIGHT = 0.02f
+
 /** Weight for categories absent from the platform profile — boost these. */
 private const val ABSENT_WEIGHT = 3.0f
 
@@ -36,6 +39,8 @@ private const val STALE_THRESHOLD_MS = 7L * 24 * 60 * 60 * 1000
 @Singleton
 class AdversarialScraperLayer @Inject constructor(
     private val dao: PlatformProfileDao,
+    private val snapshotDao: ProfileSnapshotDao,
+    private val driftCalculator: ProfileDriftCalculator,
     private val clock: Clock = SystemClockImpl(),
 ) {
     private val gson = Gson()
@@ -51,7 +56,7 @@ class AdversarialScraperLayer @Inject constructor(
      * platform profiles change OR the enabled flag is toggled.
      */
     fun getWeights(): Flow<Map<CategoryPool, Float>> =
-        combine(dao.observeAll(), _enabled) { profiles, enabled ->
+        combine(dao.observeAll(), snapshotDao.observeAll(), _enabled) { profiles, snapshots, enabled ->
             if (!enabled || profiles.isEmpty()) return@combine neutralWeights()
 
             val now = clock.currentTimeMillis()
@@ -59,14 +64,22 @@ class AdversarialScraperLayer @Inject constructor(
 
             for (profile in profiles) {
                 if (now - profile.lastScraped > STALE_THRESHOLD_MS) continue
-                val categories = parseCategories(profile.scrapedCategoriesJson)
-                confirmedCategories.addAll(categories)
+                confirmedCategories.addAll(parseCategories(profile.scrapedCategoriesJson))
             }
 
             if (confirmedCategories.isEmpty()) return@combine neutralWeights()
 
+            // Confirmed categories not budging across the two most recent import snapshots: the
+            // current noise is not moving them, so push harder (#170 E1). Empty until a platform
+            // has >=2 snapshots, so this is a no-op on a fresh install (falls back to static weights).
+            val sticky = driftCalculator.stickyConfirmed(snapshots, ::parseCategories)
+
             CategoryPool.values().associateWith { category ->
-                if (confirmedCategories.contains(category)) CONFIRMED_WEIGHT else ABSENT_WEIGHT
+                when {
+                    category in confirmedCategories && category in sticky -> STICKY_CONFIRMED_WEIGHT
+                    category in confirmedCategories -> CONFIRMED_WEIGHT
+                    else -> ABSENT_WEIGHT
+                }
             }
         }
 

--- a/app/src/main/java/com/fauxx/targeting/layer2/ProfileDriftCalculator.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/ProfileDriftCalculator.kt
@@ -1,0 +1,39 @@
+package com.fauxx.targeting.layer2
+
+import com.fauxx.data.querybank.CategoryPool
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Pure, injectable drift analysis over the [ProfileSnapshot] history (issue #170 E1).
+ *
+ * The roadmap's insight: a confirmed category that "won't budge" across successive snapshots
+ * is a diagnostic that the current noise is not moving it, so Layer 2 should push harder there.
+ * Snapshots are category sets, so per-category drift is presence-change; "sticky" means present
+ * in both of a platform's two most recent snapshots.
+ */
+@Singleton
+class ProfileDriftCalculator @Inject constructor() {
+
+    /**
+     * Categories that are present in BOTH of a platform's two most recent snapshots (unioned
+     * across platforms): confirmed and not responding to the current noise. Returns empty when
+     * no platform has at least two snapshots yet, so callers fall back to static behavior.
+     *
+     * [parse] converts a snapshot's stored JSON to a category set (reuses the caller's parser).
+     */
+    fun stickyConfirmed(
+        snapshots: List<ProfileSnapshot>,
+        parse: (String) -> Set<CategoryPool>,
+    ): Set<CategoryPool> {
+        val sticky = mutableSetOf<CategoryPool>()
+        for ((_, snaps) in snapshots.groupBy { it.platformName }) {
+            val latestTwo = snaps.sortedByDescending { it.capturedAt }.take(2)
+            if (latestTwo.size < 2) continue
+            val current = parse(latestTwo[0].scrapedCategoriesJson)
+            val prior = parse(latestTwo[1].scrapedCategoriesJson)
+            sticky.addAll(current intersect prior)
+        }
+        return sticky
+    }
+}

--- a/app/src/main/java/com/fauxx/targeting/layer2/ProfileDriftMetric.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/ProfileDriftMetric.kt
@@ -1,0 +1,72 @@
+package com.fauxx.targeting.layer2
+
+import com.fauxx.data.querybank.CategoryPool
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.ln
+
+/** Whether enough snapshots exist to show a drift number yet (issue #171 E2). */
+enum class DriftState { COLLECTING, AVAILABLE }
+
+/** Result of the profile-drift computation; [klDivergence] is null while [state] is COLLECTING. */
+data class DriftResult(val state: DriftState, val klDivergence: Double?)
+
+/**
+ * Computes profile drift for the dashboard (issue #171 E2): the KL divergence of the user's
+ * latest imported ad-interest distribution from their baseline (earliest) import, over the
+ * CategoryPool support. Needs at least two snapshots for some platform; until then it reports
+ * COLLECTING.
+ *
+ * Honest caveat (surfaced in the dashboard help text): drift can reflect the platform retraining
+ * its own model, not only Fauxx's effect. It is an indicator of movement, not proof of efficacy.
+ */
+@Singleton
+class ProfileDriftMetric @Inject constructor() {
+
+    private val gson = Gson()
+
+    fun compute(snapshots: List<ProfileSnapshot>): DriftResult {
+        val baselineSets = mutableListOf<Set<CategoryPool>>()
+        val currentSets = mutableListOf<Set<CategoryPool>>()
+        for ((_, snaps) in snapshots.groupBy { it.platformName }) {
+            val sorted = snaps.sortedBy { it.capturedAt }
+            if (sorted.size < 2) continue
+            baselineSets.add(parse(sorted.first().scrapedCategoriesJson))
+            currentSets.add(parse(sorted.last().scrapedCategoriesJson))
+        }
+        if (baselineSets.isEmpty()) return DriftResult(DriftState.COLLECTING, null)
+        val baseline = baselineSets.flatten().toSet()
+        val current = currentSets.flatten().toSet()
+        return DriftResult(DriftState.AVAILABLE, kl(current, baseline))
+    }
+
+    /** KL(current || baseline) over the CategoryPool support, Laplace-smoothed so it stays finite. */
+    fun kl(current: Set<CategoryPool>, baseline: Set<CategoryPool>): Double {
+        val cats = CategoryPool.values()
+        val p = dist(current, cats)
+        val q = dist(baseline, cats)
+        var sum = 0.0
+        for (c in cats) {
+            val pi = p.getValue(c)
+            val qi = q.getValue(c)
+            if (pi > 0.0) sum += pi * ln(pi / qi)
+        }
+        return sum
+    }
+
+    private fun dist(set: Set<CategoryPool>, cats: Array<CategoryPool>): Map<CategoryPool, Double> {
+        val alpha = 0.5
+        val denom = set.size + alpha * cats.size
+        return cats.associateWith { c -> ((if (c in set) 1.0 else 0.0) + alpha) / denom }
+    }
+
+    private fun parse(json: String): Set<CategoryPool> = try {
+        val type = object : TypeToken<List<String>>() {}.type
+        val names: List<String> = gson.fromJson(json, type)
+        names.mapNotNull { runCatching { CategoryPool.valueOf(it) }.getOrNull() }.toSet()
+    } catch (e: Exception) {
+        emptySet()
+    }
+}

--- a/app/src/main/java/com/fauxx/targeting/layer2/ProfileSnapshot.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/ProfileSnapshot.kt
@@ -1,0 +1,33 @@
+package com.fauxx.targeting.layer2
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Where a [ProfileSnapshot] came from. Only [IMPORT] is captured in M2; [PHANTOM]
+ * (parsing the phantom context's own unauthenticated ad-preference page) is reserved
+ * for an M3 follow-up. Authenticated scraping of the user's real platform account is
+ * not possible from an embedded WebView (issues #51 / #52), so it is intentionally absent.
+ */
+enum class SnapshotSource { IMPORT, PHANTOM }
+
+/**
+ * An append-only, point-in-time snapshot of the ad-interest categories attributed to the
+ * user on a platform, captured so Layer 2 can compute drift over time (issue #170 E1) and
+ * the dashboard can show profile-drift (issue #171 E2).
+ *
+ * Distinct from [PlatformProfileCache], which holds one mutable row per platform (the latest
+ * state its weight calculation reads); this table is the history those two rows lose.
+ */
+@Entity(
+    tableName = "profile_snapshot",
+    indices = [Index(value = ["platformName", "capturedAt"])],
+)
+data class ProfileSnapshot(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val platformName: String,
+    val source: SnapshotSource,
+    val scrapedCategoriesJson: String,
+    val capturedAt: Long,
+)

--- a/app/src/main/java/com/fauxx/targeting/layer2/ProfileSnapshotDao.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/ProfileSnapshotDao.kt
@@ -1,0 +1,40 @@
+package com.fauxx.targeting.layer2
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/** DAO for the append-only profile-snapshot history (issues #170 E1, #171 E2). */
+@Dao
+interface ProfileSnapshotDao {
+
+    @Insert
+    suspend fun insert(snapshot: ProfileSnapshot): Long
+
+    /** All snapshots, oldest first (drives drift + KL computation reactively). */
+    @Query("SELECT * FROM profile_snapshot ORDER BY capturedAt ASC")
+    fun observeAll(): Flow<List<ProfileSnapshot>>
+
+    /** The two most recent snapshots for a platform (current + prior), for week-over-week drift. */
+    @Query("SELECT * FROM profile_snapshot WHERE platformName = :platform ORDER BY capturedAt DESC LIMIT 2")
+    suspend fun latestTwoForPlatform(platform: String): List<ProfileSnapshot>
+
+    /** The earliest snapshot for a platform (the immutable KL baseline). */
+    @Query("SELECT * FROM profile_snapshot WHERE platformName = :platform ORDER BY capturedAt ASC LIMIT 1")
+    suspend fun earliestForPlatform(platform: String): ProfileSnapshot?
+
+    /**
+     * Retention: delete snapshots older than [cutoff], but always keep the earliest snapshot per
+     * platform so E2's baseline survives. (MIN(id) per platform is the earliest, since id
+     * auto-increments in capture order.)
+     */
+    @Query(
+        "DELETE FROM profile_snapshot WHERE capturedAt < :cutoff " +
+            "AND id NOT IN (SELECT MIN(id) FROM profile_snapshot GROUP BY platformName)"
+    )
+    suspend fun deleteOlderThanKeepingBaseline(cutoff: Long)
+
+    @Query("DELETE FROM profile_snapshot")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/fauxx/targeting/layer2/importers/FacebookDyiImporter.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/importers/FacebookDyiImporter.kt
@@ -52,6 +52,7 @@ class FacebookDyiImporter @Inject constructor(
     @ApplicationContext private val context: Context,
     private val categoryMapper: CategoryMapper,
     private val platformProfileDao: PlatformProfileDao,
+    private val profileSnapshotDao: com.fauxx.targeting.layer2.ProfileSnapshotDao,
     private val clock: Clock
 ) : AdProfileImporter {
 
@@ -204,11 +205,21 @@ class FacebookDyiImporter @Inject constructor(
 
     private suspend fun persistCategories(mapped: Set<CategoryPool>) {
         val json = gson.toJson(mapped.map { it.name })
+        val now = clock.currentTimeMillis()
         platformProfileDao.upsert(
             PlatformProfileCache(
                 platformName = source.platformId,
                 scrapedCategoriesJson = json,
-                lastScraped = clock.currentTimeMillis()
+                lastScraped = now
+            )
+        )
+        // Append an immutable IMPORT snapshot so Layer 2 can compute drift over time (#170 E1).
+        profileSnapshotDao.insert(
+            com.fauxx.targeting.layer2.ProfileSnapshot(
+                platformName = source.platformId,
+                source = com.fauxx.targeting.layer2.SnapshotSource.IMPORT,
+                scrapedCategoriesJson = json,
+                capturedAt = now,
             )
         )
     }

--- a/app/src/main/java/com/fauxx/targeting/layer2/importers/GoogleTakeoutImporter.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/importers/GoogleTakeoutImporter.kt
@@ -47,6 +47,7 @@ class GoogleTakeoutImporter @Inject constructor(
     @ApplicationContext private val context: Context,
     private val categoryMapper: CategoryMapper,
     private val platformProfileDao: PlatformProfileDao,
+    private val profileSnapshotDao: com.fauxx.targeting.layer2.ProfileSnapshotDao,
     private val clock: Clock
 ) : AdProfileImporter {
 
@@ -231,11 +232,21 @@ class GoogleTakeoutImporter @Inject constructor(
 
     private suspend fun persistCategories(mapped: Set<com.fauxx.data.querybank.CategoryPool>) {
         val json = gson.toJson(mapped.map { it.name })
+        val now = clock.currentTimeMillis()
         platformProfileDao.upsert(
             PlatformProfileCache(
                 platformName = source.platformId,
                 scrapedCategoriesJson = json,
-                lastScraped = clock.currentTimeMillis()
+                lastScraped = now
+            )
+        )
+        // Append an immutable IMPORT snapshot so Layer 2 can compute drift over time (#170 E1).
+        profileSnapshotDao.insert(
+            com.fauxx.targeting.layer2.ProfileSnapshot(
+                platformName = source.platformId,
+                source = com.fauxx.targeting.layer2.SnapshotSource.IMPORT,
+                scrapedCategoriesJson = json,
+                capturedAt = now,
             )
         )
     }

--- a/app/src/main/java/com/fauxx/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/com/fauxx/ui/screens/DashboardScreen.kt
@@ -248,8 +248,11 @@ fun DashboardScreen(
             )
         }
 
-        // Noise ratio indicator
-        NoiseRatioCard(ratio = uiState.estimatedNoiseRatio)
+        // Synthetic-activity rate (issue #160)
+        SyntheticActivityCard(actionsPerHour = uiState.syntheticActionsPerHour)
+
+        // Profile-drift indicator (issue #171 E2)
+        DriftCard(driftState = uiState.driftState, kl = uiState.driftKlDivergence)
     }
 }
 
@@ -548,13 +551,35 @@ private fun SectionHeaderWithHelp(
 }
 
 @Composable
-private fun NoiseRatioCard(ratio: Float) {
-    val animated by animateFloatAsState(
-        targetValue = ratio.coerceIn(0f, 1f),
-        animationSpec = tween(durationMillis = 1000),
-        label = "noise_ratio"
-    )
+private fun SyntheticActivityCard(actionsPerHour: Float) {
+    // A plain rate read-out, deliberately NOT a fill bar: the old bar read like a slider and was
+    // mistaken for a control (issues #149/#150), and the percentage implied a real-vs-fake ratio
+    // Android cannot measure (issue #160).
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            SectionHeaderWithHelp(
+                title = stringResource(R.string.dashboard_synthetic_activity_title),
+                help = stringResource(R.string.dashboard_synthetic_activity_help)
+            )
+            Text(
+                text = stringResource(R.string.dashboard_synthetic_activity_value, actionsPerHour),
+                style = MaterialTheme.typography.labelMedium,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}
 
+@Composable
+private fun DriftCard(driftState: com.fauxx.targeting.layer2.DriftState, kl: Double?) {
     Card(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
     ) {
@@ -564,30 +589,18 @@ private fun NoiseRatioCard(ratio: Float) {
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 SectionHeaderWithHelp(
-                    title = stringResource(R.string.dashboard_noise_ratio_title),
-                    help = stringResource(R.string.dashboard_noise_ratio_help)
+                    title = stringResource(R.string.dashboard_drift_title),
+                    help = stringResource(R.string.dashboard_drift_help)
                 )
                 Text(
-                    text = stringResource(R.string.dashboard_noise_ratio_value, (animated * 100).toInt()),
+                    text = if (driftState == com.fauxx.targeting.layer2.DriftState.AVAILABLE && kl != null) {
+                        stringResource(R.string.dashboard_drift_value, kl)
+                    } else {
+                        stringResource(R.string.dashboard_drift_collecting)
+                    },
                     style = MaterialTheme.typography.labelMedium,
                     fontFamily = FontFamily.Monospace,
                     color = MaterialTheme.colorScheme.primary
-                )
-            }
-            Spacer(Modifier.height(8.dp))
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(8.dp)
-                    .clip(RoundedCornerShape(4.dp))
-                    .background(MaterialTheme.colorScheme.outline)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth(animated)
-                        .height(8.dp)
-                        .clip(RoundedCornerShape(4.dp))
-                        .background(MaterialTheme.colorScheme.primary)
                 )
             }
         }

--- a/app/src/main/java/com/fauxx/ui/viewmodels/DashboardViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/viewmodels/DashboardViewModel.kt
@@ -17,6 +17,10 @@ import com.fauxx.engine.PoisonEngine
 import com.fauxx.engine.PoisonProfileRepository
 import com.fauxx.service.PhantomForegroundService
 import com.fauxx.targeting.TargetingEngine
+import com.fauxx.targeting.layer2.DriftResult
+import com.fauxx.targeting.layer2.DriftState
+import com.fauxx.targeting.layer2.ProfileDriftMetric
+import com.fauxx.targeting.layer2.ProfileSnapshotDao
 import com.fauxx.targeting.layer3.PersonaRotationLayer
 import com.fauxx.util.Clock
 import com.fauxx.util.SystemClockImpl
@@ -45,8 +49,11 @@ data class DashboardUiState(
     val actionsThisWeek: Int = 0,
     val categoryDistribution: Map<CategoryPool, Float> = emptyMap(),
     val currentPersona: SyntheticPersona? = null,
-    val estimatedNoiseRatio: Float = 0f,
+    val syntheticActionsPerHour: Float = 0f,
     val healthWarnings: List<String> = emptyList(),
+    /** Profile-drift (issue #171 E2): KL divergence of the latest import from the baseline. */
+    val driftState: DriftState = DriftState.COLLECTING,
+    val driftKlDivergence: Double? = null,
     /** Mobile-data tier (issue #62); gates the "use mobile data" one-tap action — the
      *  button only helps when this is null (mobile off), not when there's no network. */
     val mobileIntensity: IntensityLevel? = null
@@ -62,6 +69,8 @@ class DashboardViewModel @Inject constructor(
     private val targetingEngine: TargetingEngine,
     private val personaLayer: PersonaRotationLayer,
     private val dataStore: DataStore<Preferences>,
+    private val profileSnapshotDao: ProfileSnapshotDao,
+    private val profileDriftMetric: ProfileDriftMetric,
     private val clock: Clock = SystemClockImpl(),
 ) : ViewModel() {
 
@@ -91,7 +100,8 @@ class DashboardViewModel @Inject constructor(
         personaLayer.currentPersona,
         poisonEngine.healthWarnings,
         poisonEngine.engineState,
-        profileRepo.profiles
+        profileRepo.profiles,
+        profileSnapshotDao.observeAll().map { profileDriftMetric.compute(it) }
     ) { flows ->
         @Suppress("UNCHECKED_CAST")
         val enabled = flows[0] as Boolean
@@ -104,6 +114,7 @@ class DashboardViewModel @Inject constructor(
         val warnings = flows[5] as List<String>
         val state = flows[6] as EngineState
         val profile = flows[7] as PoisonProfile
+        val drift = flows[8] as DriftResult
         DashboardUiState(
             engineEnabled = enabled,
             engineState = state,
@@ -111,8 +122,10 @@ class DashboardViewModel @Inject constructor(
             actionsThisWeek = week,
             categoryDistribution = weights,
             currentPersona = persona,
-            estimatedNoiseRatio = computeNoiseRatio(today),
+            syntheticActionsPerHour = computeSyntheticActionRate(today),
             healthWarnings = warnings,
+            driftState = drift.state,
+            driftKlDivergence = drift.klDivergence,
             mobileIntensity = profile.mobileIntensity
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DashboardUiState())
@@ -180,9 +193,11 @@ class DashboardViewModel @Inject constructor(
         context.startService(PhantomForegroundService.stopIntent(context))
     }
 
-    private fun computeNoiseRatio(actionsToday: Int): Float {
-        // Simple heuristic: 0% at 0 actions, 100% at 500+ actions per day
-        return (actionsToday / 500f).coerceIn(0f, 1f)
+    private fun computeSyntheticActionRate(actionsToday: Int): Float {
+        // Average synthetic actions per hour over the last 24h: an honest measure of how much
+        // cover traffic Fauxx adds. NOT a ratio against the user's real traffic, which Android
+        // exposes no per-app provenance for (issue #160).
+        return actionsToday / 24f
     }
 
     /**

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -412,9 +412,6 @@
     <string name="dashboard_active_persona_title">PERSONA ACTIVA</string>
     <string name="dashboard_active_persona_help">Una identidad sintética que el motor adopta durante aproximadamente una semana. La actividad se pondera hacia los intereses de esta persona para crear un ruido temporalmente coherente, lo que dificulta que los rastreadores filtren la señal falsa. Las personas sintéticas rotan automáticamente.</string>
     <string name="dashboard_persona_subtitle">%1$s · %2$s</string>
-    <string name="dashboard_noise_ratio_title">PROPORCIÓN DE RUIDO</string>
-    <string name="dashboard_noise_ratio_help">Estima cuánto de tu perfil de navegación visible es ruido sintético frente a actividad real. Cuanto más alto, mejor: al 80%% o más, un intermediario de datos tendría que identificar correctamente 4 de cada 5 señales como falsas para construir un perfil preciso.</string>
-    <string name="dashboard_noise_ratio_value">%d%%</string>
     <string name="dashboard_battery_dialog_title">Mantener Fauxx funcionando en segundo plano</string>
     <string name="dashboard_battery_dialog_body_intro">Android pausa de forma agresiva las apps en segundo plano para ahorrar batería. Para envenenar perfiles de forma continua, Fauxx necesita estar exento de la optimización de batería.</string>
     <string name="dashboard_battery_dialog_body_action">En la siguiente pantalla, elige \"Permitir\" para que el motor pueda seguir generando actividad sintética mientras la pantalla esté apagada.</string>
@@ -441,4 +438,9 @@
     <string name="log_export_toast_saved_to_downloads">Guardado en Descargas/%s</string>
     <string name="log_export_toast_save_failed">No se pudo guardar el archivo</string>
     <string name="log_export_toast_copied_to_clipboard">Copiado al portapapeles</string>
+    <string name="dashboard_drift_title">DERIVA DEL PERFIL</string>
+    <string name="dashboard_drift_help">Cuánto se ha alejado tu perfil de intereses publicitarios importado desde la primera importación (de referencia), expresado como divergencia KL. Un valor más alto indica más movimiento. La deriva también puede reflejar que la plataforma reentrena su propio modelo, no solo Fauxx, así que considérala un indicador, no una prueba.</string>
+    <string name="dashboard_drift_collecting">recopilando…</string>
+    <string name="dashboard_synthetic_activity_title">ACTIVIDAD SINTÉTICA</string>
+    <string name="dashboard_synthetic_activity_help">El número medio de acciones sintéticas que Fauxx generó por hora durante las últimas 24 horas. Muestra cuánto tráfico de cobertura añade Fauxx. No es una proporción frente a tu actividad real, algo que Android no permite medir a una aplicación.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -412,9 +412,6 @@
     <string name="dashboard_active_persona_title">PERSONA ACTIVE</string>
     <string name="dashboard_active_persona_help">Une identité synthétique que le moteur adopte pendant environ une semaine. L\'activité est pondérée vers les centres d\'intérêt de cette persona pour créer un bruit cohérent dans le temps — ce qui complique le filtrage du faux signal par les traqueurs. Les personas tournent automatiquement.</string>
     <string name="dashboard_persona_subtitle">%1$s · %2$s</string>
-    <string name="dashboard_noise_ratio_title">TAUX DE BRUIT</string>
-    <string name="dashboard_noise_ratio_help">Estime quelle part de ton profil de navigation visible correspond à du bruit synthétique plutôt qu\'à de l\'activité réelle. Plus c\'est élevé, mieux c\'est — à 80 %% ou plus, un courtier en données devrait identifier correctement 4 signaux sur 5 comme faux pour construire un profil précis.</string>
-    <string name="dashboard_noise_ratio_value">%d%%</string>
     <string name="dashboard_battery_dialog_title">Garder Fauxx actif en arrière-plan</string>
     <string name="dashboard_battery_dialog_body_intro">Android met fortement en pause les apps en arrière-plan pour économiser la batterie. Pour empoisonner les profils en continu, Fauxx doit être exempté de l\'optimisation de la batterie.</string>
     <string name="dashboard_battery_dialog_body_action">Sur l\'écran suivant, choisis \"Autoriser\" pour que le moteur puisse continuer à générer une activité synthétique quand ton écran est éteint.</string>
@@ -441,4 +438,9 @@
     <string name="log_export_toast_saved_to_downloads">Enregistré dans Téléchargements/%s</string>
     <string name="log_export_toast_save_failed">Impossible d\'enregistrer le fichier</string>
     <string name="log_export_toast_copied_to_clipboard">Copié dans le presse-papiers</string>
+    <string name="dashboard_drift_title">DÉRIVE DU PROFIL</string>
+    <string name="dashboard_drift_help">À quel point votre profil d\'intérêts publicitaires importé s\'est éloigné de votre premier import (de référence), exprimé en divergence KL. Plus la valeur est élevée, plus le mouvement est important. La dérive peut aussi refléter le réentraînement du modèle par la plateforme, pas seulement Fauxx, considérez-la donc comme un indicateur, pas une preuve.</string>
+    <string name="dashboard_drift_collecting">collecte…</string>
+    <string name="dashboard_synthetic_activity_title">ACTIVITÉ SYNTHÉTIQUE</string>
+    <string name="dashboard_synthetic_activity_help">Le nombre moyen d\'actions synthétiques générées par Fauxx par heure au cours des dernières 24 heures. Cela indique la quantité de trafic de couverture ajoutée par Fauxx. Ce n\'est pas un ratio par rapport à votre activité réelle, qu\'Android ne permet pas à une application de mesurer.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -161,7 +161,6 @@
     <!-- Dashboard screen -->
     <string name="dashboard_category_distribution_help">Показывает, как твой синтетический шум распределён по тематическим категориям. Чем шире разброс, тем более запутанный профиль видят трекеры. Категории взвешиваются движком таргетинга, чтобы максимально отдалить шум от твоих реальных интересов.</string>
     <string name="dashboard_active_persona_help">Синтетическая личность, которую движок использует примерно неделю. Активность смещается в сторону интересов этой персоны, чтобы создавать согласованный во времени шум — так трекерам сложнее отфильтровать поддельный сигнал. Персоны меняются автоматически.</string>
-    <string name="dashboard_noise_ratio_help">Оценивает, какая часть твоего видимого профиля браузинга является синтетическим шумом, а не реальной активностью. Чем выше, тем лучше: при 80%%+ брокеру данных пришлось бы правильно распознать 4 из 5 сигналов как фальшивые, чтобы построить точный профиль.</string>
     <string name="dashboard_battery_dialog_title">Пусть Fauxx работает в фоне</string>
 
     <!-- Targeting screen -->
@@ -435,8 +434,6 @@
     <string name="dashboard_chart_legend_entry">%1$s %2$d%%</string>
     <string name="dashboard_active_persona_title">АКТИВНАЯ ПЕРСОНА</string>
     <string name="dashboard_persona_subtitle">%1$s · %2$s</string>
-    <string name="dashboard_noise_ratio_title">КОЭФФИЦИЕНТ ШУМА</string>
-    <string name="dashboard_noise_ratio_value">%d%%</string>
     <string name="dashboard_battery_dialog_body_intro">Android агрессивно ставит фоновые приложения на паузу для экономии батареи. Для непрерывного отравления профиля Fauxx должен быть исключён из оптимизации батареи.</string>
     <string name="dashboard_battery_dialog_body_action">На следующем экране выбери «Разрешить», чтобы движок мог продолжать генерировать синтетическую активность с выключенным экраном.</string>
     <string name="dashboard_battery_dialog_continue">Продолжить</string>
@@ -461,4 +458,9 @@
     <string name="log_export_toast_save_failed">Не удалось сохранить файл</string>
     <string name="log_export_toast_copied_to_clipboard">Скопировано в буфер</string>
 
+    <string name="dashboard_drift_title">ДРЕЙФ ПРОФИЛЯ</string>
+    <string name="dashboard_drift_help">Насколько ваш импортированный профиль рекламных интересов отдалился от первого (базового) импорта, в виде KL-дивергенции. Большее значение означает большее движение. Дрейф также может отражать переобучение модели самой платформой, а не только работу Fauxx, поэтому воспринимайте его как индикатор, а не доказательство.</string>
+    <string name="dashboard_drift_collecting">сбор данных…</string>
+    <string name="dashboard_synthetic_activity_title">СИНТЕТИЧЕСКАЯ АКТИВНОСТЬ</string>
+    <string name="dashboard_synthetic_activity_help">Среднее число синтетических действий, которые Fauxx генерировал в час за последние 24 часа. Показывает, сколько маскирующего трафика добавляет Fauxx. Это не соотношение с вашей реальной активностью, которую приложение в Android измерить не может.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -410,9 +410,6 @@
     <string name="dashboard_active_persona_title">ACTIVE PERSONA</string>
     <string name="dashboard_active_persona_help">A synthetic identity the engine adopts for about a week. Activity is weighted toward this persona\'s interests to create temporally coherent noise — making it harder for trackers to filter out the fake signal. Personas rotate automatically.</string>
     <string name="dashboard_persona_subtitle">%1$s · %2$s</string>
-    <string name="dashboard_noise_ratio_title">NOISE RATIO</string>
-    <string name="dashboard_noise_ratio_help">Estimates how much of your visible browsing profile is synthetic noise vs real activity. Higher is better — at 80%%+, a data broker would need to correctly identify 4 out of 5 signals as fake to build an accurate profile.</string>
-    <string name="dashboard_noise_ratio_value">%d%%</string>
     <string name="dashboard_battery_dialog_title">Keep Fauxx running in the background</string>
     <string name="dashboard_battery_dialog_body_intro">Android aggressively pauses background apps to save battery. For continuous profile poisoning, Fauxx needs to be exempt from battery optimization.</string>
     <string name="dashboard_battery_dialog_body_action">On the next screen, choose \"Allow\" so the engine can keep generating synthetic activity while your screen is off.</string>
@@ -439,4 +436,11 @@
     <string name="log_export_toast_saved_to_downloads">Saved to Downloads/%s</string>
     <string name="log_export_toast_save_failed">Failed to save file</string>
     <string name="log_export_toast_copied_to_clipboard">Copied to clipboard</string>
+    <string name="dashboard_drift_title">PROFILE DRIFT</string>
+    <string name="dashboard_drift_help">How far your imported ad-interest profile has moved from its first (baseline) import, shown as a KL divergence. Higher means more movement. Drift can also reflect the platform retraining its own model, not only Fauxx, so treat it as an indicator, not proof.</string>
+    <string name="dashboard_drift_value" translatable="false">%.2f</string>
+    <string name="dashboard_drift_collecting">collecting…</string>
+    <string name="dashboard_synthetic_activity_title">SYNTHETIC ACTIVITY</string>
+    <string name="dashboard_synthetic_activity_help">The average number of synthetic actions Fauxx generated per hour over the last 24 hours. It shows how much cover traffic Fauxx is adding. It is not a ratio against your real activity, which Android does not let an app measure.</string>
+    <string name="dashboard_synthetic_activity_value" translatable="false">%.1f/h</string>
 </resources>

--- a/app/src/test/java/com/fauxx/AdversarialScraperLayerTest.kt
+++ b/app/src/test/java/com/fauxx/AdversarialScraperLayerTest.kt
@@ -4,6 +4,10 @@ import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.targeting.layer2.AdversarialScraperLayer
 import com.fauxx.targeting.layer2.PlatformProfileCache
 import com.fauxx.targeting.layer2.PlatformProfileDao
+import com.fauxx.targeting.layer2.ProfileDriftCalculator
+import com.fauxx.targeting.layer2.ProfileSnapshot
+import com.fauxx.targeting.layer2.ProfileSnapshotDao
+import com.fauxx.targeting.layer2.SnapshotSource
 import com.google.gson.Gson
 import io.mockk.every
 import io.mockk.mockk
@@ -18,32 +22,41 @@ class AdversarialScraperLayerTest {
 
     private val gson = Gson()
 
+    /** Build a layer with a real drift calculator and a snapshot DAO returning [snapshots]. */
+    private fun layer(
+        dao: PlatformProfileDao,
+        snapshots: List<ProfileSnapshot> = emptyList(),
+    ): AdversarialScraperLayer {
+        val snapshotDao: ProfileSnapshotDao =
+            mockk { every { observeAll() } returns MutableStateFlow(snapshots) }
+        return AdversarialScraperLayer(dao, snapshotDao, ProfileDriftCalculator())
+    }
+
+    private fun daoWith(vararg profiles: PlatformProfileCache): PlatformProfileDao =
+        mockk { every { observeAll() } returns MutableStateFlow(profiles.toList()) }
+
+    private fun profile(platform: String, categories: List<String>, lastScraped: Long = System.currentTimeMillis()) =
+        PlatformProfileCache(platform, gson.toJson(categories), lastScraped)
+
+    private fun snapshot(platform: String, categories: List<String>, at: Long) =
+        ProfileSnapshot(
+            id = at, platformName = platform, source = SnapshotSource.IMPORT,
+            scrapedCategoriesJson = gson.toJson(categories), capturedAt = at,
+        )
+
     @Test
     fun `disabled layer returns all neutral weights`() = runTest {
-        val profilesFlow = MutableStateFlow(emptyList<PlatformProfileCache>())
-        val dao: PlatformProfileDao = mockk { every { observeAll() } returns profilesFlow }
-        val layer = AdversarialScraperLayer(dao)
+        val layer = layer(daoWith())
         layer.setEnabled(false)
-
-        val weights = layer.getWeights().first()
-        weights.values.forEach { w ->
+        layer.getWeights().first().values.forEach { w ->
             assertEquals("All weights should be 1.0 when disabled", 1.0f, w, 0.001f)
         }
     }
 
     @Test
     fun `confirmed categories get 0_05 weight`() = runTest {
-        val categories = listOf("GAMING", "MEDICAL")
-        val profile = PlatformProfileCache(
-            platformName = "google",
-            scrapedCategoriesJson = gson.toJson(categories),
-            lastScraped = System.currentTimeMillis()
-        )
-        val profilesFlow = MutableStateFlow(listOf(profile))
-        val dao: PlatformProfileDao = mockk { every { observeAll() } returns profilesFlow }
-        val layer = AdversarialScraperLayer(dao)
+        val layer = layer(daoWith(profile("google", listOf("GAMING", "MEDICAL"))))
         layer.setEnabled(true)
-
         val weights = layer.getWeights().first()
         assertEquals(0.05f, weights[CategoryPool.GAMING]!!, 0.001f)
         assertEquals(0.05f, weights[CategoryPool.MEDICAL]!!, 0.001f)
@@ -51,84 +64,63 @@ class AdversarialScraperLayerTest {
 
     @Test
     fun `absent categories get 3_0 weight`() = runTest {
-        val categories = listOf("GAMING")
-        val profile = PlatformProfileCache(
-            platformName = "google",
-            scrapedCategoriesJson = gson.toJson(categories),
-            lastScraped = System.currentTimeMillis()
-        )
-        val profilesFlow = MutableStateFlow(listOf(profile))
-        val dao: PlatformProfileDao = mockk { every { observeAll() } returns profilesFlow }
-        val layer = AdversarialScraperLayer(dao)
+        val layer = layer(daoWith(profile("google", listOf("GAMING"))))
         layer.setEnabled(true)
-
         val weights = layer.getWeights().first()
-        // Any category NOT in the scraped list should get 3.0
         assertEquals(3.0f, weights[CategoryPool.RETIREMENT]!!, 0.001f)
         assertEquals(3.0f, weights[CategoryPool.COOKING]!!, 0.001f)
     }
 
     @Test
     fun `stale data returns neutral weights`() = runTest {
-        val categories = listOf("GAMING")
         val eightDaysAgo = System.currentTimeMillis() - 8L * 24 * 60 * 60 * 1000
-        val profile = PlatformProfileCache(
-            platformName = "google",
-            scrapedCategoriesJson = gson.toJson(categories),
-            lastScraped = eightDaysAgo
-        )
-        val profilesFlow = MutableStateFlow(listOf(profile))
-        val dao: PlatformProfileDao = mockk { every { observeAll() } returns profilesFlow }
-        val layer = AdversarialScraperLayer(dao)
+        val layer = layer(daoWith(profile("google", listOf("GAMING"), lastScraped = eightDaysAgo)))
         layer.setEnabled(true)
-
-        val weights = layer.getWeights().first()
-        // All stale data should fall back to neutral
-        weights.values.forEach { w ->
+        layer.getWeights().first().values.forEach { w ->
             assertEquals("Stale data should produce neutral weights", 1.0f, w, 0.001f)
         }
     }
 
     @Test
     fun `invalid JSON categories are gracefully ignored`() = runTest {
-        val profile = PlatformProfileCache(
-            platformName = "google",
-            scrapedCategoriesJson = "not valid json",
-            lastScraped = System.currentTimeMillis()
-        )
-        val profilesFlow = MutableStateFlow(listOf(profile))
-        val dao: PlatformProfileDao = mockk { every { observeAll() } returns profilesFlow }
-        val layer = AdversarialScraperLayer(dao)
+        val layer = layer(daoWith(PlatformProfileCache("google", "not valid json", System.currentTimeMillis())))
         layer.setEnabled(true)
-
-        val weights = layer.getWeights().first()
-        // Should fall back to neutral on parse error
-        weights.values.forEach { w ->
+        layer.getWeights().first().values.forEach { w ->
             assertEquals("Invalid JSON should produce neutral weights", 1.0f, w, 0.001f)
         }
     }
 
     @Test
     fun `multiple platforms merge confirmed categories`() = runTest {
-        val googleProfile = PlatformProfileCache(
-            platformName = "google",
-            scrapedCategoriesJson = gson.toJson(listOf("GAMING")),
-            lastScraped = System.currentTimeMillis()
-        )
-        val facebookProfile = PlatformProfileCache(
-            platformName = "facebook",
-            scrapedCategoriesJson = gson.toJson(listOf("MEDICAL")),
-            lastScraped = System.currentTimeMillis()
-        )
-        val profilesFlow = MutableStateFlow(listOf(googleProfile, facebookProfile))
-        val dao: PlatformProfileDao = mockk { every { observeAll() } returns profilesFlow }
-        val layer = AdversarialScraperLayer(dao)
+        val layer = layer(daoWith(profile("google", listOf("GAMING")), profile("facebook", listOf("MEDICAL"))))
         layer.setEnabled(true)
-
         val weights = layer.getWeights().first()
         assertEquals(0.05f, weights[CategoryPool.GAMING]!!, 0.001f)
         assertEquals(0.05f, weights[CategoryPool.MEDICAL]!!, 0.001f)
-        // Others should still be boosted
         assertTrue(weights[CategoryPool.COOKING]!! == 3.0f)
+    }
+
+    @Test
+    fun `a category present in both recent snapshots is pushed harder`() = runTest {
+        // GAMING appears in both of google's two most recent snapshots (sticky = not budging).
+        // MEDICAL is confirmed (in the latest cache) but not sticky -> standard suppression.
+        val snaps = listOf(
+            snapshot("google", listOf("GAMING"), at = 1_000),
+            snapshot("google", listOf("GAMING"), at = 2_000),
+        )
+        val layer = layer(daoWith(profile("google", listOf("GAMING", "MEDICAL"))), snaps)
+        layer.setEnabled(true)
+        val weights = layer.getWeights().first()
+        assertEquals("sticky confirmed category is pushed harder", 0.02f, weights[CategoryPool.GAMING]!!, 0.001f)
+        assertEquals("non-sticky confirmed stays at standard suppression", 0.05f, weights[CategoryPool.MEDICAL]!!, 0.001f)
+    }
+
+    @Test
+    fun `a single snapshot does not trigger sticky weighting`() = runTest {
+        val snaps = listOf(snapshot("google", listOf("GAMING"), at = 1_000))
+        val layer = layer(daoWith(profile("google", listOf("GAMING"))), snaps)
+        layer.setEnabled(true)
+        // Only one snapshot -> no drift comparison -> standard 0.05, not 0.02.
+        assertEquals(0.05f, layer.getWeights().first()[CategoryPool.GAMING]!!, 0.001f)
     }
 }

--- a/app/src/test/java/com/fauxx/DashboardViewModelTest.kt
+++ b/app/src/test/java/com/fauxx/DashboardViewModelTest.kt
@@ -76,7 +76,11 @@ class DashboardViewModelTest {
 
         val vm = DashboardViewModel(
             context, actionLogDao, profileRepo, poisonEngine, targetingEngine,
-            personaLayer, dataStore, clock
+            personaLayer, dataStore,
+            mockk<com.fauxx.targeting.layer2.ProfileSnapshotDao>(relaxed = true) {
+                every { observeAll() } returns MutableStateFlow(emptyList<com.fauxx.targeting.layer2.ProfileSnapshot>())
+            },
+            com.fauxx.targeting.layer2.ProfileDriftMetric(), clock
         )
         val job = launch { vm.uiState.collect {} }
         testScheduler.runCurrent()

--- a/app/src/test/java/com/fauxx/service/RetentionWorkerTest.kt
+++ b/app/src/test/java/com/fauxx/service/RetentionWorkerTest.kt
@@ -41,7 +41,7 @@ class RetentionWorkerTest {
                     appContext: Context,
                     workerClassName: String,
                     workerParameters: WorkerParameters
-                ): RetentionWorker = RetentionWorker(appContext, workerParameters, dao, dataStore)
+                ): RetentionWorker = RetentionWorker(appContext, workerParameters, dao, mockk(relaxed = true), dataStore)
             })
             .build()
 

--- a/app/src/test/java/com/fauxx/targeting/layer2/ProfileDriftMetricTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer2/ProfileDriftMetricTest.kt
@@ -1,0 +1,56 @@
+package com.fauxx.targeting.layer2
+
+import com.fauxx.data.querybank.CategoryPool
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProfileDriftMetricTest {
+
+    private val gson = Gson()
+    private val metric = ProfileDriftMetric()
+
+    private fun snap(platform: String, cats: List<String>, at: Long) =
+        ProfileSnapshot(
+            platformName = platform, source = SnapshotSource.IMPORT,
+            scrapedCategoriesJson = gson.toJson(cats), capturedAt = at,
+        )
+
+    @Test
+    fun `collecting until two snapshots exist for a platform`() {
+        assertEquals(DriftState.COLLECTING, metric.compute(emptyList()).state)
+        val r = metric.compute(listOf(snap("google", listOf("GAMING"), 1)))
+        assertEquals(DriftState.COLLECTING, r.state)
+        assertNull(r.klDivergence)
+    }
+
+    @Test
+    fun `identical baseline and latest yields zero drift`() {
+        val snaps = listOf(
+            snap("google", listOf("GAMING", "MEDICAL"), 1),
+            snap("google", listOf("GAMING", "MEDICAL"), 2),
+        )
+        val r = metric.compute(snaps)
+        assertEquals(DriftState.AVAILABLE, r.state)
+        assertEquals(0.0, r.klDivergence!!, 1e-9)
+    }
+
+    @Test
+    fun `a changed profile yields positive drift`() {
+        val snaps = listOf(
+            snap("google", listOf("GAMING"), 1),
+            snap("google", listOf("COOKING", "TRAVEL", "FINANCE"), 2),
+        )
+        val r = metric.compute(snaps)
+        assertEquals(DriftState.AVAILABLE, r.state)
+        assertTrue("drift should be positive when the profile changes", r.klDivergence!! > 0.0)
+    }
+
+    @Test
+    fun `kl is zero for identical sets and positive otherwise`() {
+        assertEquals(0.0, metric.kl(setOf(CategoryPool.GAMING), setOf(CategoryPool.GAMING)), 1e-9)
+        assertTrue(metric.kl(setOf(CategoryPool.GAMING), setOf(CategoryPool.COOKING)) > 0.0)
+    }
+}

--- a/app/src/test/java/com/fauxx/targeting/layer2/importers/FacebookDyiImporterTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer2/importers/FacebookDyiImporterTest.kt
@@ -55,7 +55,7 @@ class FacebookDyiImporterTest {
             """.trimIndent().toByteArray()
         )
         val mapper = CategoryMapper(context)
-        importer = FacebookDyiImporter(context, mapper, dao, clock)
+        importer = FacebookDyiImporter(context, mapper, dao, mockk(relaxed = true), clock)
     }
 
     @Test

--- a/app/src/test/java/com/fauxx/targeting/layer2/importers/GoogleTakeoutImporterTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer2/importers/GoogleTakeoutImporterTest.kt
@@ -62,7 +62,7 @@ class GoogleTakeoutImporterTest {
             """.trimIndent().toByteArray()
         )
         val mapper = CategoryMapper(context)
-        importer = GoogleTakeoutImporter(context, mapper, dao, clock)
+        importer = GoogleTakeoutImporter(context, mapper, dao, mockk(relaxed = true), clock)
     }
 
     @Test


### PR DESCRIPTION
Implements milestone M2 (Close the Loop: measurement & feedback). Turns Layer 2 from open-loop into a feedback controller, surfaces profile drift honestly, and replaces the misleading noise-ratio metric. Spike: `.devloop/spikes/m2-measurement-fix.md`.

## E1 (#170) — Layer 2 import-delta feedback controller
The in-app scraper was retired in #52 because embedded WebViews cannot authenticate to Google/Facebook (403 `disallowed_useragent`), so reviving it is impossible. Instead this uses the data that already works: successive user Takeout/DYI imports.
- New append-only `profile_snapshot` history table (entity + DAO), `PhantomDatabase` v4->5 migration (DDL verified byte-exact against the generated `5.json`), DI wiring, and `RetentionWorker` pruning that always keeps each platform's baseline.
- Both importers capture an IMPORT snapshot on each successful import.
- `ProfileDriftCalculator` + a drift-aware `AdversarialScraperLayer`: confirmed categories that will not budge across the two most recent snapshots are pushed harder (0.02 vs 0.05), with a neutral fallback until at least two snapshots exist.

## E2 (#171) — profile-drift dashboard card
- `ProfileDriftMetric`: Laplace-smoothed KL divergence of the latest import from the baseline import over the CategoryPool support; reports COLLECTING until two snapshots exist.
- `DashboardViewModel` exposes `driftState` + `driftKlDivergence`; a `DriftCard` shows the value (or "collecting…") with honest help text noting drift can reflect the platform retraining its own model, not only Fauxx.

## #160 — honest noise-ratio reframe
A real fake-vs-real traffic ratio is infeasible on Android (no per-UID traffic provenance without a VPN), and the shipped "NOISE RATIO / 4 of 5 signals fake" metric was misleading.
- Replaced `computeNoiseRatio` (`actionsToday/500`) with `computeSyntheticActionRate` (actions/hour over 24h).
- `NoiseRatioCard` -> `SyntheticActivityCard`: a plain "X/h" read-out, not a slider-like bar (fixes the #149/#150 confusion). Removed the false "4 of 5 fake" copy; added honest synthetic-activity strings in en/es/fr/ru.

## Scope / deferrals
- **E3 (#172) deferred to M3** (already moved): a control-profile A/B needs a separate `:control` process (process-awareness, BootGuard boot-path changes, multi-process SQLCipher) that is much larger and riskier than the roadmap implied, and only measures Fauxx's own phantom context.
- Phantom self-scrape (an automatic E1 signal) deferred to M3; M2 ships import-delta only.

## Verification
Full-flavor unit suite green (new `ProfileDriftMetricTest`, `ProfileDriftCalculator`/sticky-drift tests in `AdversarialScraperLayerTest`, updated importer/retention/dashboard tests). androidTest compiles; `PhantomDatabaseMigrationTest` extended to v5 (validates the migration against the exported schema when the instrumented suite runs).

Closes #170
Closes #171
Closes #160
