### PR TITLE
M3: Coherent Persona (the strategic pivot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,7 @@ Thumbs.db
 CLAUDE.md
 .devloop
 .claude/
-scripts/
+# Local one-off dev/AI-review tools stay ignored; the E7 persona-distribution
+# builder is committed (it regenerates a shipped asset and must be reviewable).
+scripts/*
+!scripts/build_persona_distribution.py

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ CLAUDE.md
 # builder is committed (it regenerates a shipped asset and must be reviewable).
 scripts/*
 !scripts/build_persona_distribution.py
+!scripts/backfill_city_regions.py

--- a/app/schemas/com.fauxx.data.db.PhantomDatabase/6.json
+++ b/app/schemas/com.fauxx.data.db.PhantomDatabase/6.json
@@ -1,0 +1,264 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "20b72fa7c692e3230d565ba794c01c00",
+    "entities": [
+      {
+        "tableName": "action_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `actionType` TEXT NOT NULL, `category` TEXT NOT NULL, `detail` TEXT NOT NULL, `success` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionType",
+            "columnName": "actionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detail",
+            "columnName": "detail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "success",
+            "columnName": "success",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_action_log_timestamp_success",
+            "unique": false,
+            "columnNames": [
+              "timestamp",
+              "success"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_action_log_timestamp_success` ON `${TABLE_NAME}` (`timestamp`, `success`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_demographic_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ageRange` TEXT, `gender` TEXT, `profession` TEXT, `region` TEXT, `interestsJson` TEXT, `customInterestsJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ageRange",
+            "columnName": "ageRange",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "profession",
+            "columnName": "profession",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "region",
+            "columnName": "region",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interestsJson",
+            "columnName": "interestsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customInterestsJson",
+            "columnName": "customInterestsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "platform_profile_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platformName` TEXT NOT NULL, `scrapedCategoriesJson` TEXT NOT NULL, `lastScraped` INTEGER NOT NULL, PRIMARY KEY(`platformName`))",
+        "fields": [
+          {
+            "fieldPath": "platformName",
+            "columnName": "platformName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrapedCategoriesJson",
+            "columnName": "scrapedCategoriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastScraped",
+            "columnName": "lastScraped",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platformName"
+          ]
+        }
+      },
+      {
+        "tableName": "profile_snapshot",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `platformName` TEXT NOT NULL, `source` TEXT NOT NULL, `scrapedCategoriesJson` TEXT NOT NULL, `capturedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformName",
+            "columnName": "platformName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrapedCategoriesJson",
+            "columnName": "scrapedCategoriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_profile_snapshot_platformName_capturedAt",
+            "unique": false,
+            "columnNames": [
+              "platformName",
+              "capturedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_profile_snapshot_platformName_capturedAt` ON `${TABLE_NAME}` (`platformName`, `capturedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "persona_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `personaJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaJson",
+            "columnName": "personaJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "circadian_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hourOfDay` INTEGER NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`hourOfDay`))",
+        "fields": [
+          {
+            "fieldPath": "hourOfDay",
+            "columnName": "hourOfDay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "hourOfDay"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '20b72fa7c692e3230d565ba794c01c00')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/fauxx/data/db/PhantomDatabaseDaoRoundTripTest.kt
+++ b/app/src/androidTest/java/com/fauxx/data/db/PhantomDatabaseDaoRoundTripTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.fauxx.data.model.ActionType
 import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.engine.scheduling.CircadianUsageEntity
 import com.fauxx.targeting.layer1.AgeRange
 import com.fauxx.targeting.layer1.DemographicProfileDao
 import com.fauxx.targeting.layer1.Gender
@@ -30,7 +31,7 @@ import org.junit.runner.RunWith
 
 /**
  * Round-trips every DAO of [PhantomDatabase] through a REAL SQLCipher-encrypted database, built
- * fresh at the current schema version (v4, no migrations). The point is to prove that values
+ * fresh at the current schema version (v6, no migrations). The point is to prove that values
  * survive the full Room <-> SQLCipher <-> Room path with their type-converted columns intact:
  *
  * - [ActionType] and [CategoryPool] persist via the explicit [PhantomTypeConverters] (enum.name).
@@ -257,6 +258,34 @@ class PhantomDatabaseDaoRoundTripTest {
         // A cutoff at/after the timestamp returns nothing (query is strictly-greater).
         val none = dao.getRecentPersonas(1_700_000_555_000L)
         assertTrue("strictly-greater cutoff excludes the boundary row", none.isEmpty())
+    }
+
+    @Test
+    fun circadianUsageDao_roundTripsHistogramWithReplaceAndDelete() = runBlocking {
+        val dao = db.circadianUsageDao()
+
+        // Empty table to start.
+        assertTrue("no circadian rows before upsert", dao.getAll().isEmpty())
+
+        // Persist a full 24-bucket snapshot (the observer always writes all hours).
+        val snapshot = (0 until 24).map { CircadianUsageEntity(hourOfDay = it, count = it.toLong()) }
+        dao.upsertAll(snapshot)
+
+        val read = dao.getAll().associateBy { it.hourOfDay }
+        assertEquals("all 24 hour buckets round-trip", 24, read.size)
+        assertEquals(0L, read[0]?.count)
+        assertEquals(23L, read[23]?.count)
+
+        // REPLACE on the hourOfDay primary key: re-upserting must overwrite, not duplicate.
+        val updated = (0 until 24).map { CircadianUsageEntity(hourOfDay = it, count = (it * 2).toLong()) }
+        dao.upsertAll(updated)
+        val reread = dao.getAll()
+        assertEquals("REPLACE must not create duplicate rows", 24, reread.size)
+        assertEquals(46L, reread.first { it.hourOfDay == 23 }.count)
+
+        // deleteAll wipes the learned rhythm (the "Clear My Profile" path).
+        dao.deleteAll()
+        assertTrue("deleteAll clears the histogram", dao.getAll().isEmpty())
     }
 
     private companion object {

--- a/app/src/androidTest/java/com/fauxx/data/db/PhantomDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/fauxx/data/db/PhantomDatabaseMigrationTest.kt
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith
  * Exercises [PhantomDatabase]'s real migrations under SQLCipher on a device — the path that
  * actually runs on a user's phone when they update the app. A broken migration here is silent
  * data loss or an open-time crash for every existing install, so this verifies both that the
- * 1->2->3->4 chain applies its schema changes AND that rows written before the update survive it.
+ * 1->2->3->4->5->6 chain applies its schema changes AND that rows written before the update survive it.
  *
  * Room's exported schemas only include 3.json, so [androidx.room.testing.MigrationTestHelper]
  * (which needs 1.json/2.json to stand up an old DB) can't be used. Instead we hand-seed an
@@ -47,23 +47,23 @@ class PhantomDatabaseMigrationTest {
     }
 
     @Test
-    fun migrate1To5_preservesSeededRows_andAppliesSchemaChanges() {
+    fun migrate1To6_preservesSeededRows_andAppliesSchemaChanges() {
         seedEncryptedV1Database()
 
         val db = buildRoomDatabase()
         try {
-            // First access runs the 1->2->3->4->5 migration chain and validates the result against v5.
+            // First access runs the 1->2->3->4->5->6 migration chain and validates the result against v6.
             val sdb = db.openHelper.writableDatabase
 
             // Rows written at v1 must survive the migration.
             sdb.query("SELECT detail, success FROM action_log").use { c ->
-                assertTrue("seeded action_log row must survive 1->3", c.moveToFirst())
+                assertTrue("seeded action_log row must survive the migration", c.moveToFirst())
                 assertEquals("exactly one action_log row after migration", 1, c.count)
                 assertEquals("v1-seeded-action", c.getString(0))
                 assertEquals(1, c.getInt(1))
             }
             sdb.query("SELECT ageRange, customInterestsJson FROM user_demographic_profile WHERE id = 0").use { c ->
-                assertTrue("seeded demographic row must survive 1->3", c.moveToFirst())
+                assertTrue("seeded demographic row must survive the migration", c.moveToFirst())
                 assertEquals("25-34", c.getString(0))
                 assertTrue("customInterestsJson added by 2->3 defaults to NULL on existing rows", c.isNull(1))
             }
@@ -94,13 +94,19 @@ class PhantomDatabaseMigrationTest {
             ).use { c ->
                 assertTrue("MIGRATION_4_5 must create profile_snapshot", c.moveToFirst())
             }
+            // MIGRATION_5_6 created the circadian_usage histogram table (issue #177 E10).
+            sdb.query(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='circadian_usage'"
+            ).use { c ->
+                assertTrue("MIGRATION_5_6 must create circadian_usage", c.moveToFirst())
+            }
         } finally {
             db.close()
         }
     }
 
     @Test
-    fun freshCreateAtV3_roundTripsThroughSqlcipher() {
+    fun freshCreateAtV6_roundTripsThroughSqlcipher() {
         val db = buildRoomDatabase()
         try {
             val sdb = db.openHelper.writableDatabase
@@ -112,17 +118,23 @@ class PhantomDatabaseMigrationTest {
                 assertTrue(c.moveToFirst())
                 assertEquals(1, c.getInt(0))
             }
-            // The index ships on a fresh v3 create too, not just via the migration path.
+            // The index ships on a fresh v6 create too, not just via the migration path.
             sdb.query(
                 "SELECT name FROM sqlite_master WHERE type='index' AND name='index_action_log_timestamp_success'"
             ).use { c ->
-                assertTrue("fresh v3 create must include the composite index", c.moveToFirst())
+                assertTrue("fresh v6 create must include the composite index", c.moveToFirst())
             }
             assertTrue(columnExists(sdb, "user_demographic_profile", "customInterestsJson"))
             assertTrue(
-                "fresh v4 create must include action_log.metadata",
+                "fresh v6 create must include action_log.metadata",
                 columnExists(sdb, "action_log", "metadata")
             )
+            // A fresh create at v6 ships the circadian_usage table directly (issue #177 E10).
+            sdb.query(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='circadian_usage'"
+            ).use { c ->
+                assertTrue("fresh v6 create must include circadian_usage", c.moveToFirst())
+            }
         } finally {
             db.close()
         }
@@ -131,7 +143,7 @@ class PhantomDatabaseMigrationTest {
     private fun buildRoomDatabase(): PhantomDatabase =
         Room.databaseBuilder(context, PhantomDatabase::class.java, TEST_DB)
             .openHelperFactory(SupportOpenHelperFactory(passphrase))
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
             .build()
 
     /**

--- a/app/src/main/assets/city_coords.json
+++ b/app/src/main/assets/city_coords.json
@@ -1,4032 +1,4838 @@
 [
-  {
-    "name": "New York, United States",
-    "lat": 40.7128,
-    "lng": -74.006
-  },
-  {
-    "name": "Los Angeles, United States",
-    "lat": 34.0522,
-    "lng": -118.2437
-  },
-  {
-    "name": "Chicago, United States",
-    "lat": 41.8781,
-    "lng": -87.6298
-  },
-  {
-    "name": "Houston, United States",
-    "lat": 29.7604,
-    "lng": -95.3698
-  },
-  {
-    "name": "Phoenix, United States",
-    "lat": 33.4484,
-    "lng": -112.074
-  },
-  {
-    "name": "Philadelphia, United States",
-    "lat": 39.9526,
-    "lng": -75.1652
-  },
-  {
-    "name": "San Antonio, United States",
-    "lat": 29.4241,
-    "lng": -98.4936
-  },
-  {
-    "name": "San Diego, United States",
-    "lat": 32.7157,
-    "lng": -117.1611
-  },
-  {
-    "name": "Dallas, United States",
-    "lat": 32.7767,
-    "lng": -96.797
-  },
-  {
-    "name": "San Jose, United States",
-    "lat": 37.3382,
-    "lng": -121.8863
-  },
-  {
-    "name": "Austin, United States",
-    "lat": 30.2672,
-    "lng": -97.7431
-  },
-  {
-    "name": "Jacksonville, United States",
-    "lat": 30.3322,
-    "lng": -81.6557
-  },
-  {
-    "name": "Fort Worth, United States",
-    "lat": 32.7555,
-    "lng": -97.3308
-  },
-  {
-    "name": "Columbus, United States",
-    "lat": 39.9612,
-    "lng": -82.9988
-  },
-  {
-    "name": "Charlotte, United States",
-    "lat": 35.2271,
-    "lng": -80.8431
-  },
-  {
-    "name": "Indianapolis, United States",
-    "lat": 39.7684,
-    "lng": -86.1581
-  },
-  {
-    "name": "San Francisco, United States",
-    "lat": 37.7749,
-    "lng": -122.4194
-  },
-  {
-    "name": "Seattle, United States",
-    "lat": 47.6062,
-    "lng": -122.3321
-  },
-  {
-    "name": "Denver, United States",
-    "lat": 39.7392,
-    "lng": -104.9903
-  },
-  {
-    "name": "Nashville, United States",
-    "lat": 36.1627,
-    "lng": -86.7816
-  },
-  {
-    "name": "Boston, United States",
-    "lat": 42.3601,
-    "lng": -71.0589
-  },
-  {
-    "name": "Atlanta, United States",
-    "lat": 33.749,
-    "lng": -84.388
-  },
-  {
-    "name": "Miami, United States",
-    "lat": 25.7617,
-    "lng": -80.1918
-  },
-  {
-    "name": "Minneapolis, United States",
-    "lat": 44.9778,
-    "lng": -93.265
-  },
-  {
-    "name": "Portland, United States",
-    "lat": 45.5231,
-    "lng": -122.6765
-  },
-  {
-    "name": "Las Vegas, United States",
-    "lat": 36.1699,
-    "lng": -115.1398
-  },
-  {
-    "name": "Memphis, United States",
-    "lat": 35.1495,
-    "lng": -90.049
-  },
-  {
-    "name": "Louisville, United States",
-    "lat": 38.2527,
-    "lng": -85.7585
-  },
-  {
-    "name": "Baltimore, United States",
-    "lat": 39.2904,
-    "lng": -76.6122
-  },
-  {
-    "name": "Milwaukee, United States",
-    "lat": 43.0389,
-    "lng": -87.9065
-  },
-  {
-    "name": "Albuquerque, United States",
-    "lat": 35.0844,
-    "lng": -106.6504
-  },
-  {
-    "name": "Tucson, United States",
-    "lat": 32.2226,
-    "lng": -110.9747
-  },
-  {
-    "name": "Fresno, United States",
-    "lat": 36.7378,
-    "lng": -119.7871
-  },
-  {
-    "name": "Sacramento, United States",
-    "lat": 38.5816,
-    "lng": -121.4944
-  },
-  {
-    "name": "Kansas City, United States",
-    "lat": 39.0997,
-    "lng": -94.5786
-  },
-  {
-    "name": "Mesa, United States",
-    "lat": 33.4152,
-    "lng": -111.8315
-  },
-  {
-    "name": "Omaha, United States",
-    "lat": 41.2565,
-    "lng": -95.9345
-  },
-  {
-    "name": "Colorado Springs, United States",
-    "lat": 38.8339,
-    "lng": -104.8214
-  },
-  {
-    "name": "Raleigh, United States",
-    "lat": 35.7796,
-    "lng": -78.6382
-  },
-  {
-    "name": "Long Beach, United States",
-    "lat": 33.7701,
-    "lng": -118.1937
-  },
-  {
-    "name": "Virginia Beach, United States",
-    "lat": 36.8529,
-    "lng": -75.978
-  },
-  {
-    "name": "Oakland, United States",
-    "lat": 37.8044,
-    "lng": -122.2712
-  },
-  {
-    "name": "Tampa, United States",
-    "lat": 27.9506,
-    "lng": -82.4572
-  },
-  {
-    "name": "New Orleans, United States",
-    "lat": 29.9511,
-    "lng": -90.0715
-  },
-  {
-    "name": "Cleveland, United States",
-    "lat": 41.4993,
-    "lng": -81.6944
-  },
-  {
-    "name": "Bakersfield, United States",
-    "lat": 35.3733,
-    "lng": -119.0187
-  },
-  {
-    "name": "Aurora, United States",
-    "lat": 39.7294,
-    "lng": -104.8319
-  },
-  {
-    "name": "Anaheim, United States",
-    "lat": 33.8366,
-    "lng": -117.9143
-  },
-  {
-    "name": "Santa Ana, United States",
-    "lat": 33.7455,
-    "lng": -117.8677
-  },
-  {
-    "name": "Corpus Christi, United States",
-    "lat": 27.8006,
-    "lng": -97.3964
-  },
-  {
-    "name": "Riverside, United States",
-    "lat": 33.9533,
-    "lng": -117.3962
-  },
-  {
-    "name": "Lexington, United States",
-    "lat": 38.0406,
-    "lng": -84.5037
-  },
-  {
-    "name": "St. Louis, United States",
-    "lat": 38.627,
-    "lng": -90.1994
-  },
-  {
-    "name": "Pittsburgh, United States",
-    "lat": 40.4406,
-    "lng": -79.9959
-  },
-  {
-    "name": "Anchorage, United States",
-    "lat": 61.2181,
-    "lng": -149.9003
-  },
-  {
-    "name": "Stockton, United States",
-    "lat": 37.9577,
-    "lng": -121.2908
-  },
-  {
-    "name": "Cincinnati, United States",
-    "lat": 39.1031,
-    "lng": -84.512
-  },
-  {
-    "name": "Salt Lake City, United States",
-    "lat": 40.7608,
-    "lng": -111.891
-  },
-  {
-    "name": "Tulsa, United States",
-    "lat": 36.154,
-    "lng": -95.9928
-  },
-  {
-    "name": "Greensboro, United States",
-    "lat": 36.0726,
-    "lng": -79.792
-  },
-  {
-    "name": "Buffalo, United States",
-    "lat": 42.8864,
-    "lng": -78.8784
-  },
-  {
-    "name": "Newark, United States",
-    "lat": 40.7357,
-    "lng": -74.1724
-  },
-  {
-    "name": "Plano, United States",
-    "lat": 33.0198,
-    "lng": -96.6989
-  },
-  {
-    "name": "Henderson, United States",
-    "lat": 36.0395,
-    "lng": -114.9817
-  },
-  {
-    "name": "Lincoln, United States",
-    "lat": 40.8136,
-    "lng": -96.7026
-  },
-  {
-    "name": "St. Paul, United States",
-    "lat": 44.9537,
-    "lng": -93.09
-  },
-  {
-    "name": "Orlando, United States",
-    "lat": 28.5383,
-    "lng": -81.3792
-  },
-  {
-    "name": "Boise, United States",
-    "lat": 43.615,
-    "lng": -116.2023
-  },
-  {
-    "name": "Richmond, United States",
-    "lat": 37.5407,
-    "lng": -77.436
-  },
-  {
-    "name": "Spokane, United States",
-    "lat": 47.6588,
-    "lng": -117.426
-  },
-  {
-    "name": "Des Moines, United States",
-    "lat": 41.5868,
-    "lng": -93.625
-  },
-  {
-    "name": "Detroit, United States",
-    "lat": 42.3314,
-    "lng": -83.0458
-  },
-  {
-    "name": "Madison, United States",
-    "lat": 43.0731,
-    "lng": -89.4012
-  },
-  {
-    "name": "Lubbock, United States",
-    "lat": 33.5779,
-    "lng": -101.8552
-  },
-  {
-    "name": "Durham, United States",
-    "lat": 35.994,
-    "lng": -78.8986
-  },
-  {
-    "name": "Winston-Salem, United States",
-    "lat": 36.0999,
-    "lng": -80.2442
-  },
-  {
-    "name": "Chandler, United States",
-    "lat": 33.3062,
-    "lng": -111.8413
-  },
-  {
-    "name": "Laredo, United States",
-    "lat": 27.5306,
-    "lng": -99.4803
-  },
-  {
-    "name": "Honolulu, United States",
-    "lat": 21.3069,
-    "lng": -157.8583
-  },
-  {
-    "name": "Scottsdale, United States",
-    "lat": 33.4942,
-    "lng": -111.9261
-  },
-  {
-    "name": "Toronto, Canada",
-    "lat": 43.6532,
-    "lng": -79.3832
-  },
-  {
-    "name": "Montreal, Canada",
-    "lat": 45.5017,
-    "lng": -73.5673
-  },
-  {
-    "name": "Vancouver, Canada",
-    "lat": 49.2827,
-    "lng": -123.1207
-  },
-  {
-    "name": "Calgary, Canada",
-    "lat": 51.0447,
-    "lng": -114.0719
-  },
-  {
-    "name": "Edmonton, Canada",
-    "lat": 53.5461,
-    "lng": -113.4938
-  },
-  {
-    "name": "Ottawa, Canada",
-    "lat": 45.4215,
-    "lng": -75.6972
-  },
-  {
-    "name": "Winnipeg, Canada",
-    "lat": 49.8951,
-    "lng": -97.1384
-  },
-  {
-    "name": "Quebec City, Canada",
-    "lat": 46.8139,
-    "lng": -71.208
-  },
-  {
-    "name": "Hamilton, Canada",
-    "lat": 43.2557,
-    "lng": -79.8711
-  },
-  {
-    "name": "Halifax, Canada",
-    "lat": 44.6488,
-    "lng": -63.5752
-  },
-  {
-    "name": "Victoria, Canada",
-    "lat": 48.4284,
-    "lng": -123.3656
-  },
-  {
-    "name": "Saskatoon, Canada",
-    "lat": 52.1332,
-    "lng": -106.67
-  },
-  {
-    "name": "Regina, Canada",
-    "lat": 50.4452,
-    "lng": -104.6189
-  },
-  {
-    "name": "Mexico City, Mexico",
-    "lat": 19.4326,
-    "lng": -99.1332
-  },
-  {
-    "name": "Guadalajara, Mexico",
-    "lat": 20.6597,
-    "lng": -103.3496
-  },
-  {
-    "name": "Monterrey, Mexico",
-    "lat": 25.6866,
-    "lng": -100.3161
-  },
-  {
-    "name": "Puebla, Mexico",
-    "lat": 19.0414,
-    "lng": -98.2063
-  },
-  {
-    "name": "Tijuana, Mexico",
-    "lat": 32.5027,
-    "lng": -117.0036
-  },
-  {
-    "name": "León, Mexico",
-    "lat": 21.1221,
-    "lng": -101.6822
-  },
-  {
-    "name": "Ciudad Juárez, Mexico",
-    "lat": 31.6904,
-    "lng": -106.4245
-  },
-  {
-    "name": "Cancún, Mexico",
-    "lat": 21.1619,
-    "lng": -86.8515
-  },
-  {
-    "name": "Mérida, Mexico",
-    "lat": 20.9674,
-    "lng": -89.5926
-  },
-  {
-    "name": "Culiacán, Mexico",
-    "lat": 24.8091,
-    "lng": -107.394
-  },
-  {
-    "name": "London, United Kingdom",
-    "lat": 51.5074,
-    "lng": -0.1278
-  },
-  {
-    "name": "Birmingham, United Kingdom",
-    "lat": 52.4862,
-    "lng": -1.8904
-  },
-  {
-    "name": "Manchester, United Kingdom",
-    "lat": 53.4808,
-    "lng": -2.2426
-  },
-  {
-    "name": "Glasgow, United Kingdom",
-    "lat": 55.8642,
-    "lng": -4.2518
-  },
-  {
-    "name": "Liverpool, United Kingdom",
-    "lat": 53.4084,
-    "lng": -2.9916
-  },
-  {
-    "name": "Leeds, United Kingdom",
-    "lat": 53.8008,
-    "lng": -1.5491
-  },
-  {
-    "name": "Sheffield, United Kingdom",
-    "lat": 53.3811,
-    "lng": -1.4701
-  },
-  {
-    "name": "Edinburgh, United Kingdom",
-    "lat": 55.9533,
-    "lng": -3.1883
-  },
-  {
-    "name": "Bristol, United Kingdom",
-    "lat": 51.4545,
-    "lng": -2.5879
-  },
-  {
-    "name": "Cardiff, United Kingdom",
-    "lat": 51.4816,
-    "lng": -3.1791
-  },
-  {
-    "name": "Belfast, United Kingdom",
-    "lat": 54.5973,
-    "lng": -5.9301
-  },
-  {
-    "name": "Dublin, Ireland",
-    "lat": 53.3498,
-    "lng": -6.2603
-  },
-  {
-    "name": "Cork, Ireland",
-    "lat": 51.8985,
-    "lng": -8.4756
-  },
-  {
-    "name": "Paris, France",
-    "lat": 48.8566,
-    "lng": 2.3522
-  },
-  {
-    "name": "Lyon, France",
-    "lat": 45.764,
-    "lng": 4.8357
-  },
-  {
-    "name": "Marseille, France",
-    "lat": 43.2965,
-    "lng": 5.3698
-  },
-  {
-    "name": "Toulouse, France",
-    "lat": 43.6047,
-    "lng": 1.4442
-  },
-  {
-    "name": "Nice, France",
-    "lat": 43.7102,
-    "lng": 7.262
-  },
-  {
-    "name": "Nantes, France",
-    "lat": 47.2184,
-    "lng": -1.5536
-  },
-  {
-    "name": "Strasbourg, France",
-    "lat": 48.5734,
-    "lng": 7.7521
-  },
-  {
-    "name": "Bordeaux, France",
-    "lat": 44.8378,
-    "lng": -0.5792
-  },
-  {
-    "name": "Berlin, Germany",
-    "lat": 52.52,
-    "lng": 13.405
-  },
-  {
-    "name": "Hamburg, Germany",
-    "lat": 53.5753,
-    "lng": 10.0153
-  },
-  {
-    "name": "Munich, Germany",
-    "lat": 48.1351,
-    "lng": 11.582
-  },
-  {
-    "name": "Cologne, Germany",
-    "lat": 50.9333,
-    "lng": 6.95
-  },
-  {
-    "name": "Frankfurt, Germany",
-    "lat": 50.1109,
-    "lng": 8.6821
-  },
-  {
-    "name": "Stuttgart, Germany",
-    "lat": 48.7758,
-    "lng": 9.1829
-  },
-  {
-    "name": "Düsseldorf, Germany",
-    "lat": 51.2217,
-    "lng": 6.7762
-  },
-  {
-    "name": "Dortmund, Germany",
-    "lat": 51.5136,
-    "lng": 7.4653
-  },
-  {
-    "name": "Essen, Germany",
-    "lat": 51.4556,
-    "lng": 7.0116
-  },
-  {
-    "name": "Leipzig, Germany",
-    "lat": 51.3397,
-    "lng": 12.3731
-  },
-  {
-    "name": "Madrid, Spain",
-    "lat": 40.4168,
-    "lng": -3.7038
-  },
-  {
-    "name": "Barcelona, Spain",
-    "lat": 41.3851,
-    "lng": 2.1734
-  },
-  {
-    "name": "Valencia, Spain",
-    "lat": 39.4699,
-    "lng": -0.3763
-  },
-  {
-    "name": "Seville, Spain",
-    "lat": 37.3891,
-    "lng": -5.9845
-  },
-  {
-    "name": "Zaragoza, Spain",
-    "lat": 41.6488,
-    "lng": -0.8891
-  },
-  {
-    "name": "Bilbao, Spain",
-    "lat": 43.263,
-    "lng": -2.935
-  },
-  {
-    "name": "Málaga, Spain",
-    "lat": 36.7213,
-    "lng": -4.4214
-  },
-  {
-    "name": "Rome, Italy",
-    "lat": 41.9028,
-    "lng": 12.4964
-  },
-  {
-    "name": "Milan, Italy",
-    "lat": 45.4642,
-    "lng": 9.19
-  },
-  {
-    "name": "Naples, Italy",
-    "lat": 40.8518,
-    "lng": 14.2681
-  },
-  {
-    "name": "Turin, Italy",
-    "lat": 45.0703,
-    "lng": 7.6869
-  },
-  {
-    "name": "Palermo, Italy",
-    "lat": 38.1157,
-    "lng": 13.3615
-  },
-  {
-    "name": "Genoa, Italy",
-    "lat": 44.4056,
-    "lng": 8.9463
-  },
-  {
-    "name": "Florence, Italy",
-    "lat": 43.7696,
-    "lng": 11.2558
-  },
-  {
-    "name": "Bologna, Italy",
-    "lat": 44.4949,
-    "lng": 11.3426
-  },
-  {
-    "name": "Amsterdam, Netherlands",
-    "lat": 52.3676,
-    "lng": 4.9041
-  },
-  {
-    "name": "Rotterdam, Netherlands",
-    "lat": 51.9244,
-    "lng": 4.4777
-  },
-  {
-    "name": "The Hague, Netherlands",
-    "lat": 52.0705,
-    "lng": 4.3007
-  },
-  {
-    "name": "Utrecht, Netherlands",
-    "lat": 52.0907,
-    "lng": 5.1214
-  },
-  {
-    "name": "Brussels, Belgium",
-    "lat": 50.8503,
-    "lng": 4.3517
-  },
-  {
-    "name": "Antwerp, Belgium",
-    "lat": 51.2194,
-    "lng": 4.4025
-  },
-  {
-    "name": "Vienna, Austria",
-    "lat": 48.2082,
-    "lng": 16.3738
-  },
-  {
-    "name": "Graz, Austria",
-    "lat": 47.0707,
-    "lng": 15.4395
-  },
-  {
-    "name": "Zurich, Switzerland",
-    "lat": 47.3769,
-    "lng": 8.5417
-  },
-  {
-    "name": "Geneva, Switzerland",
-    "lat": 46.2044,
-    "lng": 6.1432
-  },
-  {
-    "name": "Basel, Switzerland",
-    "lat": 47.5596,
-    "lng": 7.5886
-  },
-  {
-    "name": "Bern, Switzerland",
-    "lat": 46.948,
-    "lng": 7.4474
-  },
-  {
-    "name": "Stockholm, Sweden",
-    "lat": 59.3293,
-    "lng": 18.0686
-  },
-  {
-    "name": "Gothenburg, Sweden",
-    "lat": 57.7089,
-    "lng": 11.9746
-  },
-  {
-    "name": "Malmö, Sweden",
-    "lat": 55.605,
-    "lng": 13.0038
-  },
-  {
-    "name": "Oslo, Norway",
-    "lat": 59.9139,
-    "lng": 10.7522
-  },
-  {
-    "name": "Bergen, Norway",
-    "lat": 60.3913,
-    "lng": 5.3221
-  },
-  {
-    "name": "Trondheim, Norway",
-    "lat": 63.4305,
-    "lng": 10.3951
-  },
-  {
-    "name": "Copenhagen, Denmark",
-    "lat": 55.6761,
-    "lng": 12.5683
-  },
-  {
-    "name": "Aarhus, Denmark",
-    "lat": 56.1629,
-    "lng": 10.2039
-  },
-  {
-    "name": "Helsinki, Finland",
-    "lat": 60.1699,
-    "lng": 24.9384
-  },
-  {
-    "name": "Tampere, Finland",
-    "lat": 61.4978,
-    "lng": 23.761
-  },
-  {
-    "name": "Reykjavik, Iceland",
-    "lat": 64.1265,
-    "lng": -21.8174
-  },
-  {
-    "name": "Warsaw, Poland",
-    "lat": 52.2297,
-    "lng": 21.0122
-  },
-  {
-    "name": "Krakow, Poland",
-    "lat": 50.0647,
-    "lng": 19.945
-  },
-  {
-    "name": "Łódź, Poland",
-    "lat": 51.7592,
-    "lng": 19.456
-  },
-  {
-    "name": "Wrocław, Poland",
-    "lat": 51.1079,
-    "lng": 17.0385
-  },
-  {
-    "name": "Prague, Czech Republic",
-    "lat": 50.0755,
-    "lng": 14.4378
-  },
-  {
-    "name": "Brno, Czech Republic",
-    "lat": 49.1951,
-    "lng": 16.6068
-  },
-  {
-    "name": "Budapest, Hungary",
-    "lat": 47.4979,
-    "lng": 19.0402
-  },
-  {
-    "name": "Bucharest, Romania",
-    "lat": 44.4268,
-    "lng": 26.1025
-  },
-  {
-    "name": "Cluj-Napoca, Romania",
-    "lat": 46.7712,
-    "lng": 23.6236
-  },
-  {
-    "name": "Sofia, Bulgaria",
-    "lat": 42.6977,
-    "lng": 23.3219
-  },
-  {
-    "name": "Athens, Greece",
-    "lat": 37.9838,
-    "lng": 23.7275
-  },
-  {
-    "name": "Thessaloniki, Greece",
-    "lat": 40.6401,
-    "lng": 22.9444
-  },
-  {
-    "name": "Belgrade, Serbia",
-    "lat": 44.8176,
-    "lng": 20.4633
-  },
-  {
-    "name": "Zagreb, Croatia",
-    "lat": 45.815,
-    "lng": 15.9819
-  },
-  {
-    "name": "Kyiv, Ukraine",
-    "lat": 50.4501,
-    "lng": 30.5234
-  },
-  {
-    "name": "Kharkiv, Ukraine",
-    "lat": 49.9935,
-    "lng": 36.2304
-  },
-  {
-    "name": "Odessa, Ukraine",
-    "lat": 46.4825,
-    "lng": 30.7233
-  },
-  {
-    "name": "Lviv, Ukraine",
-    "lat": 49.8397,
-    "lng": 24.0297
-  },
-  {
-    "name": "Minsk, Belarus",
-    "lat": 53.9045,
-    "lng": 27.5615
-  },
-  {
-    "name": "Riga, Latvia",
-    "lat": 56.9496,
-    "lng": 24.1052
-  },
-  {
-    "name": "Tallinn, Estonia",
-    "lat": 59.437,
-    "lng": 24.7536
-  },
-  {
-    "name": "Vilnius, Lithuania",
-    "lat": 54.6872,
-    "lng": 25.2797
-  },
-  {
-    "name": "Bratislava, Slovakia",
-    "lat": 48.1486,
-    "lng": 17.1077
-  },
-  {
-    "name": "Ljubljana, Slovenia",
-    "lat": 46.0569,
-    "lng": 14.5058
-  },
-  {
-    "name": "Sarajevo, Bosnia and Herzegovina",
-    "lat": 43.8563,
-    "lng": 18.4131
-  },
-  {
-    "name": "Skopje, North Macedonia",
-    "lat": 41.9981,
-    "lng": 21.4254
-  },
-  {
-    "name": "Tirana, Albania",
-    "lat": 41.3275,
-    "lng": 19.8187
-  },
-  {
-    "name": "Chisinau, Moldova",
-    "lat": 47.0105,
-    "lng": 28.8638
-  },
-  {
-    "name": "Lisbon, Portugal",
-    "lat": 38.7223,
-    "lng": -9.1393
-  },
-  {
-    "name": "Porto, Portugal",
-    "lat": 41.1579,
-    "lng": -8.6291
-  },
-  {
-    "name": "Luxembourg City, Luxembourg",
-    "lat": 49.6116,
-    "lng": 6.1319
-  },
-  {
-    "name": "Tokyo, Japan",
-    "lat": 35.6762,
-    "lng": 139.6503
-  },
-  {
-    "name": "Osaka, Japan",
-    "lat": 34.6937,
-    "lng": 135.5023
-  },
-  {
-    "name": "Nagoya, Japan",
-    "lat": 35.1815,
-    "lng": 136.9066
-  },
-  {
-    "name": "Sapporo, Japan",
-    "lat": 43.0618,
-    "lng": 141.3545
-  },
-  {
-    "name": "Fukuoka, Japan",
-    "lat": 33.5904,
-    "lng": 130.4017
-  },
-  {
-    "name": "Kobe, Japan",
-    "lat": 34.6901,
-    "lng": 135.1956
-  },
-  {
-    "name": "Kyoto, Japan",
-    "lat": 35.0116,
-    "lng": 135.7681
-  },
-  {
-    "name": "Sendai, Japan",
-    "lat": 38.2682,
-    "lng": 140.8694
-  },
-  {
-    "name": "Hiroshima, Japan",
-    "lat": 34.3853,
-    "lng": 132.4553
-  },
-  {
-    "name": "Seoul, South Korea",
-    "lat": 37.5665,
-    "lng": 126.978
-  },
-  {
-    "name": "Busan, South Korea",
-    "lat": 35.1796,
-    "lng": 129.0756
-  },
-  {
-    "name": "Incheon, South Korea",
-    "lat": 37.4563,
-    "lng": 126.7052
-  },
-  {
-    "name": "Daegu, South Korea",
-    "lat": 35.8714,
-    "lng": 128.6014
-  },
-  {
-    "name": "Daejeon, South Korea",
-    "lat": 36.3504,
-    "lng": 127.3845
-  },
-  {
-    "name": "Gwangju, South Korea",
-    "lat": 35.1595,
-    "lng": 126.8526
-  },
-  {
-    "name": "Beijing, China",
-    "lat": 39.9042,
-    "lng": 116.4074
-  },
-  {
-    "name": "Shanghai, China",
-    "lat": 31.2304,
-    "lng": 121.4737
-  },
-  {
-    "name": "Guangzhou, China",
-    "lat": 23.1291,
-    "lng": 113.2644
-  },
-  {
-    "name": "Shenzhen, China",
-    "lat": 22.5431,
-    "lng": 114.0579
-  },
-  {
-    "name": "Chengdu, China",
-    "lat": 30.5728,
-    "lng": 104.0668
-  },
-  {
-    "name": "Chongqing, China",
-    "lat": 29.4316,
-    "lng": 106.9123
-  },
-  {
-    "name": "Wuhan, China",
-    "lat": 30.5928,
-    "lng": 114.3055
-  },
-  {
-    "name": "Xi'an, China",
-    "lat": 34.3416,
-    "lng": 108.9398
-  },
-  {
-    "name": "Tianjin, China",
-    "lat": 39.3434,
-    "lng": 117.3616
-  },
-  {
-    "name": "Nanjing, China",
-    "lat": 32.0603,
-    "lng": 118.7969
-  },
-  {
-    "name": "Hangzhou, China",
-    "lat": 30.2741,
-    "lng": 120.1551
-  },
-  {
-    "name": "Qingdao, China",
-    "lat": 36.0671,
-    "lng": 120.3826
-  },
-  {
-    "name": "Shenyang, China",
-    "lat": 41.7968,
-    "lng": 123.4291
-  },
-  {
-    "name": "Zhengzhou, China",
-    "lat": 34.7466,
-    "lng": 113.6254
-  },
-  {
-    "name": "Harbin, China",
-    "lat": 45.8038,
-    "lng": 126.5349
-  },
-  {
-    "name": "Kunming, China",
-    "lat": 25.0389,
-    "lng": 102.7183
-  },
-  {
-    "name": "Dalian, China",
-    "lat": 38.914,
-    "lng": 121.6147
-  },
-  {
-    "name": "Xiamen, China",
-    "lat": 24.4798,
-    "lng": 118.0894
-  },
-  {
-    "name": "Urumqi, China",
-    "lat": 43.8256,
-    "lng": 87.6168
-  },
-  {
-    "name": "Hong Kong, China",
-    "lat": 22.3193,
-    "lng": 114.1694
-  },
-  {
-    "name": "Taipei, Taiwan",
-    "lat": 25.033,
-    "lng": 121.5654
-  },
-  {
-    "name": "Kaohsiung, Taiwan",
-    "lat": 22.6273,
-    "lng": 120.3014
-  },
-  {
-    "name": "Singapore, Singapore",
-    "lat": 1.3521,
-    "lng": 103.8198
-  },
-  {
-    "name": "Bangkok, Thailand",
-    "lat": 13.7563,
-    "lng": 100.5018
-  },
-  {
-    "name": "Chiang Mai, Thailand",
-    "lat": 18.7883,
-    "lng": 98.9853
-  },
-  {
-    "name": "Pattaya, Thailand",
-    "lat": 12.9236,
-    "lng": 100.8825
-  },
-  {
-    "name": "Jakarta, Indonesia",
-    "lat": -6.2088,
-    "lng": 106.8456
-  },
-  {
-    "name": "Surabaya, Indonesia",
-    "lat": -7.2575,
-    "lng": 112.7521
-  },
-  {
-    "name": "Bandung, Indonesia",
-    "lat": -6.9175,
-    "lng": 107.6191
-  },
-  {
-    "name": "Medan, Indonesia",
-    "lat": 3.5952,
-    "lng": 98.6722
-  },
-  {
-    "name": "Makassar, Indonesia",
-    "lat": -5.1477,
-    "lng": 119.4327
-  },
-  {
-    "name": "Kuala Lumpur, Malaysia",
-    "lat": 3.139,
-    "lng": 101.6869
-  },
-  {
-    "name": "George Town, Malaysia",
-    "lat": 5.4141,
-    "lng": 100.3288
-  },
-  {
-    "name": "Johor Bahru, Malaysia",
-    "lat": 1.4927,
-    "lng": 103.7414
-  },
-  {
-    "name": "Manila, Philippines",
-    "lat": 14.5995,
-    "lng": 120.9842
-  },
-  {
-    "name": "Quezon City, Philippines",
-    "lat": 14.676,
-    "lng": 121.0437
-  },
-  {
-    "name": "Davao, Philippines",
-    "lat": 7.1907,
-    "lng": 125.4553
-  },
-  {
-    "name": "Cebu City, Philippines",
-    "lat": 10.3157,
-    "lng": 123.8854
-  },
-  {
-    "name": "Hanoi, Vietnam",
-    "lat": 21.0278,
-    "lng": 105.8342
-  },
-  {
-    "name": "Ho Chi Minh City, Vietnam",
-    "lat": 10.8231,
-    "lng": 106.6297
-  },
-  {
-    "name": "Da Nang, Vietnam",
-    "lat": 16.0544,
-    "lng": 108.2022
-  },
-  {
-    "name": "Phnom Penh, Cambodia",
-    "lat": 11.5564,
-    "lng": 104.9282
-  },
-  {
-    "name": "Yangon, Myanmar",
-    "lat": 16.8661,
-    "lng": 96.1951
-  },
-  {
-    "name": "Vientiane, Laos",
-    "lat": 17.9757,
-    "lng": 102.6331
-  },
-  {
-    "name": "Mumbai, India",
-    "lat": 19.076,
-    "lng": 72.8777
-  },
-  {
-    "name": "Delhi, India",
-    "lat": 28.6139,
-    "lng": 77.209
-  },
-  {
-    "name": "Bangalore, India",
-    "lat": 12.9716,
-    "lng": 77.5946
-  },
-  {
-    "name": "Hyderabad, India",
-    "lat": 17.385,
-    "lng": 78.4867
-  },
-  {
-    "name": "Chennai, India",
-    "lat": 13.0827,
-    "lng": 80.2707
-  },
-  {
-    "name": "Kolkata, India",
-    "lat": 22.5726,
-    "lng": 88.3639
-  },
-  {
-    "name": "Ahmedabad, India",
-    "lat": 23.0225,
-    "lng": 72.5714
-  },
-  {
-    "name": "Pune, India",
-    "lat": 18.5204,
-    "lng": 73.8567
-  },
-  {
-    "name": "Surat, India",
-    "lat": 21.1702,
-    "lng": 72.8311
-  },
-  {
-    "name": "Jaipur, India",
-    "lat": 26.9124,
-    "lng": 75.7873
-  },
-  {
-    "name": "Lucknow, India",
-    "lat": 26.8467,
-    "lng": 80.9462
-  },
-  {
-    "name": "Kanpur, India",
-    "lat": 26.4499,
-    "lng": 80.3319
-  },
-  {
-    "name": "Nagpur, India",
-    "lat": 21.1458,
-    "lng": 79.0882
-  },
-  {
-    "name": "Bhopal, India",
-    "lat": 23.2599,
-    "lng": 77.4126
-  },
-  {
-    "name": "Visakhapatnam, India",
-    "lat": 17.6868,
-    "lng": 83.2185
-  },
-  {
-    "name": "Dhaka, Bangladesh",
-    "lat": 23.8103,
-    "lng": 90.4125
-  },
-  {
-    "name": "Chittagong, Bangladesh",
-    "lat": 22.3569,
-    "lng": 91.7832
-  },
-  {
-    "name": "Karachi, Pakistan",
-    "lat": 24.8607,
-    "lng": 67.0011
-  },
-  {
-    "name": "Lahore, Pakistan",
-    "lat": 31.5204,
-    "lng": 74.3587
-  },
-  {
-    "name": "Islamabad, Pakistan",
-    "lat": 33.6844,
-    "lng": 73.0479
-  },
-  {
-    "name": "Faisalabad, Pakistan",
-    "lat": 31.4504,
-    "lng": 73.135
-  },
-  {
-    "name": "Rawalpindi, Pakistan",
-    "lat": 33.5651,
-    "lng": 73.0169
-  },
-  {
-    "name": "Colombo, Sri Lanka",
-    "lat": 6.9271,
-    "lng": 79.8612
-  },
-  {
-    "name": "Kathmandu, Nepal",
-    "lat": 27.7172,
-    "lng": 85.324
-  },
-  {
-    "name": "Kabul, Afghanistan",
-    "lat": 34.5553,
-    "lng": 69.2075
-  },
-  {
-    "name": "Tashkent, Uzbekistan",
-    "lat": 41.2995,
-    "lng": 69.2401
-  },
-  {
-    "name": "Almaty, Kazakhstan",
-    "lat": 43.222,
-    "lng": 76.8512
-  },
-  {
-    "name": "Nur-Sultan, Kazakhstan",
-    "lat": 51.1801,
-    "lng": 71.446
-  },
-  {
-    "name": "Bishkek, Kyrgyzstan",
-    "lat": 42.8746,
-    "lng": 74.5698
-  },
-  {
-    "name": "Dushanbe, Tajikistan",
-    "lat": 38.5598,
-    "lng": 68.787
-  },
-  {
-    "name": "Ashgabat, Turkmenistan",
-    "lat": 37.9601,
-    "lng": 58.3261
-  },
-  {
-    "name": "Ulaanbaatar, Mongolia",
-    "lat": 47.8864,
-    "lng": 106.9057
-  },
-  {
-    "name": "Dubai, United Arab Emirates",
-    "lat": 25.2048,
-    "lng": 55.2708
-  },
-  {
-    "name": "Abu Dhabi, United Arab Emirates",
-    "lat": 24.4539,
-    "lng": 54.3773
-  },
-  {
-    "name": "Sharjah, United Arab Emirates",
-    "lat": 25.3462,
-    "lng": 55.4209
-  },
-  {
-    "name": "Riyadh, Saudi Arabia",
-    "lat": 24.7136,
-    "lng": 46.6753
-  },
-  {
-    "name": "Jeddah, Saudi Arabia",
-    "lat": 21.4858,
-    "lng": 39.1925
-  },
-  {
-    "name": "Mecca, Saudi Arabia",
-    "lat": 21.3891,
-    "lng": 39.8579
-  },
-  {
-    "name": "Medina, Saudi Arabia",
-    "lat": 24.5247,
-    "lng": 39.5692
-  },
-  {
-    "name": "Dammam, Saudi Arabia",
-    "lat": 26.4207,
-    "lng": 50.0888
-  },
-  {
-    "name": "Doha, Qatar",
-    "lat": 25.2854,
-    "lng": 51.531
-  },
-  {
-    "name": "Kuwait City, Kuwait",
-    "lat": 29.3759,
-    "lng": 47.9774
-  },
-  {
-    "name": "Manama, Bahrain",
-    "lat": 26.2285,
-    "lng": 50.586
-  },
-  {
-    "name": "Muscat, Oman",
-    "lat": 23.588,
-    "lng": 58.3829
-  },
-  {
-    "name": "Sanaa, Yemen",
-    "lat": 15.3694,
-    "lng": 44.191
-  },
-  {
-    "name": "Amman, Jordan",
-    "lat": 31.9454,
-    "lng": 35.9284
-  },
-  {
-    "name": "Beirut, Lebanon",
-    "lat": 33.8938,
-    "lng": 35.5018
-  },
-  {
-    "name": "Damascus, Syria",
-    "lat": 33.5138,
-    "lng": 36.2765
-  },
-  {
-    "name": "Baghdad, Iraq",
-    "lat": 33.3152,
-    "lng": 44.3661
-  },
-  {
-    "name": "Basra, Iraq",
-    "lat": 30.5085,
-    "lng": 47.7835
-  },
-  {
-    "name": "Tehran, Iran",
-    "lat": 35.6892,
-    "lng": 51.389
-  },
-  {
-    "name": "Isfahan, Iran",
-    "lat": 32.6546,
-    "lng": 51.668
-  },
-  {
-    "name": "Mashhad, Iran",
-    "lat": 36.2605,
-    "lng": 59.6168
-  },
-  {
-    "name": "Tabriz, Iran",
-    "lat": 38.0962,
-    "lng": 46.2738
-  },
-  {
-    "name": "Ankara, Turkey",
-    "lat": 39.9334,
-    "lng": 32.8597
-  },
-  {
-    "name": "Istanbul, Turkey",
-    "lat": 41.0082,
-    "lng": 28.9784
-  },
-  {
-    "name": "Izmir, Turkey",
-    "lat": 38.4192,
-    "lng": 27.1287
-  },
-  {
-    "name": "Bursa, Turkey",
-    "lat": 40.1885,
-    "lng": 29.061
-  },
-  {
-    "name": "Antalya, Turkey",
-    "lat": 36.8969,
-    "lng": 30.7133
-  },
-  {
-    "name": "Tel Aviv, Israel",
-    "lat": 32.0853,
-    "lng": 34.7818
-  },
-  {
-    "name": "Jerusalem, Israel",
-    "lat": 31.7683,
-    "lng": 35.2137
-  },
-  {
-    "name": "Haifa, Israel",
-    "lat": 32.794,
-    "lng": 34.9896
-  },
-  {
-    "name": "Tbilisi, Georgia",
-    "lat": 41.7151,
-    "lng": 44.8271
-  },
-  {
-    "name": "Baku, Azerbaijan",
-    "lat": 40.4093,
-    "lng": 49.8671
-  },
-  {
-    "name": "Yerevan, Armenia",
-    "lat": 40.1872,
-    "lng": 44.5152
-  },
-  {
-    "name": "Moscow, Russia",
-    "lat": 55.7558,
-    "lng": 37.6173
-  },
-  {
-    "name": "Saint Petersburg, Russia",
-    "lat": 59.9311,
-    "lng": 30.3609
-  },
-  {
-    "name": "Novosibirsk, Russia",
-    "lat": 54.9884,
-    "lng": 82.9357
-  },
-  {
-    "name": "Yekaterinburg, Russia",
-    "lat": 56.8389,
-    "lng": 60.6057
-  },
-  {
-    "name": "Kazan, Russia",
-    "lat": 55.8304,
-    "lng": 49.0661
-  },
-  {
-    "name": "Nizhny Novgorod, Russia",
-    "lat": 56.2965,
-    "lng": 43.9361
-  },
-  {
-    "name": "Vladivostok, Russia",
-    "lat": 43.1332,
-    "lng": 131.9113
-  },
-  {
-    "name": "São Paulo, Brazil",
-    "lat": -23.5505,
-    "lng": -46.6333
-  },
-  {
-    "name": "Rio de Janeiro, Brazil",
-    "lat": -22.9068,
-    "lng": -43.1729
-  },
-  {
-    "name": "Brasília, Brazil",
-    "lat": -15.7975,
-    "lng": -47.8919
-  },
-  {
-    "name": "Salvador, Brazil",
-    "lat": -12.9714,
-    "lng": -38.5014
-  },
-  {
-    "name": "Fortaleza, Brazil",
-    "lat": -3.7319,
-    "lng": -38.5267
-  },
-  {
-    "name": "Belo Horizonte, Brazil",
-    "lat": -19.9191,
-    "lng": -43.9386
-  },
-  {
-    "name": "Manaus, Brazil",
-    "lat": -3.119,
-    "lng": -60.0217
-  },
-  {
-    "name": "Curitiba, Brazil",
-    "lat": -25.4284,
-    "lng": -49.2733
-  },
-  {
-    "name": "Recife, Brazil",
-    "lat": -8.0476,
-    "lng": -34.877
-  },
-  {
-    "name": "Porto Alegre, Brazil",
-    "lat": -30.0346,
-    "lng": -51.2177
-  },
-  {
-    "name": "Belém, Brazil",
-    "lat": -1.4558,
-    "lng": -48.5044
-  },
-  {
-    "name": "Goiânia, Brazil",
-    "lat": -16.6869,
-    "lng": -49.2648
-  },
-  {
-    "name": "Florianópolis, Brazil",
-    "lat": -27.5954,
-    "lng": -48.548
-  },
-  {
-    "name": "Natal, Brazil",
-    "lat": -5.7945,
-    "lng": -35.211
-  },
-  {
-    "name": "Maceió, Brazil",
-    "lat": -9.6498,
-    "lng": -35.7089
-  },
-  {
-    "name": "Buenos Aires, Argentina",
-    "lat": -34.6037,
-    "lng": -58.3816
-  },
-  {
-    "name": "Córdoba, Argentina",
-    "lat": -31.4201,
-    "lng": -64.1888
-  },
-  {
-    "name": "Rosario, Argentina",
-    "lat": -32.9442,
-    "lng": -60.6505
-  },
-  {
-    "name": "Mendoza, Argentina",
-    "lat": -32.8908,
-    "lng": -68.8272
-  },
-  {
-    "name": "Tucumán, Argentina",
-    "lat": -26.8083,
-    "lng": -65.2176
-  },
-  {
-    "name": "Mar del Plata, Argentina",
-    "lat": -38.0023,
-    "lng": -57.5575
-  },
-  {
-    "name": "Salta, Argentina",
-    "lat": -24.7821,
-    "lng": -65.4232
-  },
-  {
-    "name": "Santiago, Chile",
-    "lat": -33.4489,
-    "lng": -70.6693
-  },
-  {
-    "name": "Valparaíso, Chile",
-    "lat": -33.0472,
-    "lng": -71.6127
-  },
-  {
-    "name": "Concepción, Chile",
-    "lat": -36.827,
-    "lng": -73.0503
-  },
-  {
-    "name": "Antofagasta, Chile",
-    "lat": -23.6509,
-    "lng": -70.3975
-  },
-  {
-    "name": "Bogotá, Colombia",
-    "lat": 4.711,
-    "lng": -74.0721
-  },
-  {
-    "name": "Medellín, Colombia",
-    "lat": 6.2476,
-    "lng": -75.5658
-  },
-  {
-    "name": "Cali, Colombia",
-    "lat": 3.4516,
-    "lng": -76.532
-  },
-  {
-    "name": "Barranquilla, Colombia",
-    "lat": 10.9685,
-    "lng": -74.7813
-  },
-  {
-    "name": "Cartagena, Colombia",
-    "lat": 10.391,
-    "lng": -75.4794
-  },
-  {
-    "name": "Lima, Peru",
-    "lat": -12.0464,
-    "lng": -77.0428
-  },
-  {
-    "name": "Arequipa, Peru",
-    "lat": -16.409,
-    "lng": -71.5375
-  },
-  {
-    "name": "Trujillo, Peru",
-    "lat": -8.109,
-    "lng": -79.0215
-  },
-  {
-    "name": "Cusco, Peru",
-    "lat": -13.532,
-    "lng": -71.9675
-  },
-  {
-    "name": "Caracas, Venezuela",
-    "lat": 10.4806,
-    "lng": -66.9036
-  },
-  {
-    "name": "Maracaibo, Venezuela",
-    "lat": 10.6319,
-    "lng": -71.6438
-  },
-  {
-    "name": "Valencia, Venezuela",
-    "lat": 10.162,
-    "lng": -67.9935
-  },
-  {
-    "name": "Quito, Ecuador",
-    "lat": -0.1807,
-    "lng": -78.4678
-  },
-  {
-    "name": "Guayaquil, Ecuador",
-    "lat": -2.1711,
-    "lng": -79.9224
-  },
-  {
-    "name": "La Paz, Bolivia",
-    "lat": -16.5,
-    "lng": -68.15
-  },
-  {
-    "name": "Santa Cruz, Bolivia",
-    "lat": -17.7833,
-    "lng": -63.1822
-  },
-  {
-    "name": "Asunción, Paraguay",
-    "lat": -25.2867,
-    "lng": -57.647
-  },
-  {
-    "name": "Montevideo, Uruguay",
-    "lat": -34.9011,
-    "lng": -56.1645
-  },
-  {
-    "name": "Georgetown, Guyana",
-    "lat": 6.8013,
-    "lng": -58.1553
-  },
-  {
-    "name": "Paramaribo, Suriname",
-    "lat": 5.852,
-    "lng": -55.2038
-  },
-  {
-    "name": "Cairo, Egypt",
-    "lat": 30.0444,
-    "lng": 31.2357
-  },
-  {
-    "name": "Alexandria, Egypt",
-    "lat": 31.2001,
-    "lng": 29.9187
-  },
-  {
-    "name": "Giza, Egypt",
-    "lat": 30.0131,
-    "lng": 31.2089
-  },
-  {
-    "name": "Casablanca, Morocco",
-    "lat": 33.5731,
-    "lng": -7.5898
-  },
-  {
-    "name": "Rabat, Morocco",
-    "lat": 34.0209,
-    "lng": -6.8416
-  },
-  {
-    "name": "Marrakech, Morocco",
-    "lat": 31.6295,
-    "lng": -7.9811
-  },
-  {
-    "name": "Fez, Morocco",
-    "lat": 34.0181,
-    "lng": -5.0078
-  },
-  {
-    "name": "Algiers, Algeria",
-    "lat": 36.7372,
-    "lng": 3.0863
-  },
-  {
-    "name": "Oran, Algeria",
-    "lat": 35.6969,
-    "lng": -0.6331
-  },
-  {
-    "name": "Tunis, Tunisia",
-    "lat": 36.8188,
-    "lng": 10.1658
-  },
-  {
-    "name": "Tripoli, Libya",
-    "lat": 32.9,
-    "lng": 13.18
-  },
-  {
-    "name": "Khartoum, Sudan",
-    "lat": 15.5007,
-    "lng": 32.5599
-  },
-  {
-    "name": "Addis Ababa, Ethiopia",
-    "lat": 9.032,
-    "lng": 38.7469
-  },
-  {
-    "name": "Nairobi, Kenya",
-    "lat": -1.2921,
-    "lng": 36.8219
-  },
-  {
-    "name": "Mombasa, Kenya",
-    "lat": -4.0435,
-    "lng": 39.6682
-  },
-  {
-    "name": "Dar es Salaam, Tanzania",
-    "lat": -6.7924,
-    "lng": 39.2083
-  },
-  {
-    "name": "Kampala, Uganda",
-    "lat": 0.3476,
-    "lng": 32.5825
-  },
-  {
-    "name": "Kigali, Rwanda",
-    "lat": -1.9441,
-    "lng": 30.0619
-  },
-  {
-    "name": "Lusaka, Zambia",
-    "lat": -15.3875,
-    "lng": 28.3228
-  },
-  {
-    "name": "Harare, Zimbabwe",
-    "lat": -17.8252,
-    "lng": 31.0335
-  },
-  {
-    "name": "Maputo, Mozambique",
-    "lat": -25.9655,
-    "lng": 32.5832
-  },
-  {
-    "name": "Antananarivo, Madagascar",
-    "lat": -18.9137,
-    "lng": 47.5361
-  },
-  {
-    "name": "Johannesburg, South Africa",
-    "lat": -26.2041,
-    "lng": 28.0473
-  },
-  {
-    "name": "Cape Town, South Africa",
-    "lat": -33.9249,
-    "lng": 18.4241
-  },
-  {
-    "name": "Durban, South Africa",
-    "lat": -29.8587,
-    "lng": 31.0218
-  },
-  {
-    "name": "Pretoria, South Africa",
-    "lat": -25.7479,
-    "lng": 28.2293
-  },
-  {
-    "name": "Port Elizabeth, South Africa",
-    "lat": -33.9608,
-    "lng": 25.6022
-  },
-  {
-    "name": "Bloemfontein, South Africa",
-    "lat": -29.121,
-    "lng": 26.2041
-  },
-  {
-    "name": "Lagos, Nigeria",
-    "lat": 6.5244,
-    "lng": 3.3792
-  },
-  {
-    "name": "Kano, Nigeria",
-    "lat": 12.0022,
-    "lng": 8.592
-  },
-  {
-    "name": "Ibadan, Nigeria",
-    "lat": 7.3775,
-    "lng": 3.947
-  },
-  {
-    "name": "Abuja, Nigeria",
-    "lat": 9.0579,
-    "lng": 7.4951
-  },
-  {
-    "name": "Port Harcourt, Nigeria",
-    "lat": 4.8156,
-    "lng": 7.0498
-  },
-  {
-    "name": "Accra, Ghana",
-    "lat": 5.6037,
-    "lng": -0.187
-  },
-  {
-    "name": "Kumasi, Ghana",
-    "lat": 6.6885,
-    "lng": -1.6244
-  },
-  {
-    "name": "Dakar, Senegal",
-    "lat": 14.7167,
-    "lng": -17.4677
-  },
-  {
-    "name": "Abidjan, Côte d'Ivoire",
-    "lat": 5.36,
-    "lng": -4.0083
-  },
-  {
-    "name": "Conakry, Guinea",
-    "lat": 9.537,
-    "lng": -13.6773
-  },
-  {
-    "name": "Freetown, Sierra Leone",
-    "lat": 8.4657,
-    "lng": -13.2317
-  },
-  {
-    "name": "Monrovia, Liberia",
-    "lat": 6.2907,
-    "lng": -10.7605
-  },
-  {
-    "name": "Bamako, Mali",
-    "lat": 12.6392,
-    "lng": -8.0029
-  },
-  {
-    "name": "Ouagadougou, Burkina Faso",
-    "lat": 12.3569,
-    "lng": -1.5353
-  },
-  {
-    "name": "Niamey, Niger",
-    "lat": 13.5137,
-    "lng": 2.1098
-  },
-  {
-    "name": "N'Djamena, Chad",
-    "lat": 12.1348,
-    "lng": 15.0557
-  },
-  {
-    "name": "Douala, Cameroon",
-    "lat": 4.0511,
-    "lng": 9.7679
-  },
-  {
-    "name": "Yaoundé, Cameroon",
-    "lat": 3.848,
-    "lng": 11.5021
-  },
-  {
-    "name": "Kinshasa, Democratic Republic of the Congo",
-    "lat": -4.3217,
-    "lng": 15.3222
-  },
-  {
-    "name": "Lubumbashi, Democratic Republic of the Congo",
-    "lat": -11.6609,
-    "lng": 27.4794
-  },
-  {
-    "name": "Luanda, Angola",
-    "lat": -8.8368,
-    "lng": 13.2343
-  },
-  {
-    "name": "Brazzaville, Republic of the Congo",
-    "lat": -4.2661,
-    "lng": 15.2832
-  },
-  {
-    "name": "Libreville, Gabon",
-    "lat": 0.3901,
-    "lng": 9.4544
-  },
-  {
-    "name": "Malabo, Equatorial Guinea",
-    "lat": 3.7523,
-    "lng": 8.7742
-  },
-  {
-    "name": "Bangui, Central African Republic",
-    "lat": 4.3612,
-    "lng": 18.555
-  },
-  {
-    "name": "Lomé, Togo",
-    "lat": 6.1375,
-    "lng": 1.2123
-  },
-  {
-    "name": "Cotonou, Benin",
-    "lat": 6.3703,
-    "lng": 2.3912
-  },
-  {
-    "name": "Banjul, Gambia",
-    "lat": 13.4549,
-    "lng": -16.579
-  },
-  {
-    "name": "Bissau, Guinea-Bissau",
-    "lat": 11.8636,
-    "lng": -15.5977
-  },
-  {
-    "name": "Praia, Cape Verde",
-    "lat": 14.933,
-    "lng": -23.5133
-  },
-  {
-    "name": "Djibouti City, Djibouti",
-    "lat": 11.572,
-    "lng": 43.1456
-  },
-  {
-    "name": "Asmara, Eritrea",
-    "lat": 15.3389,
-    "lng": 38.9318
-  },
-  {
-    "name": "Mogadishu, Somalia",
-    "lat": 2.0469,
-    "lng": 45.3182
-  },
-  {
-    "name": "Lilongwe, Malawi",
-    "lat": -13.9626,
-    "lng": 33.7741
-  },
-  {
-    "name": "Gaborone, Botswana",
-    "lat": -24.6282,
-    "lng": 25.9231
-  },
-  {
-    "name": "Windhoek, Namibia",
-    "lat": -22.5609,
-    "lng": 17.0658
-  },
-  {
-    "name": "Maseru, Lesotho",
-    "lat": -29.3167,
-    "lng": 27.4833
-  },
-  {
-    "name": "Mbabane, Eswatini",
-    "lat": -26.3054,
-    "lng": 31.1367
-  },
-  {
-    "name": "Moroni, Comoros",
-    "lat": -11.7022,
-    "lng": 43.2551
-  },
-  {
-    "name": "Sydney, Australia",
-    "lat": -33.8688,
-    "lng": 151.2093
-  },
-  {
-    "name": "Melbourne, Australia",
-    "lat": -37.8136,
-    "lng": 144.9631
-  },
-  {
-    "name": "Brisbane, Australia",
-    "lat": -27.4698,
-    "lng": 153.0251
-  },
-  {
-    "name": "Perth, Australia",
-    "lat": -31.9505,
-    "lng": 115.8605
-  },
-  {
-    "name": "Adelaide, Australia",
-    "lat": -34.9285,
-    "lng": 138.6007
-  },
-  {
-    "name": "Canberra, Australia",
-    "lat": -35.2809,
-    "lng": 149.13
-  },
-  {
-    "name": "Gold Coast, Australia",
-    "lat": -28.0167,
-    "lng": 153.4
-  },
-  {
-    "name": "Newcastle, Australia",
-    "lat": -32.9267,
-    "lng": 151.7789
-  },
-  {
-    "name": "Hobart, Australia",
-    "lat": -42.8826,
-    "lng": 147.3257
-  },
-  {
-    "name": "Darwin, Australia",
-    "lat": -12.4634,
-    "lng": 130.8456
-  },
-  {
-    "name": "Cairns, Australia",
-    "lat": -16.9186,
-    "lng": 145.7781
-  },
-  {
-    "name": "Townsville, Australia",
-    "lat": -19.259,
-    "lng": 146.8169
-  },
-  {
-    "name": "Wollongong, Australia",
-    "lat": -34.4278,
-    "lng": 150.8931
-  },
-  {
-    "name": "Auckland, New Zealand",
-    "lat": -36.8485,
-    "lng": 174.7633
-  },
-  {
-    "name": "Wellington, New Zealand",
-    "lat": -41.2865,
-    "lng": 174.7762
-  },
-  {
-    "name": "Christchurch, New Zealand",
-    "lat": -43.5321,
-    "lng": 172.6362
-  },
-  {
-    "name": "Hamilton, New Zealand",
-    "lat": -37.787,
-    "lng": 175.2793
-  },
-  {
-    "name": "Dunedin, New Zealand",
-    "lat": -45.8788,
-    "lng": 170.5028
-  },
-  {
-    "name": "Tauranga, New Zealand",
-    "lat": -37.6878,
-    "lng": 176.1651
-  },
-  {
-    "name": "Port Moresby, Papua New Guinea",
-    "lat": -9.4438,
-    "lng": 147.1803
-  },
-  {
-    "name": "Suva, Fiji",
-    "lat": -18.1416,
-    "lng": 178.4415
-  },
-  {
-    "name": "Honiara, Solomon Islands",
-    "lat": -9.4333,
-    "lng": 160.05
-  },
-  {
-    "name": "Port Vila, Vanuatu",
-    "lat": -17.7333,
-    "lng": 168.3167
-  },
-  {
-    "name": "Noumea, New Caledonia",
-    "lat": -22.2758,
-    "lng": 166.4581
-  },
-  {
-    "name": "Papeete, French Polynesia",
-    "lat": -17.5334,
-    "lng": -149.5667
-  },
-  {
-    "name": "Apia, Samoa",
-    "lat": -13.8314,
-    "lng": -171.872
-  },
-  {
-    "name": "Nuku'alofa, Tonga",
-    "lat": -21.1393,
-    "lng": -175.2049
-  },
-  {
-    "name": "Tarawa, Kiribati",
-    "lat": 1.3282,
-    "lng": 172.9784
-  },
-  {
-    "name": "Funafuti, Tuvalu",
-    "lat": -8.5243,
-    "lng": 179.1942
-  },
-  {
-    "name": "Guatemala City, Guatemala",
-    "lat": 14.6349,
-    "lng": -90.5069
-  },
-  {
-    "name": "San Salvador, El Salvador",
-    "lat": 13.6929,
-    "lng": -89.2182
-  },
-  {
-    "name": "Tegucigalpa, Honduras",
-    "lat": 14.0723,
-    "lng": -87.2062
-  },
-  {
-    "name": "Managua, Nicaragua",
-    "lat": 12.1328,
-    "lng": -86.2504
-  },
-  {
-    "name": "San José, Costa Rica",
-    "lat": 9.9281,
-    "lng": -84.0907
-  },
-  {
-    "name": "Panama City, Panama",
-    "lat": 8.9936,
-    "lng": -79.5197
-  },
-  {
-    "name": "Belmopan, Belize",
-    "lat": 17.2514,
-    "lng": -88.759
-  },
-  {
-    "name": "Havana, Cuba",
-    "lat": 23.1136,
-    "lng": -82.3666
-  },
-  {
-    "name": "Santiago de Cuba, Cuba",
-    "lat": 20.0236,
-    "lng": -75.822
-  },
-  {
-    "name": "Santo Domingo, Dominican Republic",
-    "lat": 18.4861,
-    "lng": -69.9312
-  },
-  {
-    "name": "Port-au-Prince, Haiti",
-    "lat": 18.5944,
-    "lng": -72.3074
-  },
-  {
-    "name": "San Juan, Puerto Rico",
-    "lat": 18.4655,
-    "lng": -66.1057
-  },
-  {
-    "name": "Kingston, Jamaica",
-    "lat": 17.997,
-    "lng": -76.7936
-  },
-  {
-    "name": "Port of Spain, Trinidad and Tobago",
-    "lat": 10.6549,
-    "lng": -61.5019
-  },
-  {
-    "name": "Bridgetown, Barbados",
-    "lat": 13.1132,
-    "lng": -59.5988
-  },
-  {
-    "name": "Nassau, Bahamas",
-    "lat": 25.048,
-    "lng": -77.3554
-  },
-  {
-    "name": "Willemstad, Curaçao",
-    "lat": 12.1224,
-    "lng": -68.8824
-  },
-  {
-    "name": "Oranjestad, Aruba",
-    "lat": 12.5246,
-    "lng": -70.0265
-  },
-  {
-    "name": "Castries, Saint Lucia",
-    "lat": 14.0101,
-    "lng": -60.9875
-  },
-  {
-    "name": "Kingstown, Saint Vincent and the Grenadines",
-    "lat": 13.16,
-    "lng": -61.2248
-  },
-  {
-    "name": "Saint George's, Grenada",
-    "lat": 12.0561,
-    "lng": -61.7488
-  },
-  {
-    "name": "Roseau, Dominica",
-    "lat": 15.3017,
-    "lng": -61.3881
-  },
-  {
-    "name": "Basseterre, Saint Kitts and Nevis",
-    "lat": 17.3026,
-    "lng": -62.7177
-  },
-  {
-    "name": "St. John's, Antigua and Barbuda",
-    "lat": 17.1274,
-    "lng": -61.8468
-  },
-  {
-    "name": "Road Town, British Virgin Islands",
-    "lat": 18.4207,
-    "lng": -64.64
-  },
-  {
-    "name": "Philipsburg, Sint Maarten",
-    "lat": 18.0255,
-    "lng": -63.0526
-  },
-  {
-    "name": "Nuuk, Greenland",
-    "lat": 64.1836,
-    "lng": -51.7214
-  },
-  {
-    "name": "Longyearbyen, Norway",
-    "lat": 78.2232,
-    "lng": 15.6267
-  },
-  {
-    "name": "Valletta, Malta",
-    "lat": 35.8997,
-    "lng": 14.5146
-  },
-  {
-    "name": "Nicosia, Cyprus",
-    "lat": 35.1856,
-    "lng": 33.3823
-  },
-  {
-    "name": "Podgorica, Montenegro",
-    "lat": 42.4304,
-    "lng": 19.2594
-  },
-  {
-    "name": "Pristina, Kosovo",
-    "lat": 42.6629,
-    "lng": 21.1655
-  },
-  {
-    "name": "Andorra la Vella, Andorra",
-    "lat": 42.5063,
-    "lng": 1.5218
-  },
-  {
-    "name": "Monaco, Monaco",
-    "lat": 43.7384,
-    "lng": 7.4246
-  },
-  {
-    "name": "San Marino, San Marino",
-    "lat": 43.9424,
-    "lng": 12.4578
-  },
-  {
-    "name": "Vaduz, Liechtenstein",
-    "lat": 47.141,
-    "lng": 9.5215
-  },
-  {
-    "name": "Saint-Denis, Réunion",
-    "lat": -20.8789,
-    "lng": 55.4481
-  },
-  {
-    "name": "Fort-de-France, Martinique",
-    "lat": 14.6037,
-    "lng": -61.0736
-  },
-  {
-    "name": "Pointe-à-Pitre, Guadeloupe",
-    "lat": 16.2418,
-    "lng": -61.5336
-  },
-  {
-    "name": "Cayenne, French Guiana",
-    "lat": 4.9224,
-    "lng": -52.3135
-  },
-  {
-    "name": "Macau, China",
-    "lat": 22.1987,
-    "lng": 113.5439
-  },
-  {
-    "name": "Malé, Maldives",
-    "lat": 4.1755,
-    "lng": 73.5093
-  },
-  {
-    "name": "Thimphu, Bhutan",
-    "lat": 27.4728,
-    "lng": 89.639
-  },
-  {
-    "name": "Nay Pyi Taw, Myanmar",
-    "lat": 19.7633,
-    "lng": 96.0785
-  },
-  {
-    "name": "Bandar Seri Begawan, Brunei",
-    "lat": 4.9031,
-    "lng": 114.9398
-  },
-  {
-    "name": "Dili, East Timor",
-    "lat": -8.5568,
-    "lng": 125.5786
-  },
-  {
-    "name": "Naypyidaw, Myanmar",
-    "lat": 19.7633,
-    "lng": 96.0785
-  },
-  {
-    "name": "Kandy, Sri Lanka",
-    "lat": 7.2906,
-    "lng": 80.6337
-  },
-  {
-    "name": "Jaffna, Sri Lanka",
-    "lat": 9.6615,
-    "lng": 80.0255
-  },
-  {
-    "name": "Peshawar, Pakistan",
-    "lat": 34.0151,
-    "lng": 71.5249
-  },
-  {
-    "name": "Quetta, Pakistan",
-    "lat": 30.1798,
-    "lng": 66.975
-  },
-  {
-    "name": "Multan, Pakistan",
-    "lat": 30.1575,
-    "lng": 71.5249
-  },
-  {
-    "name": "Hyderabad, Pakistan",
-    "lat": 25.396,
-    "lng": 68.3578
-  },
-  {
-    "name": "Varanasi, India",
-    "lat": 25.3176,
-    "lng": 82.9739
-  },
-  {
-    "name": "Agra, India",
-    "lat": 27.1767,
-    "lng": 78.0081
-  },
-  {
-    "name": "Indore, India",
-    "lat": 22.7196,
-    "lng": 75.8577
-  },
-  {
-    "name": "Patna, India",
-    "lat": 25.5941,
-    "lng": 85.1376
-  },
-  {
-    "name": "Kochi, India",
-    "lat": 9.9312,
-    "lng": 76.2673
-  },
-  {
-    "name": "Coimbatore, India",
-    "lat": 11.0168,
-    "lng": 76.9558
-  },
-  {
-    "name": "Guwahati, India",
-    "lat": 26.1445,
-    "lng": 91.7362
-  },
-  {
-    "name": "Bhubaneswar, India",
-    "lat": 20.2961,
-    "lng": 85.8245
-  },
-  {
-    "name": "Thiruvananthapuram, India",
-    "lat": 8.5241,
-    "lng": 76.9366
-  },
-  {
-    "name": "Amritsar, India",
-    "lat": 31.634,
-    "lng": 74.8723
-  },
-  {
-    "name": "Chandigarh, India",
-    "lat": 30.7333,
-    "lng": 76.7794
-  },
-  {
-    "name": "Goa, India",
-    "lat": 15.2993,
-    "lng": 74.124
-  },
-  {
-    "name": "Nanning, China",
-    "lat": 22.817,
-    "lng": 108.3665
-  },
-  {
-    "name": "Guiyang, China",
-    "lat": 26.5783,
-    "lng": 106.7275
-  },
-  {
-    "name": "Lanzhou, China",
-    "lat": 36.0611,
-    "lng": 103.8343
-  },
-  {
-    "name": "Taiyuan, China",
-    "lat": 37.8706,
-    "lng": 112.5489
-  },
-  {
-    "name": "Shijiazhuang, China",
-    "lat": 38.0428,
-    "lng": 114.5149
-  },
-  {
-    "name": "Hefei, China",
-    "lat": 31.8639,
-    "lng": 117.2808
-  },
-  {
-    "name": "Changchun, China",
-    "lat": 43.8171,
-    "lng": 125.3235
-  },
-  {
-    "name": "Jinan, China",
-    "lat": 36.6512,
-    "lng": 117.1201
-  },
-  {
-    "name": "Fuzhou, China",
-    "lat": 26.0745,
-    "lng": 119.2965
-  },
-  {
-    "name": "Wenzhou, China",
-    "lat": 27.9938,
-    "lng": 120.6997
-  },
-  {
-    "name": "Changsha, China",
-    "lat": 28.2282,
-    "lng": 112.9388
-  },
-  {
-    "name": "Wuxi, China",
-    "lat": 31.4912,
-    "lng": 120.3119
-  },
-  {
-    "name": "Suzhou, China",
-    "lat": 31.299,
-    "lng": 120.5853
-  },
-  {
-    "name": "Nanchang, China",
-    "lat": 28.682,
-    "lng": 115.8581
-  },
-  {
-    "name": "Zibo, China",
-    "lat": 36.804,
-    "lng": 118.055
-  },
-  {
-    "name": "Tangshan, China",
-    "lat": 39.6243,
-    "lng": 118.1943
-  },
-  {
-    "name": "Baotou, China",
-    "lat": 40.6553,
-    "lng": 109.84
-  },
-  {
-    "name": "Medellin, Colombia",
-    "lat": 6.2476,
-    "lng": -75.5658
-  },
-  {
-    "name": "Bucaramanga, Colombia",
-    "lat": 7.1253,
-    "lng": -73.1198
-  },
-  {
-    "name": "Pereira, Colombia",
-    "lat": 4.8087,
-    "lng": -75.6906
-  },
-  {
-    "name": "Manizales, Colombia",
-    "lat": 5.0703,
-    "lng": -75.5138
-  },
-  {
-    "name": "Cochabamba, Bolivia",
-    "lat": -17.3895,
-    "lng": -66.1568
-  },
-  {
-    "name": "Sucre, Bolivia",
-    "lat": -19.0196,
-    "lng": -65.2619
-  },
-  {
-    "name": "Cuenca, Ecuador",
-    "lat": -2.9001,
-    "lng": -79.0059
-  },
-  {
-    "name": "Loja, Ecuador",
-    "lat": -3.9931,
-    "lng": -79.2042
-  },
-  {
-    "name": "Callao, Peru",
-    "lat": -12.056,
-    "lng": -77.1183
-  },
-  {
-    "name": "Piura, Peru",
-    "lat": -5.1945,
-    "lng": -80.6328
-  },
-  {
-    "name": "Iquitos, Peru",
-    "lat": -3.7437,
-    "lng": -73.2516
-  },
-  {
-    "name": "Concepción, Paraguay",
-    "lat": -23.409,
-    "lng": -57.428
-  },
-  {
-    "name": "Ciudad del Este, Paraguay",
-    "lat": -25.5096,
-    "lng": -54.611
-  },
-  {
-    "name": "Salto, Uruguay",
-    "lat": -31.3833,
-    "lng": -57.9667
-  },
-  {
-    "name": "Paysandú, Uruguay",
-    "lat": -32.3167,
-    "lng": -58.0833
-  },
-  {
-    "name": "Maracay, Venezuela",
-    "lat": 10.2469,
-    "lng": -67.5958
-  },
-  {
-    "name": "Barquisimeto, Venezuela",
-    "lat": 10.0647,
-    "lng": -69.357
-  },
-  {
-    "name": "Sorocaba, Brazil",
-    "lat": -23.5015,
-    "lng": -47.4526
-  },
-  {
-    "name": "Campinas, Brazil",
-    "lat": -22.9056,
-    "lng": -47.0608
-  },
-  {
-    "name": "São Luís, Brazil",
-    "lat": -2.5307,
-    "lng": -44.3068
-  },
-  {
-    "name": "Teresina, Brazil",
-    "lat": -5.0892,
-    "lng": -42.8019
-  },
-  {
-    "name": "Campo Grande, Brazil",
-    "lat": -20.4697,
-    "lng": -54.6201
-  },
-  {
-    "name": "João Pessoa, Brazil",
-    "lat": -7.1195,
-    "lng": -34.845
-  },
-  {
-    "name": "Aracaju, Brazil",
-    "lat": -10.9167,
-    "lng": -37.05
-  },
-  {
-    "name": "Macapá, Brazil",
-    "lat": 0.0356,
-    "lng": -51.0705
-  },
-  {
-    "name": "Porto Velho, Brazil",
-    "lat": -8.7612,
-    "lng": -63.9004
-  },
-  {
-    "name": "Cuiabá, Brazil",
-    "lat": -15.6014,
-    "lng": -56.0979
-  },
-  {
-    "name": "Kaduna, Nigeria",
-    "lat": 10.5222,
-    "lng": 7.4383
-  },
-  {
-    "name": "Benin City, Nigeria",
-    "lat": 6.335,
-    "lng": 5.6037
-  },
-  {
-    "name": "Enugu, Nigeria",
-    "lat": 6.4584,
-    "lng": 7.5464
-  },
-  {
-    "name": "Onitsha, Nigeria",
-    "lat": 6.1667,
-    "lng": 6.7833
-  },
-  {
-    "name": "Kisumu, Kenya",
-    "lat": -0.1022,
-    "lng": 34.7617
-  },
-  {
-    "name": "Nakuru, Kenya",
-    "lat": -0.3031,
-    "lng": 36.08
-  },
-  {
-    "name": "Mwanza, Tanzania",
-    "lat": -2.5167,
-    "lng": 32.9
-  },
-  {
-    "name": "Zanzibar City, Tanzania",
-    "lat": -6.1659,
-    "lng": 39.1989
-  },
-  {
-    "name": "Gulu, Uganda",
-    "lat": 2.7748,
-    "lng": 32.3049
-  },
-  {
-    "name": "Bujumbura, Burundi",
-    "lat": -3.3822,
-    "lng": 29.3644
-  },
-  {
-    "name": "Blantyre, Malawi",
-    "lat": -15.7861,
-    "lng": 35.0058
-  },
-  {
-    "name": "Ndola, Zambia",
-    "lat": -12.9587,
-    "lng": 28.6366
-  },
-  {
-    "name": "Bulawayo, Zimbabwe",
-    "lat": -20.15,
-    "lng": 28.5833
-  },
-  {
-    "name": "Beira, Mozambique",
-    "lat": -19.8437,
-    "lng": 34.8389
-  },
-  {
-    "name": "Toamasina, Madagascar",
-    "lat": -18.15,
-    "lng": 49.4
-  },
-  {
-    "name": "Huambo, Angola",
-    "lat": -12.7756,
-    "lng": 15.7394
-  },
-  {
-    "name": "Thiès, Senegal",
-    "lat": 14.7833,
-    "lng": -16.9167
-  },
-  {
-    "name": "Bouaké, Côte d'Ivoire",
-    "lat": 7.6833,
-    "lng": -5.0333
-  },
-  {
-    "name": "Tamale, Ghana",
-    "lat": 9.4008,
-    "lng": -0.8393
-  },
-  {
-    "name": "Mekelle, Ethiopia",
-    "lat": 13.4969,
-    "lng": 39.4769
-  },
-  {
-    "name": "Dire Dawa, Ethiopia",
-    "lat": 9.5931,
-    "lng": 41.8661
-  },
-  {
-    "name": "Omdurman, Sudan",
-    "lat": 15.65,
-    "lng": 32.4833
-  },
-  {
-    "name": "Port Sudan, Sudan",
-    "lat": 19.6158,
-    "lng": 37.2164
-  },
-  {
-    "name": "Hargeisa, Somalia",
-    "lat": 9.55,
-    "lng": 44.05
-  },
-  {
-    "name": "Juba, South Sudan",
-    "lat": 4.8594,
-    "lng": 31.5713
-  },
-  {
-    "name": "Wau, South Sudan",
-    "lat": 7.7,
-    "lng": 28.0
-  },
-  {
-    "name": "Walvis Bay, Namibia",
-    "lat": -22.9575,
-    "lng": 14.5053
-  },
-  {
-    "name": "Luxor, Egypt",
-    "lat": 25.6872,
-    "lng": 32.6396
-  },
-  {
-    "name": "Aswan, Egypt",
-    "lat": 24.0889,
-    "lng": 32.8998
-  },
-  {
-    "name": "Tangier, Morocco",
-    "lat": 35.7595,
-    "lng": -5.834
-  },
-  {
-    "name": "Annaba, Algeria",
-    "lat": 36.9,
-    "lng": 7.7667
-  },
-  {
-    "name": "Sfax, Tunisia",
-    "lat": 34.74,
-    "lng": 10.76
-  },
-  {
-    "name": "Benghazi, Libya",
-    "lat": 32.1194,
-    "lng": 20.0867
-  },
-  {
-    "name": "Nouakchott, Mauritania",
-    "lat": 18.0735,
-    "lng": -15.9582
-  },
-  {
-    "name": "Timbuktu, Mali",
-    "lat": 16.7667,
-    "lng": -3.0026
-  },
-  {
-    "name": "Ndjamena, Chad",
-    "lat": 12.1348,
-    "lng": 15.0557
-  },
-  {
-    "name": "Kinshasa, DR Congo",
-    "lat": -4.3217,
-    "lng": 15.3222
-  },
-  {
-    "name": "Goma, DR Congo",
-    "lat": -1.6792,
-    "lng": 29.2228
-  },
-  {
-    "name": "Kisangani, DR Congo",
-    "lat": 0.5153,
-    "lng": 25.19
-  },
-  {
-    "name": "Pointe-Noire, Republic of the Congo",
-    "lat": -4.7692,
-    "lng": 11.866
-  },
-  {
-    "name": "São Tomé, São Tomé and Príncipe",
-    "lat": 0.3365,
-    "lng": 6.7273
-  },
-  {
-    "name": "Victoria, Seychelles",
-    "lat": -4.6191,
-    "lng": 55.4513
-  },
-  {
-    "name": "Port Louis, Mauritius",
-    "lat": -20.1609,
-    "lng": 57.4977
-  },
-  {
-    "name": "Yokohama, Japan",
-    "lat": 35.4437,
-    "lng": 139.638
-  },
-  {
-    "name": "Kawasaki, Japan",
-    "lat": 35.5308,
-    "lng": 139.703
-  },
-  {
-    "name": "Kitakyushu, Japan",
-    "lat": 33.8833,
-    "lng": 130.875
-  },
-  {
-    "name": "Chiba, Japan",
-    "lat": 35.605,
-    "lng": 140.1233
-  },
-  {
-    "name": "Sakai, Japan",
-    "lat": 34.5733,
-    "lng": 135.483
-  },
-  {
-    "name": "Niigata, Japan",
-    "lat": 37.9161,
-    "lng": 139.0364
-  },
-  {
-    "name": "Hamamatsu, Japan",
-    "lat": 34.7108,
-    "lng": 137.7261
-  },
-  {
-    "name": "Pyongyang, North Korea",
-    "lat": 39.0194,
-    "lng": 125.7381
-  },
-  {
-    "name": "Lhasa, China",
-    "lat": 29.65,
-    "lng": 91.1
-  },
-  {
-    "name": "Hohhot, China",
-    "lat": 40.842,
-    "lng": 111.749
-  },
-  {
-    "name": "Yinchuan, China",
-    "lat": 38.4872,
-    "lng": 106.2309
-  },
-  {
-    "name": "Xining, China",
-    "lat": 36.6171,
-    "lng": 101.7782
-  },
-  {
-    "name": "Haikou, China",
-    "lat": 20.044,
-    "lng": 110.3416
-  },
-  {
-    "name": "Sanya, China",
-    "lat": 18.2479,
-    "lng": 109.5146
-  },
-  {
-    "name": "Mazar-i-Sharif, Afghanistan",
-    "lat": 36.7069,
-    "lng": 67.1107
-  },
-  {
-    "name": "Samarkand, Uzbekistan",
-    "lat": 39.655,
-    "lng": 66.9597
-  },
-  {
-    "name": "Osh, Kyrgyzstan",
-    "lat": 40.5283,
-    "lng": 72.7985
-  },
-  {
-    "name": "Mary, Turkmenistan",
-    "lat": 37.5931,
-    "lng": 61.83
-  },
-  {
-    "name": "Kutaisi, Georgia",
-    "lat": 42.2679,
-    "lng": 42.6961
-  },
-  {
-    "name": "Ganja, Azerbaijan",
-    "lat": 40.6828,
-    "lng": 46.3606
-  },
-  {
-    "name": "Gyumri, Armenia",
-    "lat": 40.7942,
-    "lng": 43.8453
-  },
-  {
-    "name": "Chelyabinsk, Russia",
-    "lat": 55.154,
-    "lng": 61.4291
-  },
-  {
-    "name": "Omsk, Russia",
-    "lat": 54.9885,
-    "lng": 73.3242
-  },
-  {
-    "name": "Samara, Russia",
-    "lat": 53.2001,
-    "lng": 50.15
-  },
-  {
-    "name": "Ufa, Russia",
-    "lat": 54.7388,
-    "lng": 55.9721
-  },
-  {
-    "name": "Rostov-on-Don, Russia",
-    "lat": 47.2357,
-    "lng": 39.7015
-  },
-  {
-    "name": "Volgograd, Russia",
-    "lat": 48.708,
-    "lng": 44.5133
-  },
-  {
-    "name": "Perm, Russia",
-    "lat": 58.0105,
-    "lng": 56.2502
-  },
-  {
-    "name": "Krasnoyarsk, Russia",
-    "lat": 56.0184,
-    "lng": 92.8672
-  },
-  {
-    "name": "Voronezh, Russia",
-    "lat": 51.672,
-    "lng": 39.1843
-  },
-  {
-    "name": "Saratov, Russia",
-    "lat": 51.5339,
-    "lng": 46.0342
-  },
-  {
-    "name": "Irkutsk, Russia",
-    "lat": 52.2978,
-    "lng": 104.2964
-  },
-  {
-    "name": "Khabarovsk, Russia",
-    "lat": 48.4827,
-    "lng": 135.084
-  },
-  {
-    "name": "Makhachkala, Russia",
-    "lat": 42.9849,
-    "lng": 47.5047
-  },
-  {
-    "name": "Tolyatti, Russia",
-    "lat": 53.5303,
-    "lng": 49.3461
-  },
-  {
-    "name": "Izhevsk, Russia",
-    "lat": 56.8526,
-    "lng": 53.2115
-  },
-  {
-    "name": "Barnaul, Russia",
-    "lat": 53.3606,
-    "lng": 83.7636
-  },
-  {
-    "name": "Ulyanovsk, Russia",
-    "lat": 54.3282,
-    "lng": 48.3866
-  },
-  {
-    "name": "Yaroslavl, Russia",
-    "lat": 57.6261,
-    "lng": 39.8845
-  },
-  {
-    "name": "Tyumen, Russia",
-    "lat": 57.1522,
-    "lng": 68.0
-  },
-  {
-    "name": "Kemerovo, Russia",
-    "lat": 55.3908,
-    "lng": 86.0847
-  },
-  {
-    "name": "Murmansk, Russia",
-    "lat": 68.9585,
-    "lng": 33.0827
-  },
-  {
-    "name": "Tomsk, Russia",
-    "lat": 56.4977,
-    "lng": 84.9744
-  },
-  {
-    "name": "Oral, Kazakhstan",
-    "lat": 51.2333,
-    "lng": 51.3667
-  },
-  {
-    "name": "Shymkent, Kazakhstan",
-    "lat": 42.3,
-    "lng": 69.6
-  },
-  {
-    "name": "Aktobe, Kazakhstan",
-    "lat": 50.2839,
-    "lng": 57.1669
-  },
-  {
-    "name": "Karaganda, Kazakhstan",
-    "lat": 49.8047,
-    "lng": 73.0878
-  },
-  {
-    "name": "Gomel, Belarus",
-    "lat": 52.4413,
-    "lng": 31.0139
-  },
-  {
-    "name": "Vitebsk, Belarus",
-    "lat": 55.1904,
-    "lng": 30.2049
-  },
-  {
-    "name": "Grodno, Belarus",
-    "lat": 53.6884,
-    "lng": 23.8258
-  },
-  {
-    "name": "Kraków, Poland",
-    "lat": 50.0647,
-    "lng": 19.945
-  },
-  {
-    "name": "Poznań, Poland",
-    "lat": 52.4064,
-    "lng": 16.9252
-  },
-  {
-    "name": "Gdańsk, Poland",
-    "lat": 54.3521,
-    "lng": 18.6466
-  },
-  {
-    "name": "Szczecin, Poland",
-    "lat": 53.4285,
-    "lng": 14.5528
-  },
-  {
-    "name": "Bydgoszcz, Poland",
-    "lat": 53.1235,
-    "lng": 18.0084
-  },
-  {
-    "name": "Lublin, Poland",
-    "lat": 51.2465,
-    "lng": 22.5684
-  },
-  {
-    "name": "Katowice, Poland",
-    "lat": 50.2649,
-    "lng": 19.0238
-  },
-  {
-    "name": "Stavanger, Norway",
-    "lat": 58.97,
-    "lng": 5.7331
-  },
-  {
-    "name": "Odense, Denmark",
-    "lat": 55.4037,
-    "lng": 10.4024
-  },
-  {
-    "name": "Aalborg, Denmark",
-    "lat": 57.048,
-    "lng": 9.9187
-  },
-  {
-    "name": "Turku, Finland",
-    "lat": 60.4518,
-    "lng": 22.2666
-  },
-  {
-    "name": "Oulu, Finland",
-    "lat": 65.0121,
-    "lng": 25.4651
-  },
-  {
-    "name": "Uppsala, Sweden",
-    "lat": 59.8586,
-    "lng": 17.6389
-  },
-  {
-    "name": "Akureyri, Iceland",
-    "lat": 65.6835,
-    "lng": -18.1002
-  },
-  {
-    "name": "Ostrava, Czech Republic",
-    "lat": 49.8209,
-    "lng": 18.2625
-  },
-  {
-    "name": "Košice, Slovakia",
-    "lat": 48.7164,
-    "lng": 21.2611
-  },
-  {
-    "name": "Debrecen, Hungary",
-    "lat": 47.5316,
-    "lng": 21.6273
-  },
-  {
-    "name": "Timișoara, Romania",
-    "lat": 45.7489,
-    "lng": 21.2087
-  },
-  {
-    "name": "Iași, Romania",
-    "lat": 47.1585,
-    "lng": 27.6014
-  },
-  {
-    "name": "Plovdiv, Bulgaria",
-    "lat": 42.15,
-    "lng": 24.75
-  },
-  {
-    "name": "Varna, Bulgaria",
-    "lat": 43.2141,
-    "lng": 27.9147
-  },
-  {
-    "name": "Patras, Greece",
-    "lat": 38.2466,
-    "lng": 21.7346
-  },
-  {
-    "name": "Novi Sad, Serbia",
-    "lat": 45.2671,
-    "lng": 19.8335
-  },
-  {
-    "name": "Split, Croatia",
-    "lat": 43.5081,
-    "lng": 16.4402
-  },
-  {
-    "name": "Rijeka, Croatia",
-    "lat": 45.3271,
-    "lng": 14.4422
-  },
-  {
-    "name": "Mostar, Bosnia and Herzegovina",
-    "lat": 43.3438,
-    "lng": 17.8078
-  },
-  {
-    "name": "Durrës, Albania",
-    "lat": 41.3246,
-    "lng": 19.4565
-  },
-  {
-    "name": "Dnipro, Ukraine",
-    "lat": 48.4647,
-    "lng": 35.0462
-  },
-  {
-    "name": "Donetsk, Ukraine",
-    "lat": 48.0159,
-    "lng": 37.8029
-  },
-  {
-    "name": "Zaporizhzhia, Ukraine",
-    "lat": 47.8388,
-    "lng": 35.1396
-  },
-  {
-    "name": "Daugavpils, Latvia",
-    "lat": 55.8748,
-    "lng": 26.5366
-  },
-  {
-    "name": "Tartu, Estonia",
-    "lat": 58.3776,
-    "lng": 26.729
-  },
-  {
-    "name": "Kaunas, Lithuania",
-    "lat": 54.8985,
-    "lng": 23.9036
-  },
-  {
-    "name": "Braga, Portugal",
-    "lat": 41.5503,
-    "lng": -8.42
-  },
-  {
-    "name": "Coimbra, Portugal",
-    "lat": 40.2033,
-    "lng": -8.4103
-  },
-  {
-    "name": "Limassol, Cyprus",
-    "lat": 34.6823,
-    "lng": 33.0464
-  },
-  {
-    "name": "Adana, Turkey",
-    "lat": 37.0,
-    "lng": 35.3213
-  },
-  {
-    "name": "Gaziantep, Turkey",
-    "lat": 37.0662,
-    "lng": 37.3833
-  },
-  {
-    "name": "Konya, Turkey",
-    "lat": 37.8667,
-    "lng": 32.4833
-  },
-  {
-    "name": "Kayseri, Turkey",
-    "lat": 38.7312,
-    "lng": 35.4787
-  },
-  {
-    "name": "Diyarbakır, Turkey",
-    "lat": 37.9144,
-    "lng": 40.2306
-  },
-  {
-    "name": "Mersin, Turkey",
-    "lat": 36.8,
-    "lng": 34.6333
-  },
-  {
-    "name": "Beer Sheva, Israel",
-    "lat": 31.2589,
-    "lng": 34.7978
-  },
-  {
-    "name": "Zarqa, Jordan",
-    "lat": 32.0728,
-    "lng": 36.0878
-  },
-  {
-    "name": "Aqaba, Jordan",
-    "lat": 29.5269,
-    "lng": 35.0069
-  },
-  {
-    "name": "Tripoli, Lebanon",
-    "lat": 34.4367,
-    "lng": 35.8497
-  },
-  {
-    "name": "Aleppo, Syria",
-    "lat": 36.2021,
-    "lng": 37.1343
-  },
-  {
-    "name": "Mosul, Iraq",
-    "lat": 36.335,
-    "lng": 43.1189
-  },
-  {
-    "name": "Erbil, Iraq",
-    "lat": 36.1901,
-    "lng": 44.0091
-  },
-  {
-    "name": "Shiraz, Iran",
-    "lat": 29.5918,
-    "lng": 52.5837
-  },
-  {
-    "name": "Ahvaz, Iran",
-    "lat": 31.3183,
-    "lng": 48.6706
-  },
-  {
-    "name": "Karaj, Iran",
-    "lat": 35.84,
-    "lng": 50.9391
-  },
-  {
-    "name": "Qom, Iran",
-    "lat": 34.6416,
-    "lng": 50.8746
-  },
-  {
-    "name": "Aden, Yemen",
-    "lat": 12.7794,
-    "lng": 45.0367
-  },
-  {
-    "name": "Taif, Saudi Arabia",
-    "lat": 21.2625,
-    "lng": 40.375
-  },
-  {
-    "name": "Salalah, Oman",
-    "lat": 17.0151,
-    "lng": 54.0924
-  },
-  {
-    "name": "Ajman, United Arab Emirates",
-    "lat": 25.4052,
-    "lng": 55.5136
-  },
-  {
-    "name": "Longyearbyen, Svalbard",
-    "lat": 78.2232,
-    "lng": 15.6267
-  },
-  {
-    "name": "Kiruna, Sweden",
-    "lat": 67.8558,
-    "lng": 20.2253
-  },
-  {
-    "name": "Tromsø, Norway",
-    "lat": 69.6489,
-    "lng": 18.9551
-  },
-  {
-    "name": "Rovaniemi, Finland",
-    "lat": 66.5039,
-    "lng": 25.7294
-  },
-  {
-    "name": "Iqaluit, Canada",
-    "lat": 63.7467,
-    "lng": -68.517
-  },
-  {
-    "name": "Yellowknife, Canada",
-    "lat": 62.454,
-    "lng": -114.3718
-  },
-  {
-    "name": "Whitehorse, Canada",
-    "lat": 60.7212,
-    "lng": -135.0568
-  },
-  {
-    "name": "Fairbanks, United States",
-    "lat": 64.8378,
-    "lng": -147.7164
-  },
-  {
-    "name": "Nome, United States",
-    "lat": 64.5011,
-    "lng": -165.4064
-  },
-  {
-    "name": "Barrow, United States",
-    "lat": 71.2906,
-    "lng": -156.7886
-  },
-  {
-    "name": "Nadi, Fiji",
-    "lat": -17.7765,
-    "lng": 177.4356
-  },
-  {
-    "name": "Lautoka, Fiji",
-    "lat": -17.608,
-    "lng": 177.4536
-  },
-  {
-    "name": "Rarotonga, Cook Islands",
-    "lat": -21.2361,
-    "lng": -159.7777
-  },
-  {
-    "name": "Avarua, Cook Islands",
-    "lat": -21.2122,
-    "lng": -159.7738
-  },
-  {
-    "name": "Majuro, Marshall Islands",
-    "lat": 7.0897,
-    "lng": 171.3803
-  },
-  {
-    "name": "Palikir, Micronesia",
-    "lat": 6.9147,
-    "lng": 158.1611
-  },
-  {
-    "name": "Koror, Palau",
-    "lat": 7.3419,
-    "lng": 134.4797
-  },
-  {
-    "name": "Yaren, Nauru",
-    "lat": -0.5477,
-    "lng": 166.9209
-  },
-  {
-    "name": "Mata-Utu, Wallis and Futuna",
-    "lat": -13.2825,
-    "lng": -176.1762
-  },
-  {
-    "name": "Hagåtña, Guam",
-    "lat": 13.4745,
-    "lng": 144.7504
-  },
-  {
-    "name": "Saipan, Northern Mariana Islands",
-    "lat": 15.1853,
-    "lng": 145.7466
-  },
-  {
-    "name": "Pago Pago, American Samoa",
-    "lat": -14.271,
-    "lng": -170.1322
-  },
-  {
-    "name": "Midway Atoll, United States",
-    "lat": 28.2072,
-    "lng": -177.3735
-  },
-  {
-    "name": "Hilo, United States",
-    "lat": 19.7297,
-    "lng": -155.09
-  },
-  {
-    "name": "Kailua-Kona, United States",
-    "lat": 19.64,
-    "lng": -155.9969
-  },
-  {
-    "name": "Kahului, United States",
-    "lat": 20.8893,
-    "lng": -156.4729
-  },
-  {
-    "name": "Freeport, Bahamas",
-    "lat": 26.5285,
-    "lng": -78.6956
-  },
-  {
-    "name": "Camagüey, Cuba",
-    "lat": 21.3802,
-    "lng": -77.9178
-  },
-  {
-    "name": "Holguín, Cuba",
-    "lat": 20.8874,
-    "lng": -76.2624
-  },
-  {
-    "name": "Santa Clara, Cuba",
-    "lat": 22.407,
-    "lng": -79.9649
-  },
-  {
-    "name": "Santiago de los Caballeros, Dominican Republic",
-    "lat": 19.4517,
-    "lng": -70.697
-  },
-  {
-    "name": "Cap-Haïtien, Haiti",
-    "lat": 19.7575,
-    "lng": -72.2036
-  },
-  {
-    "name": "Ponce, Puerto Rico",
-    "lat": 18.0111,
-    "lng": -66.6141
-  },
-  {
-    "name": "Montego Bay, Jamaica",
-    "lat": 18.4762,
-    "lng": -77.8939
-  },
-  {
-    "name": "Scarborough, Trinidad and Tobago",
-    "lat": 11.1848,
-    "lng": -60.7429
-  },
-  {
-    "name": "Kingstown, Saint Vincent",
-    "lat": 13.16,
-    "lng": -61.2248
-  },
-  {
-    "name": "St. John's, Antigua",
-    "lat": 17.1274,
-    "lng": -61.8468
-  },
-  {
-    "name": "Charlotte Amalie, US Virgin Islands",
-    "lat": 18.342,
-    "lng": -64.9307
-  },
-  {
-    "name": "Gustavia, Saint Barthélemy",
-    "lat": 17.8957,
-    "lng": -62.8509
-  },
-  {
-    "name": "Marigot, Saint Martin",
-    "lat": 18.0667,
-    "lng": -63.0833
-  },
-  {
-    "name": "Quetzaltenango, Guatemala",
-    "lat": 14.8444,
-    "lng": -91.5177
-  },
-  {
-    "name": "Antigua, Guatemala",
-    "lat": 14.5586,
-    "lng": -90.7295
-  },
-  {
-    "name": "Santa Ana, El Salvador",
-    "lat": 13.9978,
-    "lng": -89.5597
-  },
-  {
-    "name": "San Pedro Sula, Honduras",
-    "lat": 15.5,
-    "lng": -88.0333
-  },
-  {
-    "name": "León, Nicaragua",
-    "lat": 12.4379,
-    "lng": -86.8781
-  },
-  {
-    "name": "Granada, Nicaragua",
-    "lat": 11.9347,
-    "lng": -85.956
-  },
-  {
-    "name": "Liberia, Costa Rica",
-    "lat": 10.6298,
-    "lng": -85.4401
-  },
-  {
-    "name": "Colón, Panama",
-    "lat": 9.3595,
-    "lng": -79.9003
-  },
-  {
-    "name": "David, Panama",
-    "lat": 8.427,
-    "lng": -82.428
-  },
-  {
-    "name": "Belize City, Belize",
-    "lat": 17.251,
-    "lng": -88.759
-  },
-  {
-    "name": "Lerwick, United Kingdom",
-    "lat": 60.1544,
-    "lng": -1.1461
-  },
-  {
-    "name": "Torshavn, Faroe Islands",
-    "lat": 62.0108,
-    "lng": -6.7741
-  },
-  {
-    "name": "Douglas, Isle of Man",
-    "lat": 54.1524,
-    "lng": -4.4862
-  },
-  {
-    "name": "St. Helier, Jersey",
-    "lat": 49.1858,
-    "lng": -2.11
-  },
-  {
-    "name": "St. Peter Port, Guernsey",
-    "lat": 49.456,
-    "lng": -2.536
-  },
-  {
-    "name": "Funchal, Madeira",
-    "lat": 32.6669,
-    "lng": -16.9241
-  },
-  {
-    "name": "Ponta Delgada, Azores",
-    "lat": 37.7412,
-    "lng": -25.6756
-  },
-  {
-    "name": "Las Palmas, Canary Islands",
-    "lat": 28.1235,
-    "lng": -15.4363
-  },
-  {
-    "name": "Santa Cruz de Tenerife, Canary Islands",
-    "lat": 28.4636,
-    "lng": -16.2518
-  },
-  {
-    "name": "Palma de Mallorca, Spain",
-    "lat": 39.5693,
-    "lng": 2.6502
-  },
-  {
-    "name": "Ibiza, Spain",
-    "lat": 38.9087,
-    "lng": 1.4328
-  },
-  {
-    "name": "Ceuta, Spain",
-    "lat": 35.8893,
-    "lng": -5.3213
-  },
-  {
-    "name": "Melilla, Spain",
-    "lat": 35.2923,
-    "lng": -2.9381
-  },
-  {
-    "name": "Gibraltar, Gibraltar",
-    "lat": 36.1408,
-    "lng": -5.3536
-  },
-  {
-    "name": "Nosy Be, Madagascar",
-    "lat": -13.3254,
-    "lng": 48.2686
-  },
-  {
-    "name": "Mahé, Seychelles",
-    "lat": -4.6796,
-    "lng": 55.492
-  },
-  {
-    "name": "Dzaoudzi, Mayotte",
-    "lat": -12.787,
-    "lng": 45.275
-  },
-  {
-    "name": "Mamoudzou, Mayotte",
-    "lat": -12.7806,
-    "lng": 45.2278
-  },
-  {
-    "name": "Jamestown, Saint Helena",
-    "lat": -15.9251,
-    "lng": -5.7179
-  },
-  {
-    "name": "Georgetown, Ascension Island",
-    "lat": -7.9147,
-    "lng": -14.4076
-  },
-  {
-    "name": "Edinburgh of the Seven Seas, Tristan da Cunha",
-    "lat": -37.0684,
-    "lng": -12.311
-  }
+ {
+  "name": "New York, United States",
+  "lat": 40.7128,
+  "lng": -74.006,
+  "region": "US_NORTHEAST"
+ },
+ {
+  "name": "Los Angeles, United States",
+  "lat": 34.0522,
+  "lng": -118.2437,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Chicago, United States",
+  "lat": 41.8781,
+  "lng": -87.6298,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Houston, United States",
+  "lat": 29.7604,
+  "lng": -95.3698,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Phoenix, United States",
+  "lat": 33.4484,
+  "lng": -112.074,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Philadelphia, United States",
+  "lat": 39.9526,
+  "lng": -75.1652,
+  "region": "US_NORTHEAST"
+ },
+ {
+  "name": "San Antonio, United States",
+  "lat": 29.4241,
+  "lng": -98.4936,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "San Diego, United States",
+  "lat": 32.7157,
+  "lng": -117.1611,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Dallas, United States",
+  "lat": 32.7767,
+  "lng": -96.797,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "San Jose, United States",
+  "lat": 37.3382,
+  "lng": -121.8863,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Austin, United States",
+  "lat": 30.2672,
+  "lng": -97.7431,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Jacksonville, United States",
+  "lat": 30.3322,
+  "lng": -81.6557,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Fort Worth, United States",
+  "lat": 32.7555,
+  "lng": -97.3308,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Columbus, United States",
+  "lat": 39.9612,
+  "lng": -82.9988,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Charlotte, United States",
+  "lat": 35.2271,
+  "lng": -80.8431,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Indianapolis, United States",
+  "lat": 39.7684,
+  "lng": -86.1581,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "San Francisco, United States",
+  "lat": 37.7749,
+  "lng": -122.4194,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Seattle, United States",
+  "lat": 47.6062,
+  "lng": -122.3321,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Denver, United States",
+  "lat": 39.7392,
+  "lng": -104.9903,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Nashville, United States",
+  "lat": 36.1627,
+  "lng": -86.7816,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Boston, United States",
+  "lat": 42.3601,
+  "lng": -71.0589,
+  "region": "US_NORTHEAST"
+ },
+ {
+  "name": "Atlanta, United States",
+  "lat": 33.749,
+  "lng": -84.388,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Miami, United States",
+  "lat": 25.7617,
+  "lng": -80.1918,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Minneapolis, United States",
+  "lat": 44.9778,
+  "lng": -93.265,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Portland, United States",
+  "lat": 45.5231,
+  "lng": -122.6765,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Las Vegas, United States",
+  "lat": 36.1699,
+  "lng": -115.1398,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Memphis, United States",
+  "lat": 35.1495,
+  "lng": -90.049,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Louisville, United States",
+  "lat": 38.2527,
+  "lng": -85.7585,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Baltimore, United States",
+  "lat": 39.2904,
+  "lng": -76.6122,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Milwaukee, United States",
+  "lat": 43.0389,
+  "lng": -87.9065,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Albuquerque, United States",
+  "lat": 35.0844,
+  "lng": -106.6504,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Tucson, United States",
+  "lat": 32.2226,
+  "lng": -110.9747,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Fresno, United States",
+  "lat": 36.7378,
+  "lng": -119.7871,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Sacramento, United States",
+  "lat": 38.5816,
+  "lng": -121.4944,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Kansas City, United States",
+  "lat": 39.0997,
+  "lng": -94.5786,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Mesa, United States",
+  "lat": 33.4152,
+  "lng": -111.8315,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Omaha, United States",
+  "lat": 41.2565,
+  "lng": -95.9345,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Colorado Springs, United States",
+  "lat": 38.8339,
+  "lng": -104.8214,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Raleigh, United States",
+  "lat": 35.7796,
+  "lng": -78.6382,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Long Beach, United States",
+  "lat": 33.7701,
+  "lng": -118.1937,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Virginia Beach, United States",
+  "lat": 36.8529,
+  "lng": -75.978,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Oakland, United States",
+  "lat": 37.8044,
+  "lng": -122.2712,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Tampa, United States",
+  "lat": 27.9506,
+  "lng": -82.4572,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "New Orleans, United States",
+  "lat": 29.9511,
+  "lng": -90.0715,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Cleveland, United States",
+  "lat": 41.4993,
+  "lng": -81.6944,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Bakersfield, United States",
+  "lat": 35.3733,
+  "lng": -119.0187,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Aurora, United States",
+  "lat": 39.7294,
+  "lng": -104.8319,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Anaheim, United States",
+  "lat": 33.8366,
+  "lng": -117.9143,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Santa Ana, United States",
+  "lat": 33.7455,
+  "lng": -117.8677,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Corpus Christi, United States",
+  "lat": 27.8006,
+  "lng": -97.3964,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Riverside, United States",
+  "lat": 33.9533,
+  "lng": -117.3962,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Lexington, United States",
+  "lat": 38.0406,
+  "lng": -84.5037,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "St. Louis, United States",
+  "lat": 38.627,
+  "lng": -90.1994,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Pittsburgh, United States",
+  "lat": 40.4406,
+  "lng": -79.9959,
+  "region": "US_NORTHEAST"
+ },
+ {
+  "name": "Anchorage, United States",
+  "lat": 61.2181,
+  "lng": -149.9003,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Stockton, United States",
+  "lat": 37.9577,
+  "lng": -121.2908,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Cincinnati, United States",
+  "lat": 39.1031,
+  "lng": -84.512,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Salt Lake City, United States",
+  "lat": 40.7608,
+  "lng": -111.891,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Tulsa, United States",
+  "lat": 36.154,
+  "lng": -95.9928,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Greensboro, United States",
+  "lat": 36.0726,
+  "lng": -79.792,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Buffalo, United States",
+  "lat": 42.8864,
+  "lng": -78.8784,
+  "region": "US_NORTHEAST"
+ },
+ {
+  "name": "Newark, United States",
+  "lat": 40.7357,
+  "lng": -74.1724,
+  "region": "US_NORTHEAST"
+ },
+ {
+  "name": "Plano, United States",
+  "lat": 33.0198,
+  "lng": -96.6989,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Henderson, United States",
+  "lat": 36.0395,
+  "lng": -114.9817,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Lincoln, United States",
+  "lat": 40.8136,
+  "lng": -96.7026,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "St. Paul, United States",
+  "lat": 44.9537,
+  "lng": -93.09,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Orlando, United States",
+  "lat": 28.5383,
+  "lng": -81.3792,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Boise, United States",
+  "lat": 43.615,
+  "lng": -116.2023,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Richmond, United States",
+  "lat": 37.5407,
+  "lng": -77.436,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Spokane, United States",
+  "lat": 47.6588,
+  "lng": -117.426,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Des Moines, United States",
+  "lat": 41.5868,
+  "lng": -93.625,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Detroit, United States",
+  "lat": 42.3314,
+  "lng": -83.0458,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Madison, United States",
+  "lat": 43.0731,
+  "lng": -89.4012,
+  "region": "US_MIDWEST"
+ },
+ {
+  "name": "Lubbock, United States",
+  "lat": 33.5779,
+  "lng": -101.8552,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Durham, United States",
+  "lat": 35.994,
+  "lng": -78.8986,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Winston-Salem, United States",
+  "lat": 36.0999,
+  "lng": -80.2442,
+  "region": "US_SOUTHEAST"
+ },
+ {
+  "name": "Chandler, United States",
+  "lat": 33.3062,
+  "lng": -111.8413,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Laredo, United States",
+  "lat": 27.5306,
+  "lng": -99.4803,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Honolulu, United States",
+  "lat": 21.3069,
+  "lng": -157.8583,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Scottsdale, United States",
+  "lat": 33.4942,
+  "lng": -111.9261,
+  "region": "US_SOUTHWEST"
+ },
+ {
+  "name": "Toronto, Canada",
+  "lat": 43.6532,
+  "lng": -79.3832,
+  "region": "CANADA"
+ },
+ {
+  "name": "Montreal, Canada",
+  "lat": 45.5017,
+  "lng": -73.5673,
+  "region": "QUEBEC CANADA"
+ },
+ {
+  "name": "Vancouver, Canada",
+  "lat": 49.2827,
+  "lng": -123.1207,
+  "region": "CANADA"
+ },
+ {
+  "name": "Calgary, Canada",
+  "lat": 51.0447,
+  "lng": -114.0719,
+  "region": "CANADA"
+ },
+ {
+  "name": "Edmonton, Canada",
+  "lat": 53.5461,
+  "lng": -113.4938,
+  "region": "CANADA"
+ },
+ {
+  "name": "Ottawa, Canada",
+  "lat": 45.4215,
+  "lng": -75.6972,
+  "region": "CANADA"
+ },
+ {
+  "name": "Winnipeg, Canada",
+  "lat": 49.8951,
+  "lng": -97.1384,
+  "region": "CANADA"
+ },
+ {
+  "name": "Quebec City, Canada",
+  "lat": 46.8139,
+  "lng": -71.208,
+  "region": "QUEBEC CANADA"
+ },
+ {
+  "name": "Hamilton, Canada",
+  "lat": 43.2557,
+  "lng": -79.8711,
+  "region": "CANADA"
+ },
+ {
+  "name": "Halifax, Canada",
+  "lat": 44.6488,
+  "lng": -63.5752,
+  "region": "CANADA"
+ },
+ {
+  "name": "Victoria, Canada",
+  "lat": 48.4284,
+  "lng": -123.3656,
+  "region": "CANADA"
+ },
+ {
+  "name": "Saskatoon, Canada",
+  "lat": 52.1332,
+  "lng": -106.67,
+  "region": "CANADA"
+ },
+ {
+  "name": "Regina, Canada",
+  "lat": 50.4452,
+  "lng": -104.6189,
+  "region": "CANADA"
+ },
+ {
+  "name": "Mexico City, Mexico",
+  "lat": 19.4326,
+  "lng": -99.1332,
+  "region": "MEXICO LATIN_AMERICA"
+ },
+ {
+  "name": "Guadalajara, Mexico",
+  "lat": 20.6597,
+  "lng": -103.3496,
+  "region": "MEXICO LATIN_AMERICA"
+ },
+ {
+  "name": "Monterrey, Mexico",
+  "lat": 25.6866,
+  "lng": -100.3161,
+  "region": "MEXICO LATIN_AMERICA"
+ },
+ {
+  "name": "Puebla, Mexico",
+  "lat": 19.0414,
+  "lng": -98.2063,
+  "region": "MEXICO LATIN_AMERICA"
+ },
+ {
+  "name": "Tijuana, Mexico",
+  "lat": 32.5027,
+  "lng": -117.0036,
+  "region": "MEXICO LATIN_AMERICA"
+ },
+ {
+  "name": "León, Mexico",
+  "lat": 21.1221,
+  "lng": -101.6822,
+  "region": "MEXICO LATIN_AMERICA"
+ },
+ {
+  "name": "Ciudad Juárez, Mexico",
+  "lat": 31.6904,
+  "lng": -106.4245,
+  "region": "MEXICO LATIN_AMERICA"
+ },
+ {
+  "name": "Cancún, Mexico",
+  "lat": 21.1619,
+  "lng": -86.8515,
+  "region": "MEXICO LATIN_AMERICA"
+ },
+ {
+  "name": "Mérida, Mexico",
+  "lat": 20.9674,
+  "lng": -89.5926,
+  "region": "MEXICO LATIN_AMERICA"
+ },
+ {
+  "name": "Culiacán, Mexico",
+  "lat": 24.8091,
+  "lng": -107.394,
+  "region": "MEXICO LATIN_AMERICA"
+ },
+ {
+  "name": "London, United Kingdom",
+  "lat": 51.5074,
+  "lng": -0.1278,
+  "region": "UK"
+ },
+ {
+  "name": "Birmingham, United Kingdom",
+  "lat": 52.4862,
+  "lng": -1.8904,
+  "region": "UK"
+ },
+ {
+  "name": "Manchester, United Kingdom",
+  "lat": 53.4808,
+  "lng": -2.2426,
+  "region": "UK"
+ },
+ {
+  "name": "Glasgow, United Kingdom",
+  "lat": 55.8642,
+  "lng": -4.2518,
+  "region": "UK"
+ },
+ {
+  "name": "Liverpool, United Kingdom",
+  "lat": 53.4084,
+  "lng": -2.9916,
+  "region": "UK"
+ },
+ {
+  "name": "Leeds, United Kingdom",
+  "lat": 53.8008,
+  "lng": -1.5491,
+  "region": "UK"
+ },
+ {
+  "name": "Sheffield, United Kingdom",
+  "lat": 53.3811,
+  "lng": -1.4701,
+  "region": "UK"
+ },
+ {
+  "name": "Edinburgh, United Kingdom",
+  "lat": 55.9533,
+  "lng": -3.1883,
+  "region": "UK"
+ },
+ {
+  "name": "Bristol, United Kingdom",
+  "lat": 51.4545,
+  "lng": -2.5879,
+  "region": "UK"
+ },
+ {
+  "name": "Cardiff, United Kingdom",
+  "lat": 51.4816,
+  "lng": -3.1791,
+  "region": "UK"
+ },
+ {
+  "name": "Belfast, United Kingdom",
+  "lat": 54.5973,
+  "lng": -5.9301,
+  "region": "UK"
+ },
+ {
+  "name": "Dublin, Ireland",
+  "lat": 53.3498,
+  "lng": -6.2603,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Cork, Ireland",
+  "lat": 51.8985,
+  "lng": -8.4756,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Paris, France",
+  "lat": 48.8566,
+  "lng": 2.3522,
+  "region": "FRANCE WESTERN_EUROPE"
+ },
+ {
+  "name": "Lyon, France",
+  "lat": 45.764,
+  "lng": 4.8357,
+  "region": "FRANCE WESTERN_EUROPE"
+ },
+ {
+  "name": "Marseille, France",
+  "lat": 43.2965,
+  "lng": 5.3698,
+  "region": "FRANCE WESTERN_EUROPE"
+ },
+ {
+  "name": "Toulouse, France",
+  "lat": 43.6047,
+  "lng": 1.4442,
+  "region": "FRANCE WESTERN_EUROPE"
+ },
+ {
+  "name": "Nice, France",
+  "lat": 43.7102,
+  "lng": 7.262,
+  "region": "FRANCE WESTERN_EUROPE"
+ },
+ {
+  "name": "Nantes, France",
+  "lat": 47.2184,
+  "lng": -1.5536,
+  "region": "FRANCE WESTERN_EUROPE"
+ },
+ {
+  "name": "Strasbourg, France",
+  "lat": 48.5734,
+  "lng": 7.7521,
+  "region": "FRANCE WESTERN_EUROPE"
+ },
+ {
+  "name": "Bordeaux, France",
+  "lat": 44.8378,
+  "lng": -0.5792,
+  "region": "FRANCE WESTERN_EUROPE"
+ },
+ {
+  "name": "Berlin, Germany",
+  "lat": 52.52,
+  "lng": 13.405,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Hamburg, Germany",
+  "lat": 53.5753,
+  "lng": 10.0153,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Munich, Germany",
+  "lat": 48.1351,
+  "lng": 11.582,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Cologne, Germany",
+  "lat": 50.9333,
+  "lng": 6.95,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Frankfurt, Germany",
+  "lat": 50.1109,
+  "lng": 8.6821,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Stuttgart, Germany",
+  "lat": 48.7758,
+  "lng": 9.1829,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Düsseldorf, Germany",
+  "lat": 51.2217,
+  "lng": 6.7762,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Dortmund, Germany",
+  "lat": 51.5136,
+  "lng": 7.4653,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Essen, Germany",
+  "lat": 51.4556,
+  "lng": 7.0116,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Leipzig, Germany",
+  "lat": 51.3397,
+  "lng": 12.3731,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Madrid, Spain",
+  "lat": 40.4168,
+  "lng": -3.7038,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Barcelona, Spain",
+  "lat": 41.3851,
+  "lng": 2.1734,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Valencia, Spain",
+  "lat": 39.4699,
+  "lng": -0.3763,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Seville, Spain",
+  "lat": 37.3891,
+  "lng": -5.9845,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Zaragoza, Spain",
+  "lat": 41.6488,
+  "lng": -0.8891,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Bilbao, Spain",
+  "lat": 43.263,
+  "lng": -2.935,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Málaga, Spain",
+  "lat": 36.7213,
+  "lng": -4.4214,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Rome, Italy",
+  "lat": 41.9028,
+  "lng": 12.4964,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Milan, Italy",
+  "lat": 45.4642,
+  "lng": 9.19,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Naples, Italy",
+  "lat": 40.8518,
+  "lng": 14.2681,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Turin, Italy",
+  "lat": 45.0703,
+  "lng": 7.6869,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Palermo, Italy",
+  "lat": 38.1157,
+  "lng": 13.3615,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Genoa, Italy",
+  "lat": 44.4056,
+  "lng": 8.9463,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Florence, Italy",
+  "lat": 43.7696,
+  "lng": 11.2558,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Bologna, Italy",
+  "lat": 44.4949,
+  "lng": 11.3426,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Amsterdam, Netherlands",
+  "lat": 52.3676,
+  "lng": 4.9041,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Rotterdam, Netherlands",
+  "lat": 51.9244,
+  "lng": 4.4777,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "The Hague, Netherlands",
+  "lat": 52.0705,
+  "lng": 4.3007,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Utrecht, Netherlands",
+  "lat": 52.0907,
+  "lng": 5.1214,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Brussels, Belgium",
+  "lat": 50.8503,
+  "lng": 4.3517,
+  "region": "BELGIUM WESTERN_EUROPE"
+ },
+ {
+  "name": "Antwerp, Belgium",
+  "lat": 51.2194,
+  "lng": 4.4025,
+  "region": "BELGIUM WESTERN_EUROPE"
+ },
+ {
+  "name": "Vienna, Austria",
+  "lat": 48.2082,
+  "lng": 16.3738,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Graz, Austria",
+  "lat": 47.0707,
+  "lng": 15.4395,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Zurich, Switzerland",
+  "lat": 47.3769,
+  "lng": 8.5417,
+  "region": "SWITZERLAND WESTERN_EUROPE"
+ },
+ {
+  "name": "Geneva, Switzerland",
+  "lat": 46.2044,
+  "lng": 6.1432,
+  "region": "SWITZERLAND WESTERN_EUROPE"
+ },
+ {
+  "name": "Basel, Switzerland",
+  "lat": 47.5596,
+  "lng": 7.5886,
+  "region": "SWITZERLAND WESTERN_EUROPE"
+ },
+ {
+  "name": "Bern, Switzerland",
+  "lat": 46.948,
+  "lng": 7.4474,
+  "region": "SWITZERLAND WESTERN_EUROPE"
+ },
+ {
+  "name": "Stockholm, Sweden",
+  "lat": 59.3293,
+  "lng": 18.0686,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Gothenburg, Sweden",
+  "lat": 57.7089,
+  "lng": 11.9746,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Malmö, Sweden",
+  "lat": 55.605,
+  "lng": 13.0038,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Oslo, Norway",
+  "lat": 59.9139,
+  "lng": 10.7522,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Bergen, Norway",
+  "lat": 60.3913,
+  "lng": 5.3221,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Trondheim, Norway",
+  "lat": 63.4305,
+  "lng": 10.3951,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Copenhagen, Denmark",
+  "lat": 55.6761,
+  "lng": 12.5683,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Aarhus, Denmark",
+  "lat": 56.1629,
+  "lng": 10.2039,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Helsinki, Finland",
+  "lat": 60.1699,
+  "lng": 24.9384,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Tampere, Finland",
+  "lat": 61.4978,
+  "lng": 23.761,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Reykjavik, Iceland",
+  "lat": 64.1265,
+  "lng": -21.8174,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Warsaw, Poland",
+  "lat": 52.2297,
+  "lng": 21.0122,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Krakow, Poland",
+  "lat": 50.0647,
+  "lng": 19.945,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Łódź, Poland",
+  "lat": 51.7592,
+  "lng": 19.456,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Wrocław, Poland",
+  "lat": 51.1079,
+  "lng": 17.0385,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Prague, Czech Republic",
+  "lat": 50.0755,
+  "lng": 14.4378,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Brno, Czech Republic",
+  "lat": 49.1951,
+  "lng": 16.6068,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Budapest, Hungary",
+  "lat": 47.4979,
+  "lng": 19.0402,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Bucharest, Romania",
+  "lat": 44.4268,
+  "lng": 26.1025,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Cluj-Napoca, Romania",
+  "lat": 46.7712,
+  "lng": 23.6236,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Sofia, Bulgaria",
+  "lat": 42.6977,
+  "lng": 23.3219,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Athens, Greece",
+  "lat": 37.9838,
+  "lng": 23.7275,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Thessaloniki, Greece",
+  "lat": 40.6401,
+  "lng": 22.9444,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Belgrade, Serbia",
+  "lat": 44.8176,
+  "lng": 20.4633,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Zagreb, Croatia",
+  "lat": 45.815,
+  "lng": 15.9819,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Kyiv, Ukraine",
+  "lat": 50.4501,
+  "lng": 30.5234,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Kharkiv, Ukraine",
+  "lat": 49.9935,
+  "lng": 36.2304,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Odessa, Ukraine",
+  "lat": 46.4825,
+  "lng": 30.7233,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Lviv, Ukraine",
+  "lat": 49.8397,
+  "lng": 24.0297,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Minsk, Belarus",
+  "lat": 53.9045,
+  "lng": 27.5615,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Riga, Latvia",
+  "lat": 56.9496,
+  "lng": 24.1052,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Tallinn, Estonia",
+  "lat": 59.437,
+  "lng": 24.7536,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Vilnius, Lithuania",
+  "lat": 54.6872,
+  "lng": 25.2797,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Bratislava, Slovakia",
+  "lat": 48.1486,
+  "lng": 17.1077,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Ljubljana, Slovenia",
+  "lat": 46.0569,
+  "lng": 14.5058,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Sarajevo, Bosnia and Herzegovina",
+  "lat": 43.8563,
+  "lng": 18.4131,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Skopje, North Macedonia",
+  "lat": 41.9981,
+  "lng": 21.4254,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Tirana, Albania",
+  "lat": 41.3275,
+  "lng": 19.8187,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Chisinau, Moldova",
+  "lat": 47.0105,
+  "lng": 28.8638,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Lisbon, Portugal",
+  "lat": 38.7223,
+  "lng": -9.1393,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Porto, Portugal",
+  "lat": 41.1579,
+  "lng": -8.6291,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Luxembourg City, Luxembourg",
+  "lat": 49.6116,
+  "lng": 6.1319,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Tokyo, Japan",
+  "lat": 35.6762,
+  "lng": 139.6503,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Osaka, Japan",
+  "lat": 34.6937,
+  "lng": 135.5023,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Nagoya, Japan",
+  "lat": 35.1815,
+  "lng": 136.9066,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Sapporo, Japan",
+  "lat": 43.0618,
+  "lng": 141.3545,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Fukuoka, Japan",
+  "lat": 33.5904,
+  "lng": 130.4017,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kobe, Japan",
+  "lat": 34.6901,
+  "lng": 135.1956,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kyoto, Japan",
+  "lat": 35.0116,
+  "lng": 135.7681,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Sendai, Japan",
+  "lat": 38.2682,
+  "lng": 140.8694,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hiroshima, Japan",
+  "lat": 34.3853,
+  "lng": 132.4553,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Seoul, South Korea",
+  "lat": 37.5665,
+  "lng": 126.978,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Busan, South Korea",
+  "lat": 35.1796,
+  "lng": 129.0756,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Incheon, South Korea",
+  "lat": 37.4563,
+  "lng": 126.7052,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Daegu, South Korea",
+  "lat": 35.8714,
+  "lng": 128.6014,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Daejeon, South Korea",
+  "lat": 36.3504,
+  "lng": 127.3845,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Gwangju, South Korea",
+  "lat": 35.1595,
+  "lng": 126.8526,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Beijing, China",
+  "lat": 39.9042,
+  "lng": 116.4074,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Shanghai, China",
+  "lat": 31.2304,
+  "lng": 121.4737,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Guangzhou, China",
+  "lat": 23.1291,
+  "lng": 113.2644,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Shenzhen, China",
+  "lat": 22.5431,
+  "lng": 114.0579,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Chengdu, China",
+  "lat": 30.5728,
+  "lng": 104.0668,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Chongqing, China",
+  "lat": 29.4316,
+  "lng": 106.9123,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Wuhan, China",
+  "lat": 30.5928,
+  "lng": 114.3055,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Xi'an, China",
+  "lat": 34.3416,
+  "lng": 108.9398,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Tianjin, China",
+  "lat": 39.3434,
+  "lng": 117.3616,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Nanjing, China",
+  "lat": 32.0603,
+  "lng": 118.7969,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hangzhou, China",
+  "lat": 30.2741,
+  "lng": 120.1551,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Qingdao, China",
+  "lat": 36.0671,
+  "lng": 120.3826,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Shenyang, China",
+  "lat": 41.7968,
+  "lng": 123.4291,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Zhengzhou, China",
+  "lat": 34.7466,
+  "lng": 113.6254,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Harbin, China",
+  "lat": 45.8038,
+  "lng": 126.5349,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kunming, China",
+  "lat": 25.0389,
+  "lng": 102.7183,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Dalian, China",
+  "lat": 38.914,
+  "lng": 121.6147,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Xiamen, China",
+  "lat": 24.4798,
+  "lng": 118.0894,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Urumqi, China",
+  "lat": 43.8256,
+  "lng": 87.6168,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hong Kong, China",
+  "lat": 22.3193,
+  "lng": 114.1694,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Taipei, Taiwan",
+  "lat": 25.033,
+  "lng": 121.5654,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kaohsiung, Taiwan",
+  "lat": 22.6273,
+  "lng": 120.3014,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Singapore, Singapore",
+  "lat": 1.3521,
+  "lng": 103.8198,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Bangkok, Thailand",
+  "lat": 13.7563,
+  "lng": 100.5018,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Chiang Mai, Thailand",
+  "lat": 18.7883,
+  "lng": 98.9853,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Pattaya, Thailand",
+  "lat": 12.9236,
+  "lng": 100.8825,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Jakarta, Indonesia",
+  "lat": -6.2088,
+  "lng": 106.8456,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Surabaya, Indonesia",
+  "lat": -7.2575,
+  "lng": 112.7521,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Bandung, Indonesia",
+  "lat": -6.9175,
+  "lng": 107.6191,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Medan, Indonesia",
+  "lat": 3.5952,
+  "lng": 98.6722,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Makassar, Indonesia",
+  "lat": -5.1477,
+  "lng": 119.4327,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kuala Lumpur, Malaysia",
+  "lat": 3.139,
+  "lng": 101.6869,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "George Town, Malaysia",
+  "lat": 5.4141,
+  "lng": 100.3288,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Johor Bahru, Malaysia",
+  "lat": 1.4927,
+  "lng": 103.7414,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Manila, Philippines",
+  "lat": 14.5995,
+  "lng": 120.9842,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Quezon City, Philippines",
+  "lat": 14.676,
+  "lng": 121.0437,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Davao, Philippines",
+  "lat": 7.1907,
+  "lng": 125.4553,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Cebu City, Philippines",
+  "lat": 10.3157,
+  "lng": 123.8854,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hanoi, Vietnam",
+  "lat": 21.0278,
+  "lng": 105.8342,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Ho Chi Minh City, Vietnam",
+  "lat": 10.8231,
+  "lng": 106.6297,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Da Nang, Vietnam",
+  "lat": 16.0544,
+  "lng": 108.2022,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Phnom Penh, Cambodia",
+  "lat": 11.5564,
+  "lng": 104.9282,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Yangon, Myanmar",
+  "lat": 16.8661,
+  "lng": 96.1951,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Vientiane, Laos",
+  "lat": 17.9757,
+  "lng": 102.6331,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Mumbai, India",
+  "lat": 19.076,
+  "lng": 72.8777,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Delhi, India",
+  "lat": 28.6139,
+  "lng": 77.209,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Bangalore, India",
+  "lat": 12.9716,
+  "lng": 77.5946,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hyderabad, India",
+  "lat": 17.385,
+  "lng": 78.4867,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Chennai, India",
+  "lat": 13.0827,
+  "lng": 80.2707,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kolkata, India",
+  "lat": 22.5726,
+  "lng": 88.3639,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Ahmedabad, India",
+  "lat": 23.0225,
+  "lng": 72.5714,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Pune, India",
+  "lat": 18.5204,
+  "lng": 73.8567,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Surat, India",
+  "lat": 21.1702,
+  "lng": 72.8311,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Jaipur, India",
+  "lat": 26.9124,
+  "lng": 75.7873,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Lucknow, India",
+  "lat": 26.8467,
+  "lng": 80.9462,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kanpur, India",
+  "lat": 26.4499,
+  "lng": 80.3319,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Nagpur, India",
+  "lat": 21.1458,
+  "lng": 79.0882,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Bhopal, India",
+  "lat": 23.2599,
+  "lng": 77.4126,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Visakhapatnam, India",
+  "lat": 17.6868,
+  "lng": 83.2185,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Dhaka, Bangladesh",
+  "lat": 23.8103,
+  "lng": 90.4125,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Chittagong, Bangladesh",
+  "lat": 22.3569,
+  "lng": 91.7832,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Karachi, Pakistan",
+  "lat": 24.8607,
+  "lng": 67.0011,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Lahore, Pakistan",
+  "lat": 31.5204,
+  "lng": 74.3587,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Islamabad, Pakistan",
+  "lat": 33.6844,
+  "lng": 73.0479,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Faisalabad, Pakistan",
+  "lat": 31.4504,
+  "lng": 73.135,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Rawalpindi, Pakistan",
+  "lat": 33.5651,
+  "lng": 73.0169,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Colombo, Sri Lanka",
+  "lat": 6.9271,
+  "lng": 79.8612,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kathmandu, Nepal",
+  "lat": 27.7172,
+  "lng": 85.324,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kabul, Afghanistan",
+  "lat": 34.5553,
+  "lng": 69.2075,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Tashkent, Uzbekistan",
+  "lat": 41.2995,
+  "lng": 69.2401,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Almaty, Kazakhstan",
+  "lat": 43.222,
+  "lng": 76.8512,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Nur-Sultan, Kazakhstan",
+  "lat": 51.1801,
+  "lng": 71.446,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Bishkek, Kyrgyzstan",
+  "lat": 42.8746,
+  "lng": 74.5698,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Dushanbe, Tajikistan",
+  "lat": 38.5598,
+  "lng": 68.787,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Ashgabat, Turkmenistan",
+  "lat": 37.9601,
+  "lng": 58.3261,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Ulaanbaatar, Mongolia",
+  "lat": 47.8864,
+  "lng": 106.9057,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Dubai, United Arab Emirates",
+  "lat": 25.2048,
+  "lng": 55.2708,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Abu Dhabi, United Arab Emirates",
+  "lat": 24.4539,
+  "lng": 54.3773,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Sharjah, United Arab Emirates",
+  "lat": 25.3462,
+  "lng": 55.4209,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Riyadh, Saudi Arabia",
+  "lat": 24.7136,
+  "lng": 46.6753,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Jeddah, Saudi Arabia",
+  "lat": 21.4858,
+  "lng": 39.1925,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mecca, Saudi Arabia",
+  "lat": 21.3891,
+  "lng": 39.8579,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Medina, Saudi Arabia",
+  "lat": 24.5247,
+  "lng": 39.5692,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Dammam, Saudi Arabia",
+  "lat": 26.4207,
+  "lng": 50.0888,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Doha, Qatar",
+  "lat": 25.2854,
+  "lng": 51.531,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Kuwait City, Kuwait",
+  "lat": 29.3759,
+  "lng": 47.9774,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Manama, Bahrain",
+  "lat": 26.2285,
+  "lng": 50.586,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Muscat, Oman",
+  "lat": 23.588,
+  "lng": 58.3829,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Sanaa, Yemen",
+  "lat": 15.3694,
+  "lng": 44.191,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Amman, Jordan",
+  "lat": 31.9454,
+  "lng": 35.9284,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Beirut, Lebanon",
+  "lat": 33.8938,
+  "lng": 35.5018,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Damascus, Syria",
+  "lat": 33.5138,
+  "lng": 36.2765,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Baghdad, Iraq",
+  "lat": 33.3152,
+  "lng": 44.3661,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Basra, Iraq",
+  "lat": 30.5085,
+  "lng": 47.7835,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Tehran, Iran",
+  "lat": 35.6892,
+  "lng": 51.389,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Isfahan, Iran",
+  "lat": 32.6546,
+  "lng": 51.668,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mashhad, Iran",
+  "lat": 36.2605,
+  "lng": 59.6168,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Tabriz, Iran",
+  "lat": 38.0962,
+  "lng": 46.2738,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Ankara, Turkey",
+  "lat": 39.9334,
+  "lng": 32.8597,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Istanbul, Turkey",
+  "lat": 41.0082,
+  "lng": 28.9784,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Izmir, Turkey",
+  "lat": 38.4192,
+  "lng": 27.1287,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Bursa, Turkey",
+  "lat": 40.1885,
+  "lng": 29.061,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Antalya, Turkey",
+  "lat": 36.8969,
+  "lng": 30.7133,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Tel Aviv, Israel",
+  "lat": 32.0853,
+  "lng": 34.7818,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Jerusalem, Israel",
+  "lat": 31.7683,
+  "lng": 35.2137,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Haifa, Israel",
+  "lat": 32.794,
+  "lng": 34.9896,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Tbilisi, Georgia",
+  "lat": 41.7151,
+  "lng": 44.8271,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Baku, Azerbaijan",
+  "lat": 40.4093,
+  "lng": 49.8671,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Yerevan, Armenia",
+  "lat": 40.1872,
+  "lng": 44.5152,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Moscow, Russia",
+  "lat": 55.7558,
+  "lng": 37.6173,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Saint Petersburg, Russia",
+  "lat": 59.9311,
+  "lng": 30.3609,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Novosibirsk, Russia",
+  "lat": 54.9884,
+  "lng": 82.9357,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Yekaterinburg, Russia",
+  "lat": 56.8389,
+  "lng": 60.6057,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Kazan, Russia",
+  "lat": 55.8304,
+  "lng": 49.0661,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Nizhny Novgorod, Russia",
+  "lat": 56.2965,
+  "lng": 43.9361,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Vladivostok, Russia",
+  "lat": 43.1332,
+  "lng": 131.9113,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "São Paulo, Brazil",
+  "lat": -23.5505,
+  "lng": -46.6333,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Rio de Janeiro, Brazil",
+  "lat": -22.9068,
+  "lng": -43.1729,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Brasília, Brazil",
+  "lat": -15.7975,
+  "lng": -47.8919,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Salvador, Brazil",
+  "lat": -12.9714,
+  "lng": -38.5014,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Fortaleza, Brazil",
+  "lat": -3.7319,
+  "lng": -38.5267,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Belo Horizonte, Brazil",
+  "lat": -19.9191,
+  "lng": -43.9386,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Manaus, Brazil",
+  "lat": -3.119,
+  "lng": -60.0217,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Curitiba, Brazil",
+  "lat": -25.4284,
+  "lng": -49.2733,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Recife, Brazil",
+  "lat": -8.0476,
+  "lng": -34.877,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Porto Alegre, Brazil",
+  "lat": -30.0346,
+  "lng": -51.2177,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Belém, Brazil",
+  "lat": -1.4558,
+  "lng": -48.5044,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Goiânia, Brazil",
+  "lat": -16.6869,
+  "lng": -49.2648,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Florianópolis, Brazil",
+  "lat": -27.5954,
+  "lng": -48.548,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Natal, Brazil",
+  "lat": -5.7945,
+  "lng": -35.211,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Maceió, Brazil",
+  "lat": -9.6498,
+  "lng": -35.7089,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Buenos Aires, Argentina",
+  "lat": -34.6037,
+  "lng": -58.3816,
+  "region": "ARGENTINA LATIN_AMERICA"
+ },
+ {
+  "name": "Córdoba, Argentina",
+  "lat": -31.4201,
+  "lng": -64.1888,
+  "region": "ARGENTINA LATIN_AMERICA"
+ },
+ {
+  "name": "Rosario, Argentina",
+  "lat": -32.9442,
+  "lng": -60.6505,
+  "region": "ARGENTINA LATIN_AMERICA"
+ },
+ {
+  "name": "Mendoza, Argentina",
+  "lat": -32.8908,
+  "lng": -68.8272,
+  "region": "ARGENTINA LATIN_AMERICA"
+ },
+ {
+  "name": "Tucumán, Argentina",
+  "lat": -26.8083,
+  "lng": -65.2176,
+  "region": "ARGENTINA LATIN_AMERICA"
+ },
+ {
+  "name": "Mar del Plata, Argentina",
+  "lat": -38.0023,
+  "lng": -57.5575,
+  "region": "ARGENTINA LATIN_AMERICA"
+ },
+ {
+  "name": "Salta, Argentina",
+  "lat": -24.7821,
+  "lng": -65.4232,
+  "region": "ARGENTINA LATIN_AMERICA"
+ },
+ {
+  "name": "Santiago, Chile",
+  "lat": -33.4489,
+  "lng": -70.6693,
+  "region": "CHILE LATIN_AMERICA"
+ },
+ {
+  "name": "Valparaíso, Chile",
+  "lat": -33.0472,
+  "lng": -71.6127,
+  "region": "CHILE LATIN_AMERICA"
+ },
+ {
+  "name": "Concepción, Chile",
+  "lat": -36.827,
+  "lng": -73.0503,
+  "region": "CHILE LATIN_AMERICA"
+ },
+ {
+  "name": "Antofagasta, Chile",
+  "lat": -23.6509,
+  "lng": -70.3975,
+  "region": "CHILE LATIN_AMERICA"
+ },
+ {
+  "name": "Bogotá, Colombia",
+  "lat": 4.711,
+  "lng": -74.0721,
+  "region": "COLOMBIA LATIN_AMERICA"
+ },
+ {
+  "name": "Medellín, Colombia",
+  "lat": 6.2476,
+  "lng": -75.5658,
+  "region": "COLOMBIA LATIN_AMERICA"
+ },
+ {
+  "name": "Cali, Colombia",
+  "lat": 3.4516,
+  "lng": -76.532,
+  "region": "COLOMBIA LATIN_AMERICA"
+ },
+ {
+  "name": "Barranquilla, Colombia",
+  "lat": 10.9685,
+  "lng": -74.7813,
+  "region": "COLOMBIA LATIN_AMERICA"
+ },
+ {
+  "name": "Cartagena, Colombia",
+  "lat": 10.391,
+  "lng": -75.4794,
+  "region": "COLOMBIA LATIN_AMERICA"
+ },
+ {
+  "name": "Lima, Peru",
+  "lat": -12.0464,
+  "lng": -77.0428,
+  "region": "PERU LATIN_AMERICA"
+ },
+ {
+  "name": "Arequipa, Peru",
+  "lat": -16.409,
+  "lng": -71.5375,
+  "region": "PERU LATIN_AMERICA"
+ },
+ {
+  "name": "Trujillo, Peru",
+  "lat": -8.109,
+  "lng": -79.0215,
+  "region": "PERU LATIN_AMERICA"
+ },
+ {
+  "name": "Cusco, Peru",
+  "lat": -13.532,
+  "lng": -71.9675,
+  "region": "PERU LATIN_AMERICA"
+ },
+ {
+  "name": "Caracas, Venezuela",
+  "lat": 10.4806,
+  "lng": -66.9036,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Maracaibo, Venezuela",
+  "lat": 10.6319,
+  "lng": -71.6438,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Valencia, Venezuela",
+  "lat": 10.162,
+  "lng": -67.9935,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Quito, Ecuador",
+  "lat": -0.1807,
+  "lng": -78.4678,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Guayaquil, Ecuador",
+  "lat": -2.1711,
+  "lng": -79.9224,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "La Paz, Bolivia",
+  "lat": -16.5,
+  "lng": -68.15,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Santa Cruz, Bolivia",
+  "lat": -17.7833,
+  "lng": -63.1822,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Asunción, Paraguay",
+  "lat": -25.2867,
+  "lng": -57.647,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Montevideo, Uruguay",
+  "lat": -34.9011,
+  "lng": -56.1645,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Georgetown, Guyana",
+  "lat": 6.8013,
+  "lng": -58.1553,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Paramaribo, Suriname",
+  "lat": 5.852,
+  "lng": -55.2038,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Cairo, Egypt",
+  "lat": 30.0444,
+  "lng": 31.2357,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Alexandria, Egypt",
+  "lat": 31.2001,
+  "lng": 29.9187,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Giza, Egypt",
+  "lat": 30.0131,
+  "lng": 31.2089,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Casablanca, Morocco",
+  "lat": 33.5731,
+  "lng": -7.5898,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Rabat, Morocco",
+  "lat": 34.0209,
+  "lng": -6.8416,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Marrakech, Morocco",
+  "lat": 31.6295,
+  "lng": -7.9811,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Fez, Morocco",
+  "lat": 34.0181,
+  "lng": -5.0078,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Algiers, Algeria",
+  "lat": 36.7372,
+  "lng": 3.0863,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Oran, Algeria",
+  "lat": 35.6969,
+  "lng": -0.6331,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Tunis, Tunisia",
+  "lat": 36.8188,
+  "lng": 10.1658,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Tripoli, Libya",
+  "lat": 32.9,
+  "lng": 13.18,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Khartoum, Sudan",
+  "lat": 15.5007,
+  "lng": 32.5599,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Addis Ababa, Ethiopia",
+  "lat": 9.032,
+  "lng": 38.7469,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Nairobi, Kenya",
+  "lat": -1.2921,
+  "lng": 36.8219,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mombasa, Kenya",
+  "lat": -4.0435,
+  "lng": 39.6682,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Dar es Salaam, Tanzania",
+  "lat": -6.7924,
+  "lng": 39.2083,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Kampala, Uganda",
+  "lat": 0.3476,
+  "lng": 32.5825,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Kigali, Rwanda",
+  "lat": -1.9441,
+  "lng": 30.0619,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Lusaka, Zambia",
+  "lat": -15.3875,
+  "lng": 28.3228,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Harare, Zimbabwe",
+  "lat": -17.8252,
+  "lng": 31.0335,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Maputo, Mozambique",
+  "lat": -25.9655,
+  "lng": 32.5832,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Antananarivo, Madagascar",
+  "lat": -18.9137,
+  "lng": 47.5361,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Johannesburg, South Africa",
+  "lat": -26.2041,
+  "lng": 28.0473,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Cape Town, South Africa",
+  "lat": -33.9249,
+  "lng": 18.4241,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Durban, South Africa",
+  "lat": -29.8587,
+  "lng": 31.0218,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Pretoria, South Africa",
+  "lat": -25.7479,
+  "lng": 28.2293,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Port Elizabeth, South Africa",
+  "lat": -33.9608,
+  "lng": 25.6022,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Bloemfontein, South Africa",
+  "lat": -29.121,
+  "lng": 26.2041,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Lagos, Nigeria",
+  "lat": 6.5244,
+  "lng": 3.3792,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Kano, Nigeria",
+  "lat": 12.0022,
+  "lng": 8.592,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Ibadan, Nigeria",
+  "lat": 7.3775,
+  "lng": 3.947,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Abuja, Nigeria",
+  "lat": 9.0579,
+  "lng": 7.4951,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Port Harcourt, Nigeria",
+  "lat": 4.8156,
+  "lng": 7.0498,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Accra, Ghana",
+  "lat": 5.6037,
+  "lng": -0.187,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Kumasi, Ghana",
+  "lat": 6.6885,
+  "lng": -1.6244,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Dakar, Senegal",
+  "lat": 14.7167,
+  "lng": -17.4677,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Abidjan, Côte d'Ivoire",
+  "lat": 5.36,
+  "lng": -4.0083,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Conakry, Guinea",
+  "lat": 9.537,
+  "lng": -13.6773,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Freetown, Sierra Leone",
+  "lat": 8.4657,
+  "lng": -13.2317,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Monrovia, Liberia",
+  "lat": 6.2907,
+  "lng": -10.7605,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Bamako, Mali",
+  "lat": 12.6392,
+  "lng": -8.0029,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Ouagadougou, Burkina Faso",
+  "lat": 12.3569,
+  "lng": -1.5353,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Niamey, Niger",
+  "lat": 13.5137,
+  "lng": 2.1098,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "N'Djamena, Chad",
+  "lat": 12.1348,
+  "lng": 15.0557,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Douala, Cameroon",
+  "lat": 4.0511,
+  "lng": 9.7679,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Yaoundé, Cameroon",
+  "lat": 3.848,
+  "lng": 11.5021,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Kinshasa, Democratic Republic of the Congo",
+  "lat": -4.3217,
+  "lng": 15.3222,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Lubumbashi, Democratic Republic of the Congo",
+  "lat": -11.6609,
+  "lng": 27.4794,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Luanda, Angola",
+  "lat": -8.8368,
+  "lng": 13.2343,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Brazzaville, Republic of the Congo",
+  "lat": -4.2661,
+  "lng": 15.2832,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Libreville, Gabon",
+  "lat": 0.3901,
+  "lng": 9.4544,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Malabo, Equatorial Guinea",
+  "lat": 3.7523,
+  "lng": 8.7742,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Bangui, Central African Republic",
+  "lat": 4.3612,
+  "lng": 18.555,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Lomé, Togo",
+  "lat": 6.1375,
+  "lng": 1.2123,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Cotonou, Benin",
+  "lat": 6.3703,
+  "lng": 2.3912,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Banjul, Gambia",
+  "lat": 13.4549,
+  "lng": -16.579,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Bissau, Guinea-Bissau",
+  "lat": 11.8636,
+  "lng": -15.5977,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Praia, Cape Verde",
+  "lat": 14.933,
+  "lng": -23.5133,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Djibouti City, Djibouti",
+  "lat": 11.572,
+  "lng": 43.1456,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Asmara, Eritrea",
+  "lat": 15.3389,
+  "lng": 38.9318,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mogadishu, Somalia",
+  "lat": 2.0469,
+  "lng": 45.3182,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Lilongwe, Malawi",
+  "lat": -13.9626,
+  "lng": 33.7741,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Gaborone, Botswana",
+  "lat": -24.6282,
+  "lng": 25.9231,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Windhoek, Namibia",
+  "lat": -22.5609,
+  "lng": 17.0658,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Maseru, Lesotho",
+  "lat": -29.3167,
+  "lng": 27.4833,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mbabane, Eswatini",
+  "lat": -26.3054,
+  "lng": 31.1367,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Moroni, Comoros",
+  "lat": -11.7022,
+  "lng": 43.2551,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Sydney, Australia",
+  "lat": -33.8688,
+  "lng": 151.2093,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Melbourne, Australia",
+  "lat": -37.8136,
+  "lng": 144.9631,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Brisbane, Australia",
+  "lat": -27.4698,
+  "lng": 153.0251,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Perth, Australia",
+  "lat": -31.9505,
+  "lng": 115.8605,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Adelaide, Australia",
+  "lat": -34.9285,
+  "lng": 138.6007,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Canberra, Australia",
+  "lat": -35.2809,
+  "lng": 149.13,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Gold Coast, Australia",
+  "lat": -28.0167,
+  "lng": 153.4,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Newcastle, Australia",
+  "lat": -32.9267,
+  "lng": 151.7789,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hobart, Australia",
+  "lat": -42.8826,
+  "lng": 147.3257,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Darwin, Australia",
+  "lat": -12.4634,
+  "lng": 130.8456,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Cairns, Australia",
+  "lat": -16.9186,
+  "lng": 145.7781,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Townsville, Australia",
+  "lat": -19.259,
+  "lng": 146.8169,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Wollongong, Australia",
+  "lat": -34.4278,
+  "lng": 150.8931,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Auckland, New Zealand",
+  "lat": -36.8485,
+  "lng": 174.7633,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Wellington, New Zealand",
+  "lat": -41.2865,
+  "lng": 174.7762,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Christchurch, New Zealand",
+  "lat": -43.5321,
+  "lng": 172.6362,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hamilton, New Zealand",
+  "lat": -37.787,
+  "lng": 175.2793,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Dunedin, New Zealand",
+  "lat": -45.8788,
+  "lng": 170.5028,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Tauranga, New Zealand",
+  "lat": -37.6878,
+  "lng": 176.1651,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Port Moresby, Papua New Guinea",
+  "lat": -9.4438,
+  "lng": 147.1803,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Suva, Fiji",
+  "lat": -18.1416,
+  "lng": 178.4415,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Honiara, Solomon Islands",
+  "lat": -9.4333,
+  "lng": 160.05,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Port Vila, Vanuatu",
+  "lat": -17.7333,
+  "lng": 168.3167,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Noumea, New Caledonia",
+  "lat": -22.2758,
+  "lng": 166.4581,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Papeete, French Polynesia",
+  "lat": -17.5334,
+  "lng": -149.5667,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Apia, Samoa",
+  "lat": -13.8314,
+  "lng": -171.872,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Nuku'alofa, Tonga",
+  "lat": -21.1393,
+  "lng": -175.2049,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Tarawa, Kiribati",
+  "lat": 1.3282,
+  "lng": 172.9784,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Funafuti, Tuvalu",
+  "lat": -8.5243,
+  "lng": 179.1942,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Guatemala City, Guatemala",
+  "lat": 14.6349,
+  "lng": -90.5069,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "San Salvador, El Salvador",
+  "lat": 13.6929,
+  "lng": -89.2182,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Tegucigalpa, Honduras",
+  "lat": 14.0723,
+  "lng": -87.2062,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Managua, Nicaragua",
+  "lat": 12.1328,
+  "lng": -86.2504,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "San José, Costa Rica",
+  "lat": 9.9281,
+  "lng": -84.0907,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Panama City, Panama",
+  "lat": 8.9936,
+  "lng": -79.5197,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Belmopan, Belize",
+  "lat": 17.2514,
+  "lng": -88.759,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Havana, Cuba",
+  "lat": 23.1136,
+  "lng": -82.3666,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Santiago de Cuba, Cuba",
+  "lat": 20.0236,
+  "lng": -75.822,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Santo Domingo, Dominican Republic",
+  "lat": 18.4861,
+  "lng": -69.9312,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Port-au-Prince, Haiti",
+  "lat": 18.5944,
+  "lng": -72.3074,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "San Juan, Puerto Rico",
+  "lat": 18.4655,
+  "lng": -66.1057,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Kingston, Jamaica",
+  "lat": 17.997,
+  "lng": -76.7936,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Port of Spain, Trinidad and Tobago",
+  "lat": 10.6549,
+  "lng": -61.5019,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Bridgetown, Barbados",
+  "lat": 13.1132,
+  "lng": -59.5988,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Nassau, Bahamas",
+  "lat": 25.048,
+  "lng": -77.3554,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Willemstad, Curaçao",
+  "lat": 12.1224,
+  "lng": -68.8824,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Oranjestad, Aruba",
+  "lat": 12.5246,
+  "lng": -70.0265,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Castries, Saint Lucia",
+  "lat": 14.0101,
+  "lng": -60.9875,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Kingstown, Saint Vincent and the Grenadines",
+  "lat": 13.16,
+  "lng": -61.2248,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Saint George's, Grenada",
+  "lat": 12.0561,
+  "lng": -61.7488,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Roseau, Dominica",
+  "lat": 15.3017,
+  "lng": -61.3881,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Basseterre, Saint Kitts and Nevis",
+  "lat": 17.3026,
+  "lng": -62.7177,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "St. John's, Antigua and Barbuda",
+  "lat": 17.1274,
+  "lng": -61.8468,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Road Town, British Virgin Islands",
+  "lat": 18.4207,
+  "lng": -64.64,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Philipsburg, Sint Maarten",
+  "lat": 18.0255,
+  "lng": -63.0526,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Nuuk, Greenland",
+  "lat": 64.1836,
+  "lng": -51.7214,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Longyearbyen, Norway",
+  "lat": 78.2232,
+  "lng": 15.6267,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Valletta, Malta",
+  "lat": 35.8997,
+  "lng": 14.5146,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Nicosia, Cyprus",
+  "lat": 35.1856,
+  "lng": 33.3823,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Podgorica, Montenegro",
+  "lat": 42.4304,
+  "lng": 19.2594,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Pristina, Kosovo",
+  "lat": 42.6629,
+  "lng": 21.1655,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Andorra la Vella, Andorra",
+  "lat": 42.5063,
+  "lng": 1.5218,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Monaco, Monaco",
+  "lat": 43.7384,
+  "lng": 7.4246,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "San Marino, San Marino",
+  "lat": 43.9424,
+  "lng": 12.4578,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Vaduz, Liechtenstein",
+  "lat": 47.141,
+  "lng": 9.5215,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Saint-Denis, Réunion",
+  "lat": -20.8789,
+  "lng": 55.4481,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Fort-de-France, Martinique",
+  "lat": 14.6037,
+  "lng": -61.0736,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Pointe-à-Pitre, Guadeloupe",
+  "lat": 16.2418,
+  "lng": -61.5336,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Cayenne, French Guiana",
+  "lat": 4.9224,
+  "lng": -52.3135,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Macau, China",
+  "lat": 22.1987,
+  "lng": 113.5439,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Malé, Maldives",
+  "lat": 4.1755,
+  "lng": 73.5093,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Thimphu, Bhutan",
+  "lat": 27.4728,
+  "lng": 89.639,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Nay Pyi Taw, Myanmar",
+  "lat": 19.7633,
+  "lng": 96.0785,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Bandar Seri Begawan, Brunei",
+  "lat": 4.9031,
+  "lng": 114.9398,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Dili, East Timor",
+  "lat": -8.5568,
+  "lng": 125.5786,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Naypyidaw, Myanmar",
+  "lat": 19.7633,
+  "lng": 96.0785,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kandy, Sri Lanka",
+  "lat": 7.2906,
+  "lng": 80.6337,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Jaffna, Sri Lanka",
+  "lat": 9.6615,
+  "lng": 80.0255,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Peshawar, Pakistan",
+  "lat": 34.0151,
+  "lng": 71.5249,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Quetta, Pakistan",
+  "lat": 30.1798,
+  "lng": 66.975,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Multan, Pakistan",
+  "lat": 30.1575,
+  "lng": 71.5249,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hyderabad, Pakistan",
+  "lat": 25.396,
+  "lng": 68.3578,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Varanasi, India",
+  "lat": 25.3176,
+  "lng": 82.9739,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Agra, India",
+  "lat": 27.1767,
+  "lng": 78.0081,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Indore, India",
+  "lat": 22.7196,
+  "lng": 75.8577,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Patna, India",
+  "lat": 25.5941,
+  "lng": 85.1376,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kochi, India",
+  "lat": 9.9312,
+  "lng": 76.2673,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Coimbatore, India",
+  "lat": 11.0168,
+  "lng": 76.9558,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Guwahati, India",
+  "lat": 26.1445,
+  "lng": 91.7362,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Bhubaneswar, India",
+  "lat": 20.2961,
+  "lng": 85.8245,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Thiruvananthapuram, India",
+  "lat": 8.5241,
+  "lng": 76.9366,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Amritsar, India",
+  "lat": 31.634,
+  "lng": 74.8723,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Chandigarh, India",
+  "lat": 30.7333,
+  "lng": 76.7794,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Goa, India",
+  "lat": 15.2993,
+  "lng": 74.124,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Nanning, China",
+  "lat": 22.817,
+  "lng": 108.3665,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Guiyang, China",
+  "lat": 26.5783,
+  "lng": 106.7275,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Lanzhou, China",
+  "lat": 36.0611,
+  "lng": 103.8343,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Taiyuan, China",
+  "lat": 37.8706,
+  "lng": 112.5489,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Shijiazhuang, China",
+  "lat": 38.0428,
+  "lng": 114.5149,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hefei, China",
+  "lat": 31.8639,
+  "lng": 117.2808,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Changchun, China",
+  "lat": 43.8171,
+  "lng": 125.3235,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Jinan, China",
+  "lat": 36.6512,
+  "lng": 117.1201,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Fuzhou, China",
+  "lat": 26.0745,
+  "lng": 119.2965,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Wenzhou, China",
+  "lat": 27.9938,
+  "lng": 120.6997,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Changsha, China",
+  "lat": 28.2282,
+  "lng": 112.9388,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Wuxi, China",
+  "lat": 31.4912,
+  "lng": 120.3119,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Suzhou, China",
+  "lat": 31.299,
+  "lng": 120.5853,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Nanchang, China",
+  "lat": 28.682,
+  "lng": 115.8581,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Zibo, China",
+  "lat": 36.804,
+  "lng": 118.055,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Tangshan, China",
+  "lat": 39.6243,
+  "lng": 118.1943,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Baotou, China",
+  "lat": 40.6553,
+  "lng": 109.84,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Medellin, Colombia",
+  "lat": 6.2476,
+  "lng": -75.5658,
+  "region": "COLOMBIA LATIN_AMERICA"
+ },
+ {
+  "name": "Bucaramanga, Colombia",
+  "lat": 7.1253,
+  "lng": -73.1198,
+  "region": "COLOMBIA LATIN_AMERICA"
+ },
+ {
+  "name": "Pereira, Colombia",
+  "lat": 4.8087,
+  "lng": -75.6906,
+  "region": "COLOMBIA LATIN_AMERICA"
+ },
+ {
+  "name": "Manizales, Colombia",
+  "lat": 5.0703,
+  "lng": -75.5138,
+  "region": "COLOMBIA LATIN_AMERICA"
+ },
+ {
+  "name": "Cochabamba, Bolivia",
+  "lat": -17.3895,
+  "lng": -66.1568,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Sucre, Bolivia",
+  "lat": -19.0196,
+  "lng": -65.2619,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Cuenca, Ecuador",
+  "lat": -2.9001,
+  "lng": -79.0059,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Loja, Ecuador",
+  "lat": -3.9931,
+  "lng": -79.2042,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Callao, Peru",
+  "lat": -12.056,
+  "lng": -77.1183,
+  "region": "PERU LATIN_AMERICA"
+ },
+ {
+  "name": "Piura, Peru",
+  "lat": -5.1945,
+  "lng": -80.6328,
+  "region": "PERU LATIN_AMERICA"
+ },
+ {
+  "name": "Iquitos, Peru",
+  "lat": -3.7437,
+  "lng": -73.2516,
+  "region": "PERU LATIN_AMERICA"
+ },
+ {
+  "name": "Concepción, Paraguay",
+  "lat": -23.409,
+  "lng": -57.428,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Ciudad del Este, Paraguay",
+  "lat": -25.5096,
+  "lng": -54.611,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Salto, Uruguay",
+  "lat": -31.3833,
+  "lng": -57.9667,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Paysandú, Uruguay",
+  "lat": -32.3167,
+  "lng": -58.0833,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Maracay, Venezuela",
+  "lat": 10.2469,
+  "lng": -67.5958,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Barquisimeto, Venezuela",
+  "lat": 10.0647,
+  "lng": -69.357,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Sorocaba, Brazil",
+  "lat": -23.5015,
+  "lng": -47.4526,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Campinas, Brazil",
+  "lat": -22.9056,
+  "lng": -47.0608,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "São Luís, Brazil",
+  "lat": -2.5307,
+  "lng": -44.3068,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Teresina, Brazil",
+  "lat": -5.0892,
+  "lng": -42.8019,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Campo Grande, Brazil",
+  "lat": -20.4697,
+  "lng": -54.6201,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "João Pessoa, Brazil",
+  "lat": -7.1195,
+  "lng": -34.845,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Aracaju, Brazil",
+  "lat": -10.9167,
+  "lng": -37.05,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Macapá, Brazil",
+  "lat": 0.0356,
+  "lng": -51.0705,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Porto Velho, Brazil",
+  "lat": -8.7612,
+  "lng": -63.9004,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Cuiabá, Brazil",
+  "lat": -15.6014,
+  "lng": -56.0979,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Kaduna, Nigeria",
+  "lat": 10.5222,
+  "lng": 7.4383,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Benin City, Nigeria",
+  "lat": 6.335,
+  "lng": 5.6037,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Enugu, Nigeria",
+  "lat": 6.4584,
+  "lng": 7.5464,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Onitsha, Nigeria",
+  "lat": 6.1667,
+  "lng": 6.7833,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Kisumu, Kenya",
+  "lat": -0.1022,
+  "lng": 34.7617,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Nakuru, Kenya",
+  "lat": -0.3031,
+  "lng": 36.08,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mwanza, Tanzania",
+  "lat": -2.5167,
+  "lng": 32.9,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Zanzibar City, Tanzania",
+  "lat": -6.1659,
+  "lng": 39.1989,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Gulu, Uganda",
+  "lat": 2.7748,
+  "lng": 32.3049,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Bujumbura, Burundi",
+  "lat": -3.3822,
+  "lng": 29.3644,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Blantyre, Malawi",
+  "lat": -15.7861,
+  "lng": 35.0058,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Ndola, Zambia",
+  "lat": -12.9587,
+  "lng": 28.6366,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Bulawayo, Zimbabwe",
+  "lat": -20.15,
+  "lng": 28.5833,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Beira, Mozambique",
+  "lat": -19.8437,
+  "lng": 34.8389,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Toamasina, Madagascar",
+  "lat": -18.15,
+  "lng": 49.4,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Huambo, Angola",
+  "lat": -12.7756,
+  "lng": 15.7394,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Thiès, Senegal",
+  "lat": 14.7833,
+  "lng": -16.9167,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Bouaké, Côte d'Ivoire",
+  "lat": 7.6833,
+  "lng": -5.0333,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Tamale, Ghana",
+  "lat": 9.4008,
+  "lng": -0.8393,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mekelle, Ethiopia",
+  "lat": 13.4969,
+  "lng": 39.4769,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Dire Dawa, Ethiopia",
+  "lat": 9.5931,
+  "lng": 41.8661,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Omdurman, Sudan",
+  "lat": 15.65,
+  "lng": 32.4833,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Port Sudan, Sudan",
+  "lat": 19.6158,
+  "lng": 37.2164,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Hargeisa, Somalia",
+  "lat": 9.55,
+  "lng": 44.05,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Juba, South Sudan",
+  "lat": 4.8594,
+  "lng": 31.5713,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Wau, South Sudan",
+  "lat": 7.7,
+  "lng": 28.0,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Walvis Bay, Namibia",
+  "lat": -22.9575,
+  "lng": 14.5053,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Luxor, Egypt",
+  "lat": 25.6872,
+  "lng": 32.6396,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Aswan, Egypt",
+  "lat": 24.0889,
+  "lng": 32.8998,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Tangier, Morocco",
+  "lat": 35.7595,
+  "lng": -5.834,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Annaba, Algeria",
+  "lat": 36.9,
+  "lng": 7.7667,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Sfax, Tunisia",
+  "lat": 34.74,
+  "lng": 10.76,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Benghazi, Libya",
+  "lat": 32.1194,
+  "lng": 20.0867,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Nouakchott, Mauritania",
+  "lat": 18.0735,
+  "lng": -15.9582,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Timbuktu, Mali",
+  "lat": 16.7667,
+  "lng": -3.0026,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Ndjamena, Chad",
+  "lat": 12.1348,
+  "lng": 15.0557,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Kinshasa, DR Congo",
+  "lat": -4.3217,
+  "lng": 15.3222,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Goma, DR Congo",
+  "lat": -1.6792,
+  "lng": 29.2228,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Kisangani, DR Congo",
+  "lat": 0.5153,
+  "lng": 25.19,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Pointe-Noire, Republic of the Congo",
+  "lat": -4.7692,
+  "lng": 11.866,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "São Tomé, São Tomé and Príncipe",
+  "lat": 0.3365,
+  "lng": 6.7273,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Victoria, Seychelles",
+  "lat": -4.6191,
+  "lng": 55.4513,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Port Louis, Mauritius",
+  "lat": -20.1609,
+  "lng": 57.4977,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Yokohama, Japan",
+  "lat": 35.4437,
+  "lng": 139.638,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kawasaki, Japan",
+  "lat": 35.5308,
+  "lng": 139.703,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kitakyushu, Japan",
+  "lat": 33.8833,
+  "lng": 130.875,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Chiba, Japan",
+  "lat": 35.605,
+  "lng": 140.1233,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Sakai, Japan",
+  "lat": 34.5733,
+  "lng": 135.483,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Niigata, Japan",
+  "lat": 37.9161,
+  "lng": 139.0364,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hamamatsu, Japan",
+  "lat": 34.7108,
+  "lng": 137.7261,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Pyongyang, North Korea",
+  "lat": 39.0194,
+  "lng": 125.7381,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Lhasa, China",
+  "lat": 29.65,
+  "lng": 91.1,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hohhot, China",
+  "lat": 40.842,
+  "lng": 111.749,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Yinchuan, China",
+  "lat": 38.4872,
+  "lng": 106.2309,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Xining, China",
+  "lat": 36.6171,
+  "lng": 101.7782,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Haikou, China",
+  "lat": 20.044,
+  "lng": 110.3416,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Sanya, China",
+  "lat": 18.2479,
+  "lng": 109.5146,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Mazar-i-Sharif, Afghanistan",
+  "lat": 36.7069,
+  "lng": 67.1107,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Samarkand, Uzbekistan",
+  "lat": 39.655,
+  "lng": 66.9597,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Osh, Kyrgyzstan",
+  "lat": 40.5283,
+  "lng": 72.7985,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Mary, Turkmenistan",
+  "lat": 37.5931,
+  "lng": 61.83,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Kutaisi, Georgia",
+  "lat": 42.2679,
+  "lng": 42.6961,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Ganja, Azerbaijan",
+  "lat": 40.6828,
+  "lng": 46.3606,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Gyumri, Armenia",
+  "lat": 40.7942,
+  "lng": 43.8453,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Chelyabinsk, Russia",
+  "lat": 55.154,
+  "lng": 61.4291,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Omsk, Russia",
+  "lat": 54.9885,
+  "lng": 73.3242,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Samara, Russia",
+  "lat": 53.2001,
+  "lng": 50.15,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Ufa, Russia",
+  "lat": 54.7388,
+  "lng": 55.9721,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Rostov-on-Don, Russia",
+  "lat": 47.2357,
+  "lng": 39.7015,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Volgograd, Russia",
+  "lat": 48.708,
+  "lng": 44.5133,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Perm, Russia",
+  "lat": 58.0105,
+  "lng": 56.2502,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Krasnoyarsk, Russia",
+  "lat": 56.0184,
+  "lng": 92.8672,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Voronezh, Russia",
+  "lat": 51.672,
+  "lng": 39.1843,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Saratov, Russia",
+  "lat": 51.5339,
+  "lng": 46.0342,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Irkutsk, Russia",
+  "lat": 52.2978,
+  "lng": 104.2964,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Khabarovsk, Russia",
+  "lat": 48.4827,
+  "lng": 135.084,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Makhachkala, Russia",
+  "lat": 42.9849,
+  "lng": 47.5047,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Tolyatti, Russia",
+  "lat": 53.5303,
+  "lng": 49.3461,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Izhevsk, Russia",
+  "lat": 56.8526,
+  "lng": 53.2115,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Barnaul, Russia",
+  "lat": 53.3606,
+  "lng": 83.7636,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Ulyanovsk, Russia",
+  "lat": 54.3282,
+  "lng": 48.3866,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Yaroslavl, Russia",
+  "lat": 57.6261,
+  "lng": 39.8845,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Tyumen, Russia",
+  "lat": 57.1522,
+  "lng": 68.0,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Kemerovo, Russia",
+  "lat": 55.3908,
+  "lng": 86.0847,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Murmansk, Russia",
+  "lat": 68.9585,
+  "lng": 33.0827,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Tomsk, Russia",
+  "lat": 56.4977,
+  "lng": 84.9744,
+  "region": "RUSSIA EASTERN_EUROPE"
+ },
+ {
+  "name": "Oral, Kazakhstan",
+  "lat": 51.2333,
+  "lng": 51.3667,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Shymkent, Kazakhstan",
+  "lat": 42.3,
+  "lng": 69.6,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Aktobe, Kazakhstan",
+  "lat": 50.2839,
+  "lng": 57.1669,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Karaganda, Kazakhstan",
+  "lat": 49.8047,
+  "lng": 73.0878,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Gomel, Belarus",
+  "lat": 52.4413,
+  "lng": 31.0139,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Vitebsk, Belarus",
+  "lat": 55.1904,
+  "lng": 30.2049,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Grodno, Belarus",
+  "lat": 53.6884,
+  "lng": 23.8258,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Kraków, Poland",
+  "lat": 50.0647,
+  "lng": 19.945,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Poznań, Poland",
+  "lat": 52.4064,
+  "lng": 16.9252,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Gdańsk, Poland",
+  "lat": 54.3521,
+  "lng": 18.6466,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Szczecin, Poland",
+  "lat": 53.4285,
+  "lng": 14.5528,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Bydgoszcz, Poland",
+  "lat": 53.1235,
+  "lng": 18.0084,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Lublin, Poland",
+  "lat": 51.2465,
+  "lng": 22.5684,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Katowice, Poland",
+  "lat": 50.2649,
+  "lng": 19.0238,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Stavanger, Norway",
+  "lat": 58.97,
+  "lng": 5.7331,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Odense, Denmark",
+  "lat": 55.4037,
+  "lng": 10.4024,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Aalborg, Denmark",
+  "lat": 57.048,
+  "lng": 9.9187,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Turku, Finland",
+  "lat": 60.4518,
+  "lng": 22.2666,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Oulu, Finland",
+  "lat": 65.0121,
+  "lng": 25.4651,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Uppsala, Sweden",
+  "lat": 59.8586,
+  "lng": 17.6389,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Akureyri, Iceland",
+  "lat": 65.6835,
+  "lng": -18.1002,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Ostrava, Czech Republic",
+  "lat": 49.8209,
+  "lng": 18.2625,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Košice, Slovakia",
+  "lat": 48.7164,
+  "lng": 21.2611,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Debrecen, Hungary",
+  "lat": 47.5316,
+  "lng": 21.6273,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Timișoara, Romania",
+  "lat": 45.7489,
+  "lng": 21.2087,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Iași, Romania",
+  "lat": 47.1585,
+  "lng": 27.6014,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Plovdiv, Bulgaria",
+  "lat": 42.15,
+  "lng": 24.75,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Varna, Bulgaria",
+  "lat": 43.2141,
+  "lng": 27.9147,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Patras, Greece",
+  "lat": 38.2466,
+  "lng": 21.7346,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Novi Sad, Serbia",
+  "lat": 45.2671,
+  "lng": 19.8335,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Split, Croatia",
+  "lat": 43.5081,
+  "lng": 16.4402,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Rijeka, Croatia",
+  "lat": 45.3271,
+  "lng": 14.4422,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Mostar, Bosnia and Herzegovina",
+  "lat": 43.3438,
+  "lng": 17.8078,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Durrës, Albania",
+  "lat": 41.3246,
+  "lng": 19.4565,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Dnipro, Ukraine",
+  "lat": 48.4647,
+  "lng": 35.0462,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Donetsk, Ukraine",
+  "lat": 48.0159,
+  "lng": 37.8029,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Zaporizhzhia, Ukraine",
+  "lat": 47.8388,
+  "lng": 35.1396,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Daugavpils, Latvia",
+  "lat": 55.8748,
+  "lng": 26.5366,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Tartu, Estonia",
+  "lat": 58.3776,
+  "lng": 26.729,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Kaunas, Lithuania",
+  "lat": 54.8985,
+  "lng": 23.9036,
+  "region": "EASTERN_EUROPE"
+ },
+ {
+  "name": "Braga, Portugal",
+  "lat": 41.5503,
+  "lng": -8.42,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Coimbra, Portugal",
+  "lat": 40.2033,
+  "lng": -8.4103,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Limassol, Cyprus",
+  "lat": 34.6823,
+  "lng": 33.0464,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Adana, Turkey",
+  "lat": 37.0,
+  "lng": 35.3213,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Gaziantep, Turkey",
+  "lat": 37.0662,
+  "lng": 37.3833,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Konya, Turkey",
+  "lat": 37.8667,
+  "lng": 32.4833,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Kayseri, Turkey",
+  "lat": 38.7312,
+  "lng": 35.4787,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Diyarbakır, Turkey",
+  "lat": 37.9144,
+  "lng": 40.2306,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mersin, Turkey",
+  "lat": 36.8,
+  "lng": 34.6333,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Beer Sheva, Israel",
+  "lat": 31.2589,
+  "lng": 34.7978,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Zarqa, Jordan",
+  "lat": 32.0728,
+  "lng": 36.0878,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Aqaba, Jordan",
+  "lat": 29.5269,
+  "lng": 35.0069,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Tripoli, Lebanon",
+  "lat": 34.4367,
+  "lng": 35.8497,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Aleppo, Syria",
+  "lat": 36.2021,
+  "lng": 37.1343,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mosul, Iraq",
+  "lat": 36.335,
+  "lng": 43.1189,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Erbil, Iraq",
+  "lat": 36.1901,
+  "lng": 44.0091,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Shiraz, Iran",
+  "lat": 29.5918,
+  "lng": 52.5837,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Ahvaz, Iran",
+  "lat": 31.3183,
+  "lng": 48.6706,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Karaj, Iran",
+  "lat": 35.84,
+  "lng": 50.9391,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Qom, Iran",
+  "lat": 34.6416,
+  "lng": 50.8746,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Aden, Yemen",
+  "lat": 12.7794,
+  "lng": 45.0367,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Taif, Saudi Arabia",
+  "lat": 21.2625,
+  "lng": 40.375,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Salalah, Oman",
+  "lat": 17.0151,
+  "lng": 54.0924,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Ajman, United Arab Emirates",
+  "lat": 25.4052,
+  "lng": 55.5136,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Longyearbyen, Svalbard",
+  "lat": 78.2232,
+  "lng": 15.6267,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Kiruna, Sweden",
+  "lat": 67.8558,
+  "lng": 20.2253,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Tromsø, Norway",
+  "lat": 69.6489,
+  "lng": 18.9551,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Rovaniemi, Finland",
+  "lat": 66.5039,
+  "lng": 25.7294,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Iqaluit, Canada",
+  "lat": 63.7467,
+  "lng": -68.517,
+  "region": "CANADA"
+ },
+ {
+  "name": "Yellowknife, Canada",
+  "lat": 62.454,
+  "lng": -114.3718,
+  "region": "CANADA"
+ },
+ {
+  "name": "Whitehorse, Canada",
+  "lat": 60.7212,
+  "lng": -135.0568,
+  "region": "CANADA"
+ },
+ {
+  "name": "Fairbanks, United States",
+  "lat": 64.8378,
+  "lng": -147.7164,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Nome, United States",
+  "lat": 64.5011,
+  "lng": -165.4064,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Barrow, United States",
+  "lat": 71.2906,
+  "lng": -156.7886,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Nadi, Fiji",
+  "lat": -17.7765,
+  "lng": 177.4356,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Lautoka, Fiji",
+  "lat": -17.608,
+  "lng": 177.4536,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Rarotonga, Cook Islands",
+  "lat": -21.2361,
+  "lng": -159.7777,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Avarua, Cook Islands",
+  "lat": -21.2122,
+  "lng": -159.7738,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Majuro, Marshall Islands",
+  "lat": 7.0897,
+  "lng": 171.3803,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Palikir, Micronesia",
+  "lat": 6.9147,
+  "lng": 158.1611,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Koror, Palau",
+  "lat": 7.3419,
+  "lng": 134.4797,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Yaren, Nauru",
+  "lat": -0.5477,
+  "lng": 166.9209,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Mata-Utu, Wallis and Futuna",
+  "lat": -13.2825,
+  "lng": -176.1762,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Hagåtña, Guam",
+  "lat": 13.4745,
+  "lng": 144.7504,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Saipan, Northern Mariana Islands",
+  "lat": 15.1853,
+  "lng": 145.7466,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Pago Pago, American Samoa",
+  "lat": -14.271,
+  "lng": -170.1322,
+  "region": "ASIA_PACIFIC"
+ },
+ {
+  "name": "Midway Atoll, United States",
+  "lat": 28.2072,
+  "lng": -177.3735,
+  "region": "UNBOUND"
+ },
+ {
+  "name": "Hilo, United States",
+  "lat": 19.7297,
+  "lng": -155.09,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Kailua-Kona, United States",
+  "lat": 19.64,
+  "lng": -155.9969,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Kahului, United States",
+  "lat": 20.8893,
+  "lng": -156.4729,
+  "region": "US_WEST"
+ },
+ {
+  "name": "Freeport, Bahamas",
+  "lat": 26.5285,
+  "lng": -78.6956,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Camagüey, Cuba",
+  "lat": 21.3802,
+  "lng": -77.9178,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Holguín, Cuba",
+  "lat": 20.8874,
+  "lng": -76.2624,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Santa Clara, Cuba",
+  "lat": 22.407,
+  "lng": -79.9649,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Santiago de los Caballeros, Dominican Republic",
+  "lat": 19.4517,
+  "lng": -70.697,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Cap-Haïtien, Haiti",
+  "lat": 19.7575,
+  "lng": -72.2036,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Ponce, Puerto Rico",
+  "lat": 18.0111,
+  "lng": -66.6141,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Montego Bay, Jamaica",
+  "lat": 18.4762,
+  "lng": -77.8939,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Scarborough, Trinidad and Tobago",
+  "lat": 11.1848,
+  "lng": -60.7429,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Kingstown, Saint Vincent",
+  "lat": 13.16,
+  "lng": -61.2248,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "St. John's, Antigua",
+  "lat": 17.1274,
+  "lng": -61.8468,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Charlotte Amalie, US Virgin Islands",
+  "lat": 18.342,
+  "lng": -64.9307,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Gustavia, Saint Barthélemy",
+  "lat": 17.8957,
+  "lng": -62.8509,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Marigot, Saint Martin",
+  "lat": 18.0667,
+  "lng": -63.0833,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Quetzaltenango, Guatemala",
+  "lat": 14.8444,
+  "lng": -91.5177,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Antigua, Guatemala",
+  "lat": 14.5586,
+  "lng": -90.7295,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Santa Ana, El Salvador",
+  "lat": 13.9978,
+  "lng": -89.5597,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "San Pedro Sula, Honduras",
+  "lat": 15.5,
+  "lng": -88.0333,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "León, Nicaragua",
+  "lat": 12.4379,
+  "lng": -86.8781,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Granada, Nicaragua",
+  "lat": 11.9347,
+  "lng": -85.956,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Liberia, Costa Rica",
+  "lat": 10.6298,
+  "lng": -85.4401,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Colón, Panama",
+  "lat": 9.3595,
+  "lng": -79.9003,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "David, Panama",
+  "lat": 8.427,
+  "lng": -82.428,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Belize City, Belize",
+  "lat": 17.251,
+  "lng": -88.759,
+  "region": "LATIN_AMERICA"
+ },
+ {
+  "name": "Lerwick, United Kingdom",
+  "lat": 60.1544,
+  "lng": -1.1461,
+  "region": "UK"
+ },
+ {
+  "name": "Torshavn, Faroe Islands",
+  "lat": 62.0108,
+  "lng": -6.7741,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Douglas, Isle of Man",
+  "lat": 54.1524,
+  "lng": -4.4862,
+  "region": "UK"
+ },
+ {
+  "name": "St. Helier, Jersey",
+  "lat": 49.1858,
+  "lng": -2.11,
+  "region": "UK"
+ },
+ {
+  "name": "St. Peter Port, Guernsey",
+  "lat": 49.456,
+  "lng": -2.536,
+  "region": "UK"
+ },
+ {
+  "name": "Funchal, Madeira",
+  "lat": 32.6669,
+  "lng": -16.9241,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Ponta Delgada, Azores",
+  "lat": 37.7412,
+  "lng": -25.6756,
+  "region": "WESTERN_EUROPE"
+ },
+ {
+  "name": "Las Palmas, Canary Islands",
+  "lat": 28.1235,
+  "lng": -15.4363,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Santa Cruz de Tenerife, Canary Islands",
+  "lat": 28.4636,
+  "lng": -16.2518,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Palma de Mallorca, Spain",
+  "lat": 39.5693,
+  "lng": 2.6502,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Ibiza, Spain",
+  "lat": 38.9087,
+  "lng": 1.4328,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Ceuta, Spain",
+  "lat": 35.8893,
+  "lng": -5.3213,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Melilla, Spain",
+  "lat": 35.2923,
+  "lng": -2.9381,
+  "region": "SPAIN WESTERN_EUROPE"
+ },
+ {
+  "name": "Gibraltar, Gibraltar",
+  "lat": 36.1408,
+  "lng": -5.3536,
+  "region": "UK"
+ },
+ {
+  "name": "Nosy Be, Madagascar",
+  "lat": -13.3254,
+  "lng": 48.2686,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mahé, Seychelles",
+  "lat": -4.6796,
+  "lng": 55.492,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Dzaoudzi, Mayotte",
+  "lat": -12.787,
+  "lng": 45.275,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Mamoudzou, Mayotte",
+  "lat": -12.7806,
+  "lng": 45.2278,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Jamestown, Saint Helena",
+  "lat": -15.9251,
+  "lng": -5.7179,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Georgetown, Ascension Island",
+  "lat": -7.9147,
+  "lng": -14.4076,
+  "region": "MIDDLE_EAST_AFRICA"
+ },
+ {
+  "name": "Edinburgh of the Seven Seas, Tristan da Cunha",
+  "lat": -37.0684,
+  "lng": -12.311,
+  "region": "MIDDLE_EAST_AFRICA"
+ }
 ]

--- a/app/src/main/assets/persona_distribution.json
+++ b/app/src/main/assets/persona_distribution.json
@@ -1,0 +1,1928 @@
+{
+ "version": 1,
+ "source": "US Census ACS PUMS 2022 1-Year, states=['ny', 'ma', 'fl', 'ga', 'il', 'oh', 'tx', 'az', 'ca', 'wa']",
+ "note": "Joint P(AgeRange, Profession, Region) over US adults, PWGTP-weighted, region marginals post-stratified to Census state population estimates. Within-region composition reflects only the sampled states. US-only by design (hybrid: es/fr/ru keep hand-authored templates).",
+ "dimensions": {
+  "age": [
+   "AGE_18_24",
+   "AGE_25_34",
+   "AGE_35_44",
+   "AGE_45_54",
+   "AGE_55_64",
+   "AGE_65_PLUS"
+  ],
+  "profession": [
+   "STUDENT",
+   "TEACHER",
+   "ENGINEER",
+   "HEALTHCARE",
+   "LEGAL",
+   "FINANCE_PROF",
+   "RETAIL",
+   "TRADES",
+   "CREATIVE",
+   "RETIRED",
+   "HOMEMAKER",
+   "OTHER"
+  ],
+  "region": [
+   "US_NORTHEAST",
+   "US_SOUTHEAST",
+   "US_MIDWEST",
+   "US_SOUTHWEST",
+   "US_WEST"
+  ]
+ },
+ "cells": [
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "RETIRED",
+   "region": "US_SOUTHEAST",
+   "weight": 0.05775716387156617
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "RETIRED",
+   "region": "US_MIDWEST",
+   "weight": 0.038137498133561994
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "RETIRED",
+   "region": "US_WEST",
+   "weight": 0.03424453653490644
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "RETIRED",
+   "region": "US_NORTHEAST",
+   "weight": 0.030614352605378772
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "RETIRED",
+   "region": "US_SOUTHWEST",
+   "weight": 0.02020452599102781
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "STUDENT",
+   "region": "US_SOUTHEAST",
+   "weight": 0.015135260040088938
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "OTHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.013686682458378781
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "OTHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.01360642619652561
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "OTHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.01264198274374179
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "STUDENT",
+   "region": "US_WEST",
+   "weight": 0.012232543124521319
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "OTHER",
+   "region": "US_WEST",
+   "weight": 0.011249048155731321
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "STUDENT",
+   "region": "US_MIDWEST",
+   "weight": 0.01122965280851974
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "STUDENT",
+   "region": "US_NORTHEAST",
+   "weight": 0.010928416097511318
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "OTHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.010780617115262861
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "OTHER",
+   "region": "US_WEST",
+   "weight": 0.01057422575217191
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "OTHER",
+   "region": "US_MIDWEST",
+   "weight": 0.009816144455855253
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "HOMEMAKER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.009712365220680771
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "OTHER",
+   "region": "US_WEST",
+   "weight": 0.009566095237517383
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "OTHER",
+   "region": "US_MIDWEST",
+   "weight": 0.009425946545368007
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "OTHER",
+   "region": "US_MIDWEST",
+   "weight": 0.008829616960061413
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "OTHER",
+   "region": "US_MIDWEST",
+   "weight": 0.008505236607651194
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "OTHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.008014400012449867
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "HOMEMAKER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.008008581561038532
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "OTHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.007771415026306418
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "OTHER",
+   "region": "US_WEST",
+   "weight": 0.007628200973383091
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHEAST",
+   "weight": 0.007586053728967671
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "STUDENT",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0075736689109697775
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "HOMEMAKER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.007541567475082351
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "OTHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.007415435207444663
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHEAST",
+   "weight": 0.007378964776211621
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "OTHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.006914337796396543
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "OTHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.006838880752292195
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "OTHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.006809752387761404
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "RETIRED",
+   "region": "US_SOUTHEAST",
+   "weight": 0.006720031668589371
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "HOMEMAKER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.006605406031610462
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "OTHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.006456685634184281
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "HOMEMAKER",
+   "region": "US_WEST",
+   "weight": 0.006376457950209451
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "HOMEMAKER",
+   "region": "US_MIDWEST",
+   "weight": 0.006356480551785539
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "HOMEMAKER",
+   "region": "US_WEST",
+   "weight": 0.006223068098732731
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "FINANCE_PROF",
+   "region": "US_WEST",
+   "weight": 0.006126872157737908
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHEAST",
+   "weight": 0.006091600034628865
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "HOMEMAKER",
+   "region": "US_WEST",
+   "weight": 0.0060435182105155775
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "FINANCE_PROF",
+   "region": "US_MIDWEST",
+   "weight": 0.0058425581852814094
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "OTHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.005748373981780303
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHEAST",
+   "weight": 0.005668145630062451
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "HOMEMAKER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0054744573494743785
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "HOMEMAKER",
+   "region": "US_MIDWEST",
+   "weight": 0.005461482964938675
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "OTHER",
+   "region": "US_WEST",
+   "weight": 0.005361396385959268
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "FINANCE_PROF",
+   "region": "US_MIDWEST",
+   "weight": 0.005359153002890601
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "FINANCE_PROF",
+   "region": "US_WEST",
+   "weight": 0.005305426601979955
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "OTHER",
+   "region": "US_MIDWEST",
+   "weight": 0.005303929885681282
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "HOMEMAKER",
+   "region": "US_MIDWEST",
+   "weight": 0.005266194630006405
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "HOMEMAKER",
+   "region": "US_WEST",
+   "weight": 0.00509647500869145
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "FINANCE_PROF",
+   "region": "US_NORTHEAST",
+   "weight": 0.0048445081508220475
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "STUDENT",
+   "region": "US_SOUTHEAST",
+   "weight": 0.004814362945904476
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "TRADES",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0047815127187074945
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "STUDENT",
+   "region": "US_WEST",
+   "weight": 0.004774665752567379
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "FINANCE_PROF",
+   "region": "US_WEST",
+   "weight": 0.004674451729672868
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "TRADES",
+   "region": "US_SOUTHEAST",
+   "weight": 0.004622734824905616
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "RETIRED",
+   "region": "US_MIDWEST",
+   "weight": 0.004593388115576109
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "OTHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.004524965515002229
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "FINANCE_PROF",
+   "region": "US_MIDWEST",
+   "weight": 0.004460346178877819
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "OTHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.004418328622747154
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "HOMEMAKER",
+   "region": "US_MIDWEST",
+   "weight": 0.004382657219746778
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "HOMEMAKER",
+   "region": "US_NORTHEAST",
+   "weight": 0.004371709552082948
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "FINANCE_PROF",
+   "region": "US_NORTHEAST",
+   "weight": 0.004324242904014477
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "FINANCE_PROF",
+   "region": "US_MIDWEST",
+   "weight": 0.004306883700895191
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "RETIRED",
+   "region": "US_WEST",
+   "weight": 0.004270716673912814
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "FINANCE_PROF",
+   "region": "US_NORTHEAST",
+   "weight": 0.004267484946182223
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "HOMEMAKER",
+   "region": "US_NORTHEAST",
+   "weight": 0.004231554272876551
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "HOMEMAKER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.004208710797633
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "TRADES",
+   "region": "US_SOUTHEAST",
+   "weight": 0.004110555716840629
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "FINANCE_PROF",
+   "region": "US_WEST",
+   "weight": 0.004013621772108283
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "TRADES",
+   "region": "US_MIDWEST",
+   "weight": 0.003968878832598917
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "TRADES",
+   "region": "US_MIDWEST",
+   "weight": 0.003907714604014345
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "TRADES",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0039013227184262647
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "HOMEMAKER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0038931606388752055
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0038757308719191285
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "OTHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0038550776341917813
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "HOMEMAKER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0038077156386453464
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "FINANCE_PROF",
+   "region": "US_NORTHEAST",
+   "weight": 0.0037830782227339277
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "HOMEMAKER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00374031746977635
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "RETIRED",
+   "region": "US_NORTHEAST",
+   "weight": 0.003711112659533343
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "TRADES",
+   "region": "US_WEST",
+   "weight": 0.003680132308938712
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0035742857002647593
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0035565084608951986
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "HOMEMAKER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0035394759537157503
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "TRADES",
+   "region": "US_MIDWEST",
+   "weight": 0.0035213259306930153
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "OTHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0034915764059688975
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "OTHER",
+   "region": "US_MIDWEST",
+   "weight": 0.0034895534297863795
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "STUDENT",
+   "region": "US_MIDWEST",
+   "weight": 0.0034595448654082804
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "TRADES",
+   "region": "US_MIDWEST",
+   "weight": 0.0034070055289294942
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "RETAIL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0033809014247903725
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0033729393657878897
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "RETAIL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0033535783102703505
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "TRADES",
+   "region": "US_WEST",
+   "weight": 0.0033439849044278784
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "HOMEMAKER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.003292489170156579
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "STUDENT",
+   "region": "US_NORTHEAST",
+   "weight": 0.0032213347734088306
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "RETAIL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.003182593362544503
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "RETAIL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.00313435772228183
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "TRADES",
+   "region": "US_WEST",
+   "weight": 0.0031050705480876687
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "HEALTHCARE",
+   "region": "US_MIDWEST",
+   "weight": 0.0030653104621287384
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0030240309507183344
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "OTHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0029830074671383404
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "HEALTHCARE",
+   "region": "US_MIDWEST",
+   "weight": 0.0029356016079506273
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "ENGINEER",
+   "region": "US_WEST",
+   "weight": 0.0028815257800576958
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHWEST",
+   "weight": 0.002859025165869574
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "OTHER",
+   "region": "US_WEST",
+   "weight": 0.0028386133454392916
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "HEALTHCARE",
+   "region": "US_WEST",
+   "weight": 0.0028309512202934805
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "TRADES",
+   "region": "US_SOUTHWEST",
+   "weight": 0.002736832598847245
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "TRADES",
+   "region": "US_WEST",
+   "weight": 0.0026613926979284466
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "TRADES",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0026395022013878918
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "RETIRED",
+   "region": "US_SOUTHWEST",
+   "weight": 0.002612448071700453
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.002590836760849831
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "ENGINEER",
+   "region": "US_WEST",
+   "weight": 0.002572955225368991
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "HEALTHCARE",
+   "region": "US_WEST",
+   "weight": 0.002505985304623391
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0025029237448092123
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "HEALTHCARE",
+   "region": "US_NORTHEAST",
+   "weight": 0.002483288921732474
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "STUDENT",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0024597937058896293
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "HEALTHCARE",
+   "region": "US_NORTHEAST",
+   "weight": 0.0024501640796755707
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "HOMEMAKER",
+   "region": "US_WEST",
+   "weight": 0.0024422457177040576
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "HEALTHCARE",
+   "region": "US_NORTHEAST",
+   "weight": 0.0024287114956135494
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "TRADES",
+   "region": "US_NORTHEAST",
+   "weight": 0.002343807042025781
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.00233014666663593
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "RETAIL",
+   "region": "US_WEST",
+   "weight": 0.0023090709552769733
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "HEALTHCARE",
+   "region": "US_MIDWEST",
+   "weight": 0.002306774468072295
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "HEALTHCARE",
+   "region": "US_WEST",
+   "weight": 0.002297623105576871
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "TRADES",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0022721508673358
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "TRADES",
+   "region": "US_NORTHEAST",
+   "weight": 0.0022601772374910255
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "HEALTHCARE",
+   "region": "US_NORTHEAST",
+   "weight": 0.0022306919593968124
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "HOMEMAKER",
+   "region": "US_MIDWEST",
+   "weight": 0.0022258931084754986
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "TRADES",
+   "region": "US_NORTHEAST",
+   "weight": 0.002185437909684514
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "RETAIL",
+   "region": "US_WEST",
+   "weight": 0.00217917186469477
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "TRADES",
+   "region": "US_NORTHEAST",
+   "weight": 0.002173364818654094
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "RETAIL",
+   "region": "US_MIDWEST",
+   "weight": 0.00214971918685363
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "TEACHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0021354371533844167
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0021310197728823628
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "TEACHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0020998179827995617
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "HEALTHCARE",
+   "region": "US_MIDWEST",
+   "weight": 0.0020970499900169145
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "RETAIL",
+   "region": "US_MIDWEST",
+   "weight": 0.00207219255317
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHEAST",
+   "weight": 0.002065394737179897
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "RETAIL",
+   "region": "US_MIDWEST",
+   "weight": 0.0019802947065422237
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "TRADES",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0019622758377038987
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "RETAIL",
+   "region": "US_WEST",
+   "weight": 0.001954402970162212
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "HEALTHCARE",
+   "region": "US_WEST",
+   "weight": 0.0019395547690660392
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "TEACHER",
+   "region": "US_MIDWEST",
+   "weight": 0.0019129296458665404
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "ENGINEER",
+   "region": "US_MIDWEST",
+   "weight": 0.00190050633829133
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "RETAIL",
+   "region": "US_MIDWEST",
+   "weight": 0.0018993484167664628
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "HOMEMAKER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0018923477261901195
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "TEACHER",
+   "region": "US_MIDWEST",
+   "weight": 0.0018839924294413552
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "ENGINEER",
+   "region": "US_MIDWEST",
+   "weight": 0.001860206340547355
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "TEACHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0018159740675072428
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "ENGINEER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0018157736509894738
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "TEACHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0017916755688928982
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "TRADES",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0017854896701225429
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0017784625038411758
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "RETAIL",
+   "region": "US_NORTHEAST",
+   "weight": 0.0017666074708503194
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "OTHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.001759517705622602
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "TRADES",
+   "region": "US_MIDWEST",
+   "weight": 0.0017578763784992808
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "RETAIL",
+   "region": "US_WEST",
+   "weight": 0.0017384523202501289
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "ENGINEER",
+   "region": "US_WEST",
+   "weight": 0.0017302688078902533
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0017268617792407755
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "RETAIL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0016795096150785133
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "RETAIL",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0016474882814462605
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0016392592210630343
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "RETAIL",
+   "region": "US_NORTHEAST",
+   "weight": 0.0016260433419476728
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "TEACHER",
+   "region": "US_WEST",
+   "weight": 0.0016046484928147716
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "RETAIL",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0015658976312671903
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "HOMEMAKER",
+   "region": "US_NORTHEAST",
+   "weight": 0.001562727755654009
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "TEACHER",
+   "region": "US_WEST",
+   "weight": 0.0015622007728871635
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "ENGINEER",
+   "region": "US_MIDWEST",
+   "weight": 0.0015327850914222982
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "TEACHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0015066930705591312
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "RETAIL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.00150526011542066
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "RETAIL",
+   "region": "US_NORTHEAST",
+   "weight": 0.0014951873891657693
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "FINANCE_PROF",
+   "region": "US_WEST",
+   "weight": 0.0014878067515934773
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "RETAIL",
+   "region": "US_NORTHEAST",
+   "weight": 0.0014647561451076852
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "FINANCE_PROF",
+   "region": "US_MIDWEST",
+   "weight": 0.0014641322488638186
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "TEACHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0014636397718122828
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "FINANCE_PROF",
+   "region": "US_NORTHEAST",
+   "weight": 0.0014327376022288687
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "TEACHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0014187725792707067
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "ENGINEER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0014151570652901492
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "RETAIL",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0014041714977143659
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0013888968512167942
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0013855306267399402
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "TEACHER",
+   "region": "US_MIDWEST",
+   "weight": 0.001355839532047503
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0013470855711507693
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "TRADES",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0013184962495722732
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "TRADES",
+   "region": "US_WEST",
+   "weight": 0.00130821152535771
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0013050958210802824
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "TEACHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0012622793455357596
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "ENGINEER",
+   "region": "US_WEST",
+   "weight": 0.0012564241735955627
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "TEACHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.001248404180130145
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "TEACHER",
+   "region": "US_WEST",
+   "weight": 0.0012160336662625773
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "RETAIL",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0012139867222094784
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "TEACHER",
+   "region": "US_MIDWEST",
+   "weight": 0.0012061862912307918
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "RETAIL",
+   "region": "US_MIDWEST",
+   "weight": 0.0011592850586254243
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "ENGINEER",
+   "region": "US_MIDWEST",
+   "weight": 0.0011498268958895935
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "RETAIL",
+   "region": "US_WEST",
+   "weight": 0.001146218784848932
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "TEACHER",
+   "region": "US_WEST",
+   "weight": 0.0011338755092811976
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "ENGINEER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0011133378061903582
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "TRADES",
+   "region": "US_SOUTHEAST",
+   "weight": 0.001094616114310203
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.001089284452943804
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "TEACHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0010560366544172838
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "CREATIVE",
+   "region": "US_WEST",
+   "weight": 0.0010403375096276369
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.001010208109966324
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "TEACHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.001009941022388133
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "RETAIL",
+   "region": "US_MIDWEST",
+   "weight": 0.0009876096654432489
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0009764027024357232
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "CREATIVE",
+   "region": "US_WEST",
+   "weight": 0.0009372558570557728
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "HEALTHCARE",
+   "region": "US_NORTHEAST",
+   "weight": 0.0009279765772359272
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "RETAIL",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0009195963465859446
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "HEALTHCARE",
+   "region": "US_WEST",
+   "weight": 0.0009099907061116177
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0008893156619525458
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0008886153455314884
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "CREATIVE",
+   "region": "US_NORTHEAST",
+   "weight": 0.0008860173750757554
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0008821304063073062
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "RETAIL",
+   "region": "US_NORTHEAST",
+   "weight": 0.0008697034705293379
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "TRADES",
+   "region": "US_MIDWEST",
+   "weight": 0.0008586475083232297
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "TRADES",
+   "region": "US_NORTHEAST",
+   "weight": 0.0008583999789271517
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "ENGINEER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0008443467727011714
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "RETAIL",
+   "region": "US_WEST",
+   "weight": 0.0008425390689182411
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0008122593074386667
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "FINANCE_PROF",
+   "region": "US_MIDWEST",
+   "weight": 0.0008022556478925491
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "HEALTHCARE",
+   "region": "US_MIDWEST",
+   "weight": 0.000784811073144083
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "HEALTHCARE",
+   "region": "US_MIDWEST",
+   "weight": 0.0007506469773122543
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "CREATIVE",
+   "region": "US_NORTHEAST",
+   "weight": 0.0007496860430283957
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "RETAIL",
+   "region": "US_NORTHEAST",
+   "weight": 0.0007357210200702337
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "TRADES",
+   "region": "US_WEST",
+   "weight": 0.0007133597193815393
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "TEACHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0007090806804308374
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0006986366351319248
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "FINANCE_PROF",
+   "region": "US_NORTHEAST",
+   "weight": 0.0006951406835523146
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0006810307842313055
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "CREATIVE",
+   "region": "US_WEST",
+   "weight": 0.0006702432636793708
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "TRADES",
+   "region": "US_NORTHEAST",
+   "weight": 0.0006284580997601272
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0006184332702875643
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "FINANCE_PROF",
+   "region": "US_WEST",
+   "weight": 0.0006013634788996449
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "CREATIVE",
+   "region": "US_MIDWEST",
+   "weight": 0.0005604773048216864
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "TEACHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0005582060580766325
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "HEALTHCARE",
+   "region": "US_WEST",
+   "weight": 0.0005555777473515614
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "TEACHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0005472894100635778
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "CREATIVE",
+   "region": "US_NORTHEAST",
+   "weight": 0.000538976132906509
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "HEALTHCARE",
+   "region": "US_NORTHEAST",
+   "weight": 0.0005369158511038411
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "RETAIL",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0005360171396796345
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "LEGAL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0005097657099370351
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "TEACHER",
+   "region": "US_MIDWEST",
+   "weight": 0.0005038149019786537
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "CREATIVE",
+   "region": "US_MIDWEST",
+   "weight": 0.0005029167011696445
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "CREATIVE",
+   "region": "US_WEST",
+   "weight": 0.0004977434373567364
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "FINANCE_PROF",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0004941903039432932
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "TEACHER",
+   "region": "US_WEST",
+   "weight": 0.0004887325061571507
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "TRADES",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00048315682398906285
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "ENGINEER",
+   "region": "US_WEST",
+   "weight": 0.00047178742170006814
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0004711297916922406
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "LEGAL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0004624889644662715
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00045493303490747803
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "CREATIVE",
+   "region": "US_NORTHEAST",
+   "weight": 0.0004497426825349248
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "LEGAL",
+   "region": "US_WEST",
+   "weight": 0.0004421476920309908
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "LEGAL",
+   "region": "US_NORTHEAST",
+   "weight": 0.00044116485557440057
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "CREATIVE",
+   "region": "US_MIDWEST",
+   "weight": 0.0004316125429701139
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "ENGINEER",
+   "region": "US_MIDWEST",
+   "weight": 0.0004296321725116962
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "HEALTHCARE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00042562247568015093
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.00041937102112670995
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "ENGINEER",
+   "region": "US_NORTHEAST",
+   "weight": 0.00041668197376370803
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "LEGAL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.00041340217039954424
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "LEGAL",
+   "region": "US_NORTHEAST",
+   "weight": 0.00040166676825243526
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "TEACHER",
+   "region": "US_MIDWEST",
+   "weight": 0.00039607409168353647
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0003941383761613394
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "TEACHER",
+   "region": "US_NORTHEAST",
+   "weight": 0.00039361804089882186
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0003915953944576971
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "LEGAL",
+   "region": "US_NORTHEAST",
+   "weight": 0.0003845431809742299
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "LEGAL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0003842474590859877
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "LEGAL",
+   "region": "US_MIDWEST",
+   "weight": 0.0003801878412302187
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "TEACHER",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0003749925082292452
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "ENGINEER",
+   "region": "US_WEST",
+   "weight": 0.0003726388422429918
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "LEGAL",
+   "region": "US_WEST",
+   "weight": 0.00036195040435467826
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "LEGAL",
+   "region": "US_NORTHEAST",
+   "weight": 0.00034895722407912055
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0003410892571827364
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "CREATIVE",
+   "region": "US_MIDWEST",
+   "weight": 0.0003223242300763425
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "LEGAL",
+   "region": "US_MIDWEST",
+   "weight": 0.0003179306212997437
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "TEACHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.000303512797906226
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "LEGAL",
+   "region": "US_MIDWEST",
+   "weight": 0.00029889525716664695
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "LEGAL",
+   "region": "US_WEST",
+   "weight": 0.00029655597975592406
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "LEGAL",
+   "region": "US_WEST",
+   "weight": 0.0002919428363619223
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0002833911203549443
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "ENGINEER",
+   "region": "US_MIDWEST",
+   "weight": 0.00028237052662017807
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "ENGINEER",
+   "region": "US_NORTHEAST",
+   "weight": 0.0002810721411803176
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "LEGAL",
+   "region": "US_SOUTHEAST",
+   "weight": 0.00027883367656867877
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "CREATIVE",
+   "region": "US_WEST",
+   "weight": 0.0002713877121726788
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "LEGAL",
+   "region": "US_MIDWEST",
+   "weight": 0.0002688650493955591
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "CREATIVE",
+   "region": "US_NORTHEAST",
+   "weight": 0.0002655198194014232
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "LEGAL",
+   "region": "US_NORTHEAST",
+   "weight": 0.0002462798336955745
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00024403515721806312
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00024049394432791157
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "TEACHER",
+   "region": "US_WEST",
+   "weight": 0.00023589371085003407
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "TEACHER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.0002296492676617128
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHEAST",
+   "weight": 0.0002273227102752146
+  },
+  {
+   "age": "AGE_35_44",
+   "profession": "LEGAL",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00022232277909444215
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "CREATIVE",
+   "region": "US_MIDWEST",
+   "weight": 0.00020260380176227244
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00019146495389690582
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "ENGINEER",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00018990847801020723
+  },
+  {
+   "age": "AGE_45_54",
+   "profession": "LEGAL",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00018752771459771262
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "LEGAL",
+   "region": "US_WEST",
+   "weight": 0.00018356230286451576
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "CREATIVE",
+   "region": "US_WEST",
+   "weight": 0.00018288789983762852
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "LEGAL",
+   "region": "US_MIDWEST",
+   "weight": 0.0001818910746725924
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "CREATIVE",
+   "region": "US_NORTHEAST",
+   "weight": 0.00017186117231749376
+  },
+  {
+   "age": "AGE_55_64",
+   "profession": "LEGAL",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00015839214378368302
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "CREATIVE",
+   "region": "US_MIDWEST",
+   "weight": 0.00014790012598466922
+  },
+  {
+   "age": "AGE_25_34",
+   "profession": "LEGAL",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00014715604566668727
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00010571142146465367
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "CREATIVE",
+   "region": "US_SOUTHWEST",
+   "weight": 0.00010284713743646869
+  },
+  {
+   "age": "AGE_65_PLUS",
+   "profession": "LEGAL",
+   "region": "US_SOUTHWEST",
+   "weight": 8.345565826816163e-05
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "LEGAL",
+   "region": "US_NORTHEAST",
+   "weight": 5.4016259869170303e-05
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "LEGAL",
+   "region": "US_MIDWEST",
+   "weight": 2.9012968300643754e-05
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "LEGAL",
+   "region": "US_SOUTHEAST",
+   "weight": 2.614873775240276e-05
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "LEGAL",
+   "region": "US_WEST",
+   "weight": 2.3615440445706613e-05
+  },
+  {
+   "age": "AGE_18_24",
+   "profession": "LEGAL",
+   "region": "US_SOUTHWEST",
+   "weight": 9.868425518328663e-06
+  }
+ ]
+}

--- a/app/src/main/java/com/fauxx/data/crawllist/CrawlListManager.kt
+++ b/app/src/main/java/com/fauxx/data/crawllist/CrawlListManager.kt
@@ -137,6 +137,30 @@ class CrawlListManager @Inject constructor(
         return urlsByLocale.getOrPut(locale) { loadUrls(locale) }
     }
 
+    private val hostsByLocale = ConcurrentHashMap<SupportedLocale, Set<String>>()
+
+    /**
+     * True if [host] belongs to the curated crawl corpus for the active locale (exact
+     * host or subdomain, www-insensitive). E5 (#175) uses this as the ALLOW-list for
+     * following SERP result links: the corpus is the project's only reviewed set of
+     * safe-to-visit destinations, whereas the blocklist is a finite named denylist
+     * that cannot vouch for arbitrary live-SERP results (a visited URL IS the profile
+     * entry per the QueryBlocklist threat model). Empty corpus means nothing is
+     * allowed — fail closed.
+     */
+    fun isCuratedHost(host: String): Boolean {
+        val normalized = host.lowercase().removePrefix("www.")
+        return curatedHosts().any { normalized == it || normalized.endsWith(".$it") }
+    }
+
+    private fun curatedHosts(): Set<String> =
+        hostsByLocale.getOrPut(localeManager.currentLocale) {
+            currentUrls().mapNotNullTo(mutableSetOf()) { entry ->
+                runCatching { java.net.URI(entry.url).host }.getOrNull()
+                    ?.lowercase()?.removePrefix("www.")
+            }
+        }
+
     /** Evicts entries older than 24h to prevent unbounded map growth. */
     private fun cleanupStaleEntries(now: Long) {
         if (lastVisitByDomain.size < CLEANUP_THRESHOLD) return

--- a/app/src/main/java/com/fauxx/data/db/LogMetadata.kt
+++ b/app/src/main/java/com/fauxx/data/db/LogMetadata.kt
@@ -25,6 +25,9 @@ object LogMetadata {
     const val ROUTE_DISTANCE = "Route distance"
     const val ROUTE_DURATION = "Route duration"
     const val USER_AGENT = "User-Agent"
+    // E5 (#175) intent-chain search sessions: counts only, never query/link text.
+    const val SESSION_QUERIES = "Session queries"
+    const val SESSION_LINKS = "Links followed"
 
     private val gson = Gson()
     private val mapType = object : TypeToken<LinkedHashMap<String, String>>() {}.type
@@ -44,6 +47,15 @@ object LogMetadata {
     }
 
     /** Parse a metadata JSON object back to ordered pairs. Null/blank/malformed -> empty list. */
+    /**
+     * Merge extra pairs into an existing metadata JSON, preserving order; null/blank
+     * values are dropped (E5: appends session counts after the fact, since they are
+     * only known once the session finishes but the page snapshot must be captured
+     * earlier, before the document changes).
+     */
+    fun append(json: String?, vararg pairs: Pair<String, String?>): String? =
+        toJson(*(parse(json) + pairs.toList()).toTypedArray())
+
     fun parse(json: String?): List<Pair<String, String>> {
         if (json.isNullOrBlank()) return emptyList()
         return runCatching {

--- a/app/src/main/java/com/fauxx/data/db/PhantomDatabase.kt
+++ b/app/src/main/java/com/fauxx/data/db/PhantomDatabase.kt
@@ -8,6 +8,8 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.fauxx.data.model.ActionType
 import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.engine.scheduling.CircadianUsageDao
+import com.fauxx.engine.scheduling.CircadianUsageEntity
 import com.fauxx.targeting.layer1.DemographicProfileDao
 import com.fauxx.targeting.layer1.UserDemographicProfile
 import com.fauxx.targeting.layer2.PlatformProfileCache
@@ -26,6 +28,7 @@ import com.fauxx.targeting.layer3.PersonaHistoryEntity
  * - user_demographic_profile: Optional self-reported user demographics (single row)
  * - platform_profile_cache: Cached ad-platform assigned categories
  * - persona_history: History of generated synthetic personas
+ * - circadian_usage: Locally-observed screen-on histogram by hour of day (E10 #177)
  */
 @Database(
     entities = [
@@ -33,9 +36,10 @@ import com.fauxx.targeting.layer3.PersonaHistoryEntity
         UserDemographicProfile::class,
         PlatformProfileCache::class,
         ProfileSnapshot::class,
-        PersonaHistoryEntity::class
+        PersonaHistoryEntity::class,
+        CircadianUsageEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = true
 )
 @TypeConverters(PhantomTypeConverters::class)
@@ -45,6 +49,7 @@ abstract class PhantomDatabase : RoomDatabase() {
     abstract fun platformProfileDao(): PlatformProfileDao
     abstract fun profileSnapshotDao(): ProfileSnapshotDao
     abstract fun personaHistoryDao(): PersonaHistoryDao
+    abstract fun circadianUsageDao(): CircadianUsageDao
 }
 
 /** Migration from v1 to v2: add composite index on action_log(timestamp, success). */
@@ -82,6 +87,18 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
         db.execSQL(
             "CREATE INDEX IF NOT EXISTS `index_profile_snapshot_platformName_capturedAt` " +
                 "ON `profile_snapshot` (`platformName`, `capturedAt`)"
+        )
+    }
+}
+
+/** Migration from v5 to v6: add the circadian_usage hour-of-day histogram table (issue #177 E10). */
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `circadian_usage` (" +
+                "`hourOfDay` INTEGER NOT NULL, " +
+                "`count` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`hourOfDay`))"
         )
     }
 }

--- a/app/src/main/java/com/fauxx/data/model/SyntheticPersona.kt
+++ b/app/src/main/java/com/fauxx/data/model/SyntheticPersona.kt
@@ -30,7 +30,13 @@ data class SyntheticPersona(
     val activeUntil: Long
 ) {
     companion object {
-        /** Fraction of actions that follow persona interest weights vs uniform noise. */
-        const val PERSONA_FOLLOW_FRACTION = 0.70f
+        /**
+         * Fraction of actions that follow persona interest weights vs uniform noise.
+         * Raised 0.70 -> 0.85 by E9 (#176): with credible joint-sampled personas (E7)
+         * bound across modules (E8), the persona leads and the uniform spray — the
+         * most anomalous shape, since no real person is equally interested in
+         * everything — recedes to a baseline.
+         */
+        const val PERSONA_FOLLOW_FRACTION = 0.85f
     }
 }

--- a/app/src/main/java/com/fauxx/data/model/SyntheticPersona.kt
+++ b/app/src/main/java/com/fauxx/data/model/SyntheticPersona.kt
@@ -8,9 +8,13 @@ import com.fauxx.data.querybank.CategoryPool
  *
  * @property id Unique identifier for this persona.
  * @property name Generated human-like name.
- * @property ageRange Approximate age bracket (e.g., "35-44").
- * @property profession Synthetic occupation.
- * @property region Geographic region code (e.g., "US_MIDWEST").
+ * @property ageRange Age bracket as a layer-1 AgeRange enum name (e.g., "AGE_35_44").
+ * @property profession Synthetic occupation as a Profession enum name (e.g., "FINANCE_PROF").
+ * @property region Geographic region as a Region enum name (e.g., "US_MIDWEST").
+ *   Demographics are stored as enum names so they are locale-independent on disk;
+ *   display labels resolve in the UI via DemographicLabels. Personas persisted before
+ *   this canonicalization may carry legacy display strings ("35-44") — readers must
+ *   tolerate unparseable values.
  * @property interests Set of 3-5 interest categories this persona focuses on.
  * @property createdAt Epoch millis when this persona was generated.
  * @property activeUntil Epoch millis when this persona should be rotated.

--- a/app/src/main/java/com/fauxx/data/querybank/SearchRefinements.kt
+++ b/app/src/main/java/com/fauxx/data/querybank/SearchRefinements.kt
@@ -1,0 +1,72 @@
+package com.fauxx.data.querybank
+
+import com.fauxx.locale.SupportedLocale
+import kotlin.random.Random
+
+/**
+ * E5 (#175): localized search-refinement templates for intent-chain sessions.
+ *
+ * A session starts from a goal query and narrows it the way real searchers do —
+ * "trail running shoes" -> "trail running shoes reviews" -> "best trail running shoes".
+ * Templates wrap the session's goal (occasionally a lightly reformulated version of
+ * it) so every refinement stays topically related. Safety does not depend on the
+ * transformation: EVERY refined text re-passes the QueryBlocklist dispatch gate in
+ * SearchPoisonModule before anything is dispatched.
+ *
+ * This is dispatched, user-visible corpus (queries land on real SERPs): keep entries
+ * generic, benign, commercial-intent shaped, and locale-correct. The es/fr/ru entries
+ * follow the same maintainer-review expectation as the localized query banks.
+ */
+object SearchRefinements {
+
+    private val TEMPLATES: Map<SupportedLocale, List<String>> = mapOf(
+        SupportedLocale.EN to listOf(
+            "best %s", "%s reviews", "%s price", "%s near me",
+            "how to choose %s", "%s for beginners", "is %s worth it", "%s alternatives",
+            "%s comparison", "%s buying guide", "cheap %s", "%s deals",
+            "top rated %s", "%s recommendations", "%s pros and cons", "%s tips",
+        ),
+        SupportedLocale.ES to listOf(
+            "mejor %s", "%s opiniones", "%s precio", "%s cerca de mí",
+            "cómo elegir %s", "%s para principiantes", "%s alternativas",
+            "%s comparativa", "%s barato", "%s ofertas", "%s recomendaciones",
+        ),
+        SupportedLocale.FR to listOf(
+            "meilleur %s", "%s avis", "%s prix", "%s près de chez moi",
+            "comment choisir %s", "%s pour débutants", "%s alternatives",
+            "%s comparatif", "%s pas cher", "%s promotions", "%s recommandations",
+        ),
+        SupportedLocale.RU to listOf(
+            "лучший %s", "%s отзывы", "%s цена", "%s рядом со мной",
+            "как выбрать %s", "%s для начинающих", "%s аналоги",
+            "%s сравнение", "%s недорого", "%s скидки", "%s рекомендации",
+        ),
+    )
+
+    /** Chance that a refinement reformulates (drops an edge word of) a 3+-word goal. */
+    private const val REFORMULATE_FRACTION = 0.30f
+
+    /**
+     * Build [count] distinct in-topic refinements of [goal] for [locale]. Each output
+     * contains the goal — or, ~30% of the time for 3+-word goals, the goal minus one
+     * edge word, since a chain whose every query embeds the seed verbatim under a
+     * small fixed affix set is itself a clusterable fingerprint for the search engine.
+     * Falls back to the EN templates for an unmapped locale.
+     */
+    fun refine(goal: String, locale: SupportedLocale, count: Int, random: Random): List<String> {
+        val templates = TEMPLATES[locale] ?: TEMPLATES.getValue(SupportedLocale.EN)
+        return templates.shuffled(random)
+            .take(count.coerceIn(0, templates.size))
+            .map { it.replace("%s", refinementCore(goal, random)) }
+    }
+
+    private fun refinementCore(goal: String, random: Random): String {
+        val words = goal.split(' ').filter { it.isNotBlank() }
+        if (words.size < 3 || random.nextFloat() >= REFORMULATE_FRACTION) return goal
+        return if (random.nextBoolean()) {
+            words.drop(1).joinToString(" ")
+        } else {
+            words.dropLast(1).joinToString(" ")
+        }
+    }
+}

--- a/app/src/main/java/com/fauxx/di/AppModule.kt
+++ b/app/src/main/java/com/fauxx/di/AppModule.kt
@@ -15,7 +15,9 @@ import com.fauxx.data.db.MIGRATION_1_2
 import com.fauxx.data.db.MIGRATION_2_3
 import com.fauxx.data.db.MIGRATION_3_4
 import com.fauxx.data.db.MIGRATION_4_5
+import com.fauxx.data.db.MIGRATION_5_6
 import com.fauxx.data.db.PhantomDatabase
+import com.fauxx.engine.scheduling.CircadianUsageDao
 import com.fauxx.targeting.layer1.DemographicProfileDao
 import com.fauxx.targeting.layer2.PlatformProfileDao
 import com.fauxx.targeting.layer3.PersonaHistoryDao
@@ -77,7 +79,7 @@ object AppModule {
             "phantom.db"
         )
             .openHelperFactory(factory)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
             .build()
     }
 
@@ -204,4 +206,9 @@ object AppModule {
     @Singleton
     fun providePersonaHistoryDao(db: PhantomDatabase): PersonaHistoryDao =
         db.personaHistoryDao()
+
+    @Provides
+    @Singleton
+    fun provideCircadianUsageDao(db: PhantomDatabase): CircadianUsageDao =
+        db.circadianUsageDao()
 }

--- a/app/src/main/java/com/fauxx/di/CircadianModule.kt
+++ b/app/src/main/java/com/fauxx/di/CircadianModule.kt
@@ -1,0 +1,30 @@
+package com.fauxx.di
+
+import com.fauxx.engine.scheduling.CircadianObserver
+import com.fauxx.engine.scheduling.UsageHistogram
+import com.fauxx.engine.scheduling.UsageObserver
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Exposes the single [CircadianObserver] singleton under the two roles it plays (E10 #177):
+ * the [UsageObserver] lifecycle hook the engine drives, and the [UsageHistogram] read side the
+ * rate modulator consumes. Both provider methods receive the same Hilt-managed singleton
+ * (CircadianObserver has an `@Inject` constructor and is `@Singleton`), so the engine and the
+ * modulator observe one shared histogram.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object CircadianModule {
+
+    @Provides
+    @Singleton
+    fun provideUsageObserver(observer: CircadianObserver): UsageObserver = observer
+
+    @Provides
+    @Singleton
+    fun provideUsageHistogram(observer: CircadianObserver): UsageHistogram = observer
+}

--- a/app/src/main/java/com/fauxx/di/TargetingModule.kt
+++ b/app/src/main/java/com/fauxx/di/TargetingModule.kt
@@ -12,6 +12,7 @@ import com.fauxx.targeting.layer2.AdversarialScraperLayer
 import com.fauxx.targeting.layer2.CategoryMapper
 import com.fauxx.targeting.layer2.PlatformProfileDao
 import com.fauxx.locale.LocaleManager
+import com.fauxx.targeting.layer3.PersonaDistribution
 import com.fauxx.targeting.layer3.PersonaGenerator
 import com.fauxx.targeting.layer3.PersonaHistoryDao
 import com.fauxx.targeting.layer3.PersonaRotationLayer
@@ -65,12 +66,19 @@ object TargetingModule {
 
     @Provides
     @Singleton
+    fun providePersonaDistribution(@ApplicationContext context: Context): PersonaDistribution =
+        PersonaDistribution(context)
+
+    @Provides
+    @Singleton
     fun providePersonaGenerator(
         @ApplicationContext context: Context,
         historyDao: PersonaHistoryDao,
         demographicProfileDao: DemographicProfileDao,
-        localeManager: LocaleManager
-    ): PersonaGenerator = PersonaGenerator(context, historyDao, demographicProfileDao, localeManager)
+        localeManager: LocaleManager,
+        distribution: PersonaDistribution
+    ): PersonaGenerator =
+        PersonaGenerator(context, historyDao, demographicProfileDao, localeManager, distribution)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/fauxx/di/TargetingModule.kt
+++ b/app/src/main/java/com/fauxx/di/TargetingModule.kt
@@ -11,11 +11,11 @@ import com.fauxx.targeting.layer1.SelfReportLayer
 import com.fauxx.targeting.layer2.AdversarialScraperLayer
 import com.fauxx.targeting.layer2.CategoryMapper
 import com.fauxx.targeting.layer2.PlatformProfileDao
+import com.fauxx.engine.scheduling.CompositeRateModulator
 import com.fauxx.engine.scheduling.RateModulator
 import com.fauxx.locale.LocaleManager
 import com.fauxx.targeting.layer3.PersonaDistribution
 import com.fauxx.targeting.layer3.PersonaGenerator
-import com.fauxx.targeting.layer3.PersonaRateModulator
 import com.fauxx.targeting.layer3.PersonaHistoryDao
 import com.fauxx.targeting.layer3.PersonaRotationLayer
 import dagger.Module
@@ -89,11 +89,15 @@ object TargetingModule {
         historyDao: PersonaHistoryDao
     ): PersonaRotationLayer = PersonaRotationLayer(generator, historyDao)
 
-    /** E8: the single scheduler rate-modulation seam; E10 composes into this binding. */
+    /**
+     * The single scheduler rate-modulation seam. E8 contributes the persona rhythm and E10 the
+     * observed screen-on circadian rhythm; [CompositeRateModulator] combines both into one
+     * modulation point (its dependencies — PersonaRateModulator, CircadianRateModulator — are
+     * Hilt `@Inject`-constructed).
+     */
     @Provides
     @Singleton
-    fun provideRateModulator(personaLayer: PersonaRotationLayer): RateModulator =
-        PersonaRateModulator(personaLayer)
+    fun provideRateModulator(composite: CompositeRateModulator): RateModulator = composite
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/fauxx/di/TargetingModule.kt
+++ b/app/src/main/java/com/fauxx/di/TargetingModule.kt
@@ -11,9 +11,11 @@ import com.fauxx.targeting.layer1.SelfReportLayer
 import com.fauxx.targeting.layer2.AdversarialScraperLayer
 import com.fauxx.targeting.layer2.CategoryMapper
 import com.fauxx.targeting.layer2.PlatformProfileDao
+import com.fauxx.engine.scheduling.RateModulator
 import com.fauxx.locale.LocaleManager
 import com.fauxx.targeting.layer3.PersonaDistribution
 import com.fauxx.targeting.layer3.PersonaGenerator
+import com.fauxx.targeting.layer3.PersonaRateModulator
 import com.fauxx.targeting.layer3.PersonaHistoryDao
 import com.fauxx.targeting.layer3.PersonaRotationLayer
 import dagger.Module
@@ -86,6 +88,12 @@ object TargetingModule {
         generator: PersonaGenerator,
         historyDao: PersonaHistoryDao
     ): PersonaRotationLayer = PersonaRotationLayer(generator, historyDao)
+
+    /** E8: the single scheduler rate-modulation seam; E10 composes into this binding. */
+    @Provides
+    @Singleton
+    fun provideRateModulator(personaLayer: PersonaRotationLayer): RateModulator =
+        PersonaRateModulator(personaLayer)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
+++ b/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
@@ -617,17 +617,22 @@ class PoisonEngine @Inject constructor(
 
             // Schedule next action, subtracting module execution time so the
             // inter-action interval (not post-action gap) matches the target rate.
+            // The dwell/burst state machine keys off what the module actually emitted
+            // (logEntry.category), not what was planned — a module may redirect the
+            // action (E8: AppSignal's persona-interest swap), and cross-niche pacing
+            // only protects against bot signals if it tracks the visible stream.
+            val executedCategory = logEntry.category
             val execElapsed = clock.currentTimeMillis() - execStart
             val scheduledMs = scheduler.nextDelayMs(
                 actionsPerHour = activeIntensity.actionsPerHour,
                 prev = lastCategory,
-                next = category,
+                next = executedCategory,
                 allowedStart = currentProfile.allowedHoursStart,
                 allowedEnd = currentProfile.allowedHoursEnd
             )
             // Update lastCategory only on success — failed actions shouldn't poison the
             // dwell signal (a circuit-broken module isn't really "browsing" anything).
-            if (logEntry.success) lastCategory = category
+            if (logEntry.success) lastCategory = executedCategory
             val effectiveDelay = maxOf(0L, scheduledMs - execElapsed)
             Timber.d("Action: $moduleName/$category exec=${execElapsed}ms scheduled=${scheduledMs}ms effective=${effectiveDelay}ms")
             sleepRespectingConstraints(effectiveDelay)

--- a/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
+++ b/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
@@ -35,6 +35,7 @@ import com.fauxx.engine.modules.SearchPoisonModule
 import com.fauxx.engine.scheduling.ActionDispatcher
 import com.fauxx.engine.scheduling.AllowedHours
 import com.fauxx.engine.scheduling.PoissonScheduler
+import com.fauxx.engine.scheduling.UsageObserver
 import com.fauxx.targeting.TargetingEngine
 import dagger.hilt.android.qualifiers.ApplicationContext
 import androidx.datastore.preferences.core.edit
@@ -167,6 +168,12 @@ class PoisonEngine @Inject constructor(
      */
     @IoDispatcher private val loopDispatcher: CoroutineDispatcher,
     private val random: Random = Random.Default,
+    /**
+     * Observes local screen-on events to learn the user's daily rhythm (E10 #177). Registered
+     * and unregistered alongside the constraint receivers so it only runs while the engine is
+     * active. Defaults to a no-op so engine tests need not stand one up.
+     */
+    private val usageObserver: UsageObserver = UsageObserver.NONE,
 ) {
     private var scope = CoroutineScope(SupervisorJob() + loopDispatcher)
     private var engineJob: Job? = null
@@ -462,6 +469,9 @@ class PoisonEngine @Inject constructor(
             // WiFi→mobile move would keep the engine acting at the WiFi tier. Surface it.
             Timber.w(it, "registerDefaultNetworkCallback failed; transport tracking degraded")
         }
+        // Start learning the user's daily rhythm while the engine runs (E10 #177).
+        runCatching { usageObserver.start() }
+            .onFailure { Timber.w(it, "usageObserver.start failed; circadian rhythm degraded") }
     }
 
     private fun unregisterConstraintReceivers() {
@@ -470,6 +480,7 @@ class PoisonEngine @Inject constructor(
             context.getSystemService(ConnectivityManager::class.java)
                 .unregisterNetworkCallback(networkCallback)
         }
+        runCatching { usageObserver.stop() }
     }
 
     private suspend fun runLoop() {

--- a/app/src/main/java/com/fauxx/engine/modules/AppSignalModule.kt
+++ b/app/src/main/java/com/fauxx/engine/modules/AppSignalModule.kt
@@ -10,6 +10,8 @@ import com.fauxx.engine.webview.PhantomWebViewPool
 import com.fauxx.engine.webview.SYNTHETIC_WEBVIEW_HEADERS
 import com.fauxx.locale.LocaleManager
 import com.fauxx.locale.SupportedLocale
+import com.fauxx.targeting.layer3.PersonaChannel
+import com.fauxx.targeting.layer3.PersonaRotationLayer
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -188,8 +190,20 @@ class AppSignalModule @Inject constructor(
     private val profileRepo: PoisonProfileRepository,
     private val webViewPool: PhantomWebViewPool,
     private val localeManager: LocaleManager,
+    private val personaLayer: PersonaRotationLayer,
     private val random: Random = Random.Default,
 ) : Module {
+
+    companion object {
+        /**
+         * E8 (#174): probability that an off-interest action is redirected to one of
+         * the active persona's interests. App-store searches are among the
+         * highest-value identity signals brokers ingest, so they get concentrated on
+         * the persona beyond the engine-wide Layer 3 category weighting — while most
+         * actions still follow the engine distribution so Layer 0's entropy survives.
+         */
+        internal const val PERSONA_INTEREST_SWAP_FRACTION = 0.35f
+    }
 
     override suspend fun start() {
         webViewPool.initialize()
@@ -199,9 +213,23 @@ class AppSignalModule @Inject constructor(
     override fun isEnabled(): Boolean = profileRepo.getProfile().appSignalEnabled
 
     override suspend fun onAction(category: CategoryPool): ActionLogEntity {
+        val persona = personaLayer.personaForChannel(PersonaChannel.APP_SIGNAL)
+        // filterNotNull: personas restored from persisted JSON can carry a null Set
+        // element when an interest name no longer parses (Gson skips Kotlin null
+        // checks); contains/isNotEmpty tolerated that, random() would NPE.
+        val interestPool = persona?.interests?.filterNotNull().orEmpty()
+        val effectiveCategory = if (
+            interestPool.isNotEmpty() && category !in interestPool &&
+            random.nextFloat() < PERSONA_INTEREST_SWAP_FRACTION
+        ) {
+            interestPool.random(random)
+        } else {
+            category
+        }
+
         val locale = localeManager.currentLocale
-        val keywords = CATEGORY_APP_KEYWORDS[locale]?.get(category)
-            ?: CATEGORY_APP_KEYWORDS[SupportedLocale.EN]?.get(category)
+        val keywords = CATEGORY_APP_KEYWORDS[locale]?.get(effectiveCategory)
+            ?: CATEGORY_APP_KEYWORDS[SupportedLocale.EN]?.get(effectiveCategory)
             ?: DEFAULT_KEYWORDS
         val url = "https://play.google.com/store/search?q=$keywords&c=apps&hl=${locale.tag}"
         // Defensive precondition: URL is internally constructed but assert host so any
@@ -247,7 +275,9 @@ class AppSignalModule @Inject constructor(
 
         return ActionLogEntity(
             actionType = ActionType.DEEP_LINK_VISIT,
-            category = category,
+            // The category actually searched for (post persona swap), so the action
+            // log and any distribution built from it stay honest.
+            category = effectiveCategory,
             detail = url,
             metadata = metadata,
             success = success

--- a/app/src/main/java/com/fauxx/engine/modules/AppSignalModule.kt
+++ b/app/src/main/java/com/fauxx/engine/modules/AppSignalModule.kt
@@ -201,8 +201,14 @@ class AppSignalModule @Inject constructor(
          * highest-value identity signals brokers ingest, so they get concentrated on
          * the persona beyond the engine-wide Layer 3 category weighting — while most
          * actions still follow the engine distribution so Layer 0's entropy survives.
+         *
+         * Lowered 0.35 -> 0.25 with E9 (#176): the rebalanced engine distribution
+         * already lands ~half the stream on persona interests, so the old swap rate
+         * would have pushed the joint app-store concentration to ~57-66% of actions
+         * hitting 3-5 fixed search URLs. 0.25 keeps the joint concentration within
+         * the pre-E9 envelope.
          */
-        internal const val PERSONA_INTEREST_SWAP_FRACTION = 0.35f
+        internal const val PERSONA_INTEREST_SWAP_FRACTION = 0.25f
     }
 
     override suspend fun start() {

--- a/app/src/main/java/com/fauxx/engine/modules/LocationSpoofModule.kt
+++ b/app/src/main/java/com/fauxx/engine/modules/LocationSpoofModule.kt
@@ -12,6 +12,8 @@ import com.fauxx.data.location.FakeRouteGenerator
 import com.fauxx.data.model.ActionType
 import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.engine.PoisonProfileRepository
+import com.fauxx.targeting.layer3.PersonaChannel
+import com.fauxx.targeting.layer3.PersonaRotationLayer
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,6 +38,7 @@ class LocationSpoofModule @Inject constructor(
     private val routeGenerator: FakeRouteGenerator,
     private val cityDatabase: CityDatabase,
     private val profileRepo: PoisonProfileRepository,
+    private val personaLayer: PersonaRotationLayer,
     private val random: Random = Random.Default,
 ) : Module, LocationDiagnostics {
 
@@ -135,7 +138,12 @@ class LocationSpoofModule @Inject constructor(
         }
 
         val mode = FakeRouteGenerator.MovementMode.values().random(random)
-        val city = cityDatabase.randomCity()
+        // E8 (#174): bind spoofed locations to the active persona's region so the
+        // location story corroborates the demographic one. Null persona (Layer 3 off,
+        // or none generated yet) keeps the unbound any-city behavior; an unmatched
+        // region hint falls back to the full list inside randomCity.
+        val persona = personaLayer.personaForChannel(PersonaChannel.LOCATION)
+        val city = cityDatabase.randomCity(regionHint = persona?.region)
         val route = routeGenerator.generateRoute(origin = city, mode = mode, count = 5)
 
         var lastTime = route.firstOrNull()?.time ?: 0L

--- a/app/src/main/java/com/fauxx/engine/modules/SearchPoisonModule.kt
+++ b/app/src/main/java/com/fauxx/engine/modules/SearchPoisonModule.kt
@@ -8,6 +8,7 @@ import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.data.querybank.MarkovQueryGenerator
 import com.fauxx.data.querybank.QueryBankManager
 import com.fauxx.data.querybank.QueryBlocklist
+import com.fauxx.data.querybank.SearchRefinements
 import com.fauxx.engine.PoisonProfileRepository
 import com.fauxx.locale.LocaleManager
 import com.fauxx.locale.SupportedLocale
@@ -20,10 +21,12 @@ import com.fauxx.locale.AcceptLanguageVariants
 import com.fauxx.network.UserAgentPool
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.resume
 import kotlin.random.Random
 
 /**
@@ -68,20 +71,39 @@ private val SEARCH_ENGINES = listOf(
 )
 
 /**
- * Executes synthetic search queries across multiple search engines.
- * Follows 1-3 result links with random dwell time (2-30 seconds).
+ * Executes synthetic search activity as intent-chain SESSIONS (E5 #175): one onAction
+ * call runs a whole session — a goal query, then in-topic refinements built from
+ * [SearchRefinements] (so successive queries narrow the same subject instead of being
+ * independently category-random), then 1-2 organic result links followed from the final
+ * SERP via [SerpLinkSelector]. Independent single queries were themselves a
+ * bot-detectable shape: real search behavior moves through coherent narrowing sessions.
+ *
+ * Topic switches are session BOUNDARIES: the next onAction (usually a different
+ * category from the dispatcher) starts a new chain, and the engine schedules that
+ * transition through PoissonScheduler's cross-niche dwell handling, so a switch reads
+ * as a deliberate pause rather than an instant pivot. Session size scales DOWN with the
+ * configured intensity so long sessions can't starve the displayed actions/hour at
+ * aggressive tiers (issue #76); the whole session is also wall-clock budgeted.
  *
  * Query selection is category-weighted via the ActionDispatcher. Search-engine URLs are
  * locale-aware via [LocaleManager]: in Spanish or French mode the `hl=`/`setmkt`/`kl`
  * parameters and the Yahoo subdomain switch so the dispatched query lands on the
  * region-localized SERP rather than the English default.
  *
- * **Safety**: final dispatch gate. Every query is checked through [QueryBlocklist]
- * one last time before the HTTP request is built. If a query reaches this point
- * and matches the blocklist, that represents an invariant violation (upstream
- * filters failed) and the cycle is DROPPED rather than dispatched — a missing
- * action is cheaper than a false user-signal (e.g. 988 crisis-line query that
- * could trigger a welfare check or insurance flag).
+ * **Safety**: final dispatch gate. EVERY query in a session — goal and each refinement —
+ * is checked through [QueryBlocklist] one last time before its request is built. A
+ * blocked goal drops the whole cycle (an invariant violation: upstream filters failed);
+ * a blocked refinement is skipped without dispatch while the session continues, since
+ * its goal already passed. A missing action is cheaper than a false user-signal (e.g.
+ * a 988 crisis-line query that could trigger a welfare check or insurance flag).
+ * Followed links are ALLOW-listed to curated crawl-corpus hosts (the denylist alone
+ * cannot vouch for arbitrary live-SERP destinations, and a visited URL is itself a
+ * profile entry), re-gated through [DomainBlocklist], navigated by clicking the SERP's
+ * own anchor, and re-checked by PhantomWebViewClient on every navigation/redirect.
+ * Documented residual: the allow-list guarantee is FIRST-HOP strong — once a curated
+ * page is open, its own redirects/JS navigations are gated by the denylist only, the
+ * same trust extended to every other module that loads corpus pages. The corpus
+ * (reviewed editorial publishers, no open redirectors or UGC hosts) is the trust root.
  */
 @Singleton
 class SearchPoisonModule @Inject constructor(
@@ -95,6 +117,8 @@ class SearchPoisonModule @Inject constructor(
     private val customInterestMapper: CustomInterestMapper,
     private val queryBlocklist: QueryBlocklist,
     private val localeManager: LocaleManager,
+    private val crawlListManager: com.fauxx.data.crawllist.CrawlListManager,
+    private val clock: com.fauxx.util.Clock = com.fauxx.util.SystemClockImpl(),
     private val random: Random = Random.Default,
 ) : Module {
 
@@ -132,21 +156,21 @@ class SearchPoisonModule @Inject constructor(
     override fun isEnabled(): Boolean = profileRepo.getProfile().searchPoisonEnabled
 
     override suspend fun onAction(category: CategoryPool): ActionLogEntity {
-        // Use Markov generator 60% of the time for natural-looking queries
-        val query = if (random.nextFloat() < 0.60f) {
+        // Session goal. Use Markov generator 60% of the time for natural-looking queries.
+        val goal = if (random.nextFloat() < 0.60f) {
             markovGenerator.generate(category)
         } else {
             queryBankManager.randomQuery(category)
         }
 
-        // Final safety gate. If a query reaches here matching the blocklist, upstream
-        // filters (QueryBankManager load-time filter + MarkovQueryGenerator resample)
-        // have failed — log the invariant violation and drop the cycle. Do NOT dispatch.
-        if (query.isBlank() || queryBlocklist.isBlocked(query)) {
+        // Final safety gate on the goal. If a query reaches here matching the blocklist,
+        // upstream filters (QueryBankManager load-time filter + MarkovQueryGenerator
+        // resample) have failed — log the invariant violation and drop the cycle.
+        if (goal.isBlank() || queryBlocklist.isBlocked(goal)) {
             Timber.e(
                 "QueryBlocklist invariant violation — query '%s' escaped upstream " +
                     "guards; dropping action cycle (category=%s)",
-                query,
+                goal,
                 category
             )
             return ActionLogEntity(
@@ -156,20 +180,22 @@ class SearchPoisonModule @Inject constructor(
             )
         }
 
-        val encodedQuery = java.net.URLEncoder.encode(query, "UTF-8")
+        val locale = localeManager.currentLocale
         val engine = SEARCH_ENGINES.random(random)
-        val url = engine.build(encodedQuery, localeManager.currentLocale)
+        val goalUrl = engine.build(java.net.URLEncoder.encode(goal, "UTF-8"), locale)
         // Engine name suffix surfaces which SERP each search actually hit, so the user
         // can verify newly-added engines (e.g. Yandex per #24) are actually firing.
-        val detail = "[$category] $query · via ${engine.name}"
+        // The detail carries only the GOAL query (LogScrubber's export coarsening is
+        // keyed to this exact shape); refinement texts are never logged.
+        val detail = "[$category] $goal · via ${engine.name}"
 
-        // Defensive blocklist gate. The search path now runs through the WebView, so the
+        // Defensive blocklist gate. The search path runs through the WebView, so the
         // OkHttp BlocklistInterceptor no longer covers it (#165), and Android does NOT fire
         // shouldOverrideUrlLoading for a programmatic main-frame loadUrl (only
         // shouldInterceptRequest gates subresources). isUrlBlocked fails closed on an
         // unparseable URL or a failed blocklist load. SERP hosts are not blocklisted today;
         // this is defense-in-depth.
-        if (blocklist.isUrlBlocked(url)) {
+        if (blocklist.isUrlBlocked(goalUrl)) {
             Timber.w("Search URL gated by blocklist (engine=${engine.name})")
             return ActionLogEntity(
                 actionType = ActionType.SEARCH_QUERY,
@@ -179,12 +205,30 @@ class SearchPoisonModule @Inject constructor(
             )
         }
 
-        // Route the search through the real Chromium WebView so the TLS handshake (JA3/JA4),
-        // HTTP/2 SETTINGS, and header order are genuinely Chrome's and coherent with the
-        // Chromium UA (#168/#169). Accept-Language is locale-coherent with the SERP hl/gl
-        // params; Sec-GPC rides along via SYNTHETIC_WEBVIEW_HEADERS.
+        // Session plan, scaled down at aggressive tiers so a long session can't starve
+        // the displayed actions/hour (issue #76). The module can't see which transport
+        // the engine is currently pacing on, so it sizes against the HIGHEST configured
+        // tier (Wi-Fi or mobile) — the conservative direction for rate honesty.
+        val profile = profileRepo.getProfile()
+        val configuredCeiling = maxOf(
+            profile.intensity.actionsPerHour,
+            profile.mobileIntensity?.actionsPerHour ?: 0
+        )
+        val (maxRefinements, maxLinks) = sessionBounds(configuredCeiling)
+        val refinements = if (maxRefinements > 0) {
+            SearchRefinements.refine(goal, locale, random.nextInt(1, maxRefinements + 1), random)
+        } else {
+            emptyList()
+        }
+
+        // Route the session through the real Chromium WebView so the TLS handshake
+        // (JA3/JA4), HTTP/2 SETTINGS, and header order are genuinely Chrome's and
+        // coherent with the Chromium UA (#168/#169). Accept-Language is locale-coherent
+        // with the SERP hl/gl params; Sec-GPC rides along via SYNTHETIC_WEBVIEW_HEADERS.
+        // One WebView is held for the whole session: queries and clicks share history
+        // and cookies, like one human tab.
         val headers = SYNTHETIC_WEBVIEW_HEADERS +
-            ("Accept-Language" to AcceptLanguageVariants.forLocale(localeManager.currentLocale, random))
+            ("Accept-Language" to AcceptLanguageVariants.forLocale(locale, random))
 
         val webView = try {
             webViewPool.acquire()
@@ -193,21 +237,82 @@ class SearchPoisonModule @Inject constructor(
             null
         }
         var metadata: String? = null
+        var queriesDispatched = 0
+        var linksFollowed = 0
         val success = if (webView == null) {
             false
         } else {
             try {
-                withTimeoutOrNull(SEARCH_LOAD_TIMEOUT_MS) {
-                    withContext(Dispatchers.Main) { webView.loadUrl(url, headers) }
-                    delay(random.nextLong(2_000L, 8_000L))
-                    // Read metadata on Main before release() wipes the document (issue #73).
-                    metadata = withContext(Dispatchers.Main) {
-                        webViewPool.captureMetadata(webView, url, LogMetadata.SEARCH_ENGINE to engine.name)
+                val deadline = clock.currentTimeMillis() + SESSION_BUDGET_MS
+                val goalOk = loadWithDwell(webView, goalUrl, headers, QUERY_DWELL_MS)
+                if (goalOk) {
+                    queriesDispatched = 1
+
+                    // Snapshot page metadata NOW, while the document is the goal SERP:
+                    // its title only echoes the goal (already in the detail line). A
+                    // later snapshot would log the title of a refinement SERP or a
+                    // followed third-party page — text this module promises never to
+                    // log. Session counts are appended after the session ends.
+                    metadata = withTimeoutOrNull(METADATA_TIMEOUT_MS) {
+                        withContext(Dispatchers.Main) {
+                            webViewPool.captureMetadata(
+                                webView, goalUrl,
+                                LogMetadata.SEARCH_ENGINE to engine.name,
+                            )
+                        }
                     }
-                    true
-                } ?: false
+
+                    for (refinement in refinements) {
+                        if (clock.currentTimeMillis() > deadline) break
+                        // Final safety gate on EVERY query in the chain. A blocked
+                        // refinement is skipped (its goal already passed); query text is
+                        // never logged from this path.
+                        if (refinement.isBlank() || queryBlocklist.isBlocked(refinement)) {
+                            Timber.w("Refinement suppressed by safety guard (category=%s)", category)
+                            continue
+                        }
+                        val url = engine.build(java.net.URLEncoder.encode(refinement, "UTF-8"), locale)
+                        if (blocklist.isUrlBlocked(url)) continue
+                        if (loadWithDwell(webView, url, headers, QUERY_DWELL_MS)) {
+                            queriesDispatched++
+                        }
+                    }
+
+                    // Click 1-2 results on the final (most narrowed) SERP. Candidates
+                    // are ALLOW-listed to curated crawl-corpus hosts — live SERPs
+                    // surface arbitrary destinations and the denylist cannot vouch for
+                    // them (a visited URL is itself a profile entry). The click runs
+                    // the SERP's own anchor, so its instrumentation and referrer
+                    // semantics are genuine, and PhantomWebViewClient re-gates the
+                    // resulting navigation.
+                    if (maxLinks > 0 && clock.currentTimeMillis() < deadline) {
+                        val hrefs = collectSerpLinks(webView)
+                        val links = SerpLinkSelector.select(
+                            hrefs, random,
+                            max = random.nextInt(1, maxLinks + 1),
+                            isAllowed = crawlListManager::isCuratedHost,
+                            isBlocked = blocklist::isUrlBlocked,
+                        )
+                        for (link in links) {
+                            if (clock.currentTimeMillis() > deadline) break
+                            if (clickResultLink(webView, link)) {
+                                linksFollowed++
+                                delay(random.nextLong(LINK_DWELL_MS.first, LINK_DWELL_MS.last + 1))
+                            }
+                        }
+                    }
+
+                    metadata = LogMetadata.append(
+                        metadata,
+                        LogMetadata.SESSION_QUERIES to queriesDispatched.toString(),
+                        LogMetadata.SESSION_LINKS to linksFollowed.takeIf { it > 0 }?.toString(),
+                    )
+                }
+                goalOk
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e // engine stop/teardown must abort the session immediately
             } catch (e: Exception) {
-                Timber.w("Search WebView load failed: ${e.message}")
+                Timber.w("Search WebView session failed: ${e.message}")
                 false
             } finally {
                 webViewPool.release(webView)
@@ -223,8 +328,79 @@ class SearchPoisonModule @Inject constructor(
         )
     }
 
+    /** Load [url] in [webView] and dwell like a human scanning it. False on timeout/throw. */
+    private suspend fun loadWithDwell(
+        webView: android.webkit.WebView,
+        url: String,
+        headers: Map<String, String>,
+        dwellMs: LongRange,
+    ): Boolean = try {
+        withTimeoutOrNull(SEARCH_LOAD_TIMEOUT_MS) {
+            withContext(Dispatchers.Main) { webView.loadUrl(url, headers) }
+            delay(random.nextLong(dwellMs.first, dwellMs.last + 1))
+            true
+        } ?: false
+    } catch (e: kotlinx.coroutines.CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Timber.w("Search WebView load failed: ${e.message}")
+        false
+    }
+
+    /** Harvest anchor hrefs from the loaded SERP; empty on timeout or eval failure. */
+    private suspend fun collectSerpLinks(webView: android.webkit.WebView): List<String> =
+        withTimeoutOrNull(SERP_EXTRACT_TIMEOUT_MS) {
+            withContext(Dispatchers.Main) {
+                suspendCancellableCoroutine { cont ->
+                    webView.evaluateJavascript(SerpLinkSelector.COLLECT_LINKS_JS) { result ->
+                        if (cont.isActive) cont.resume(SerpLinkSelector.parseHrefs(result))
+                    }
+                }
+            }
+        } ?: emptyList()
+
+    /** Click the SERP anchor for [href]; true if the anchor was found and clicked. */
+    private suspend fun clickResultLink(webView: android.webkit.WebView, href: String): Boolean =
+        withTimeoutOrNull(SERP_EXTRACT_TIMEOUT_MS) {
+            withContext(Dispatchers.Main) {
+                suspendCancellableCoroutine { cont ->
+                    webView.evaluateJavascript(SerpLinkSelector.buildClickJs(href)) { result ->
+                        if (cont.isActive) cont.resume(result?.contains("clicked") == true)
+                    }
+                }
+            }
+        } ?: false
+
     companion object {
         /** Bounds a wedged SERP render so it can't hold a pool slot (replaces the OkHttp readTimeout). */
         private const val SEARCH_LOAD_TIMEOUT_MS = 30_000L
+
+        /** Whole-session wall-clock budget; steps are trimmed once it is exhausted. */
+        private const val SESSION_BUDGET_MS = 60_000L
+
+        /** Bounds the SERP link-harvest / click JS evaluations. */
+        private const val SERP_EXTRACT_TIMEOUT_MS = 5_000L
+
+        /** Bounds the main-thread metadata snapshot. */
+        private const val METADATA_TIMEOUT_MS = 5_000L
+
+        /** Dwell after each SERP load (scanning results / typing the next refinement). */
+        private val QUERY_DWELL_MS = 2_000L..8_000L
+
+        /** Dwell on a followed result page. */
+        private val LINK_DWELL_MS = 3_000L..12_000L
+
+        /**
+         * Session size by the highest configured intensity tier (issue #76 honesty):
+         * full narrative sessions at MEDIUM, a slimmer shape at LOW (documented as the
+         * battery-sensitive tier — fewer extra page loads), 1+1 at HIGH, and the
+         * pre-E5 single query at EXTREME where the mean gap (~7s) can't fit a session.
+         */
+        internal fun sessionBounds(actionsPerHour: Int): Pair<Int, Int> = when {
+            actionsPerHour <= 12 -> 2 to 1   // LOW: battery-sensitive
+            actionsPerHour <= 60 -> 3 to 2   // MEDIUM
+            actionsPerHour <= 200 -> 1 to 1  // HIGH
+            else -> 0 to 0                   // EXTREME
+        }
     }
 }

--- a/app/src/main/java/com/fauxx/engine/modules/SerpLinkSelector.kt
+++ b/app/src/main/java/com/fauxx/engine/modules/SerpLinkSelector.kt
@@ -1,0 +1,107 @@
+package com.fauxx.engine.modules
+
+import com.google.gson.Gson
+import java.net.URI
+import kotlin.random.Random
+
+/**
+ * E5 (#175): selects result links from a SERP's anchor list that fauxx is willing to
+ * visit, and builds the JS that "clicks" them.
+ *
+ * Pure logic, separated from the WebView so the gating is unit-testable. Two gates,
+ * both required:
+ *  - [select]'s `isAllowed` is the PRIMARY gate: an ALLOW-list of curated-corpus hosts
+ *    (CrawlListManager.isCuratedHost). Live SERPs surface arbitrary destinations, and
+ *    fauxx's blocklist is a finite named denylist, not a content classifier — a visited
+ *    URL is itself a profile entry, so only destinations already reviewed for page
+ *    visits may be navigated to.
+ *  - `isBlocked` (DomainBlocklist.isUrlBlocked) re-gates the survivors as
+ *    defense-in-depth, and PhantomWebViewClient re-checks every navigation/redirect.
+ *
+ * Engines that wrap organic results in same-host redirectors (Bing's /ck/a, Yahoo)
+ * yield no followable candidates — the wrapper host is engine-family and is excluded —
+ * so sessions on those engines simply skip the click step. Candidates keep DOM order
+ * and the pick is position-biased toward the top, like real click-through curves.
+ */
+object SerpLinkSelector {
+
+    private val gson = Gson()
+
+    /**
+     * Search-engine and ad/infra domain FAMILIES, matched against whole host labels
+     * ("blog.google" and "ads.google.com" match "google"; "googleblog.com" does not).
+     */
+    private val ENGINE_HOST_FAMILIES = setOf(
+        "google", "gstatic", "googleadservices", "googlesyndication", "doubleclick",
+        "youtube", "bing", "microsoft", "msn", "live",
+        "duckduckgo", "yahoo", "yimg", "yandex",
+    )
+
+    /** Probability of advancing past each candidate: ~55% of clicks land on the first. */
+    private const val POSITION_ADVANCE_P = 0.45f
+
+    /**
+     * Parse the result of evaluating the link-collection JS. `evaluateJavascript`
+     * yields a JSON-encoded STRING whose content is itself a JSON array of hrefs;
+     * either decode step failing yields an empty list, never a throw.
+     */
+    fun parseHrefs(evalResult: String?): List<String> = runCatching {
+        val inner: String = gson.fromJson(evalResult, String::class.java) ?: return emptyList()
+        gson.fromJson(inner, Array<String>::class.java)?.toList().orEmpty()
+    }.getOrDefault(emptyList())
+
+    /**
+     * Pick up to [max] result links: http(s) only, parseable host, no engine/ad-infra
+     * host families, one link per host, [isAllowed] host allow-list, [isBlocked] URL
+     * denylist, position-biased toward earlier (higher-ranked) results.
+     */
+    fun select(
+        hrefs: List<String>,
+        random: Random,
+        max: Int,
+        isAllowed: (host: String) -> Boolean,
+        isBlocked: (url: String) -> Boolean,
+    ): List<String> {
+        if (max <= 0) return emptyList()
+        val pool = hrefs.asSequence()
+            .filter { it.startsWith("https://") || it.startsWith("http://") }
+            .mapNotNull { href ->
+                val host = runCatching { URI(href).host }.getOrNull() ?: return@mapNotNull null
+                href to host.lowercase()
+            }
+            .filterNot { (_, host) -> host.split('.').any { it in ENGINE_HOST_FAMILIES } }
+            .distinctBy { (_, host) -> host }
+            .filter { (_, host) -> isAllowed(host) }
+            .map { (href, _) -> href }
+            .filterNot(isBlocked)
+            .toMutableList()
+
+        val picked = mutableListOf<String>()
+        while (picked.size < max && pool.isNotEmpty()) {
+            var index = 0
+            while (index < pool.size - 1 && random.nextFloat() < POSITION_ADVANCE_P) index++
+            picked += pool.removeAt(index)
+        }
+        return picked
+    }
+
+    /** Collects up to 60 absolute http(s) anchor hrefs from the loaded document. */
+    const val COLLECT_LINKS_JS =
+        "(function(){var a=[];var l=document.links;" +
+            "for(var i=0;i<l.length&&a.length<60;i++){var h=l[i].href;" +
+            "if(h&&h.indexOf('http')===0){a.push(h);}}return JSON.stringify(a);})()"
+
+    /**
+     * JS that CLICKS the anchor whose resolved href equals [href], rather than
+     * loading the URL programmatically: a real click fires the SERP's own click
+     * instrumentation (ping attributes, beacons, redirect interstitials) and produces
+     * genuine navigation/referrer semantics — a direct loadUrl of a harvested href is
+     * an impression with no click, which is itself a bot tell. The resulting
+     * navigation still passes PhantomWebViewClient's blocklist re-gate.
+     */
+    fun buildClickJs(href: String): String {
+        val escaped = href.replace("\\", "\\\\").replace("'", "\\'")
+        return "(function(){var l=document.links;for(var i=0;i<l.length;i++){" +
+            "if(l[i].href==='$escaped'){l[i].click();return 'clicked';}}return 'missing';})()"
+    }
+}

--- a/app/src/main/java/com/fauxx/engine/scheduling/CircadianObserver.kt
+++ b/app/src/main/java/com/fauxx/engine/scheduling/CircadianObserver.kt
@@ -1,0 +1,296 @@
+package com.fauxx.engine.scheduling
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import androidx.annotation.VisibleForTesting
+import com.fauxx.util.Clock
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import timber.log.Timber
+import java.util.Calendar
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Hours in a day — the fixed size of the circadian histogram. */
+internal const val HOURS_PER_DAY = 24
+
+/**
+ * Lifecycle hook the engine drives so observers register/unregister their receivers in step
+ * with the foreground service (E10 #177). [com.fauxx.engine.PoisonEngine] calls [start] when
+ * it begins running and [stop] when it stops or is destroyed.
+ */
+interface UsageObserver {
+    fun start()
+    fun stop()
+
+    companion object {
+        /** No-op observer — the engine's default when circadian observation is not wired. */
+        val NONE: UsageObserver = object : UsageObserver {
+            override fun start() {}
+            override fun stop() {}
+        }
+    }
+}
+
+/**
+ * Read side of the circadian signal: a synchronous, 24-length snapshot of per-hour
+ * observation counts. [CircadianRateModulator] reads this from the scheduler thread, which is
+ * why it must be non-suspending — the source of truth is an in-memory array kept fresh by
+ * [CircadianObserver], with the DB as the durable backing store.
+ */
+interface UsageHistogram {
+    /** Per-hour-of-day (0-23) observation counts. Always length [HOURS_PER_DAY]. */
+    fun hourlyCounts(): LongArray
+}
+
+/**
+ * Learns the user's own daily rhythm from locally-observed screen-on events and exposes it as
+ * a 24-bucket histogram (E10 #177).
+ *
+ * How it works:
+ * - While the engine runs, a dynamically-registered [Intent.ACTION_SCREEN_ON] receiver fires
+ *   each time the screen turns on. We bump the bucket for the current local hour. We store ONLY
+ *   the per-hour aggregate count, never an event timestamp, so the persisted footprint is a
+ *   coarse rhythm and nothing about any individual unlock.
+ * - The histogram is held in memory (the scheduler's synchronous read path) and mirrored to
+ *   the SQLCipher-encrypted [CircadianUsageDao] so a learned rhythm survives restarts.
+ * - It is computed and stored entirely on-device and never leaves the device.
+ *
+ * Drift handling: when any bucket reaches [RESCALE_CAP] every bucket is halved. This bounds the
+ * stored magnitude and gently ages old observations, so the rhythm tracks a user whose habits
+ * shift over weeks rather than being frozen by the first month of data.
+ *
+ * Concurrency: the in-memory [buckets] are guarded by [lock]; ALL database access (load,
+ * persist, wipe) is serialized through [dbMutex]. A [generation] counter, bumped by [clear],
+ * lets a wipe supersede any persist whose snapshot predates it, so "Clear My Profile" can never
+ * be silently undone by an in-flight persist that lands after the delete.
+ *
+ * Observation only happens while the engine is active (the receiver is unregistered on
+ * [stop]); this is the same window the engine itself runs in, so the learned rhythm reflects
+ * exactly the periods the user has Fauxx enabled.
+ *
+ * The signal is consumed by [CircadianRateModulator] and composed with the persona rhythm in
+ * [CompositeRateModulator]; until [CircadianRateModulator.MIN_OBSERVATIONS] events have
+ * accumulated the modulator stays neutral, so the scheduler falls back to its fixed window.
+ */
+@Singleton
+class CircadianObserver @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val dao: CircadianUsageDao,
+    private val clock: Clock,
+) : UsageObserver, UsageHistogram {
+
+    private val lock = Any()
+
+    /** Per-hour counts. Guarded by [lock]. */
+    private val buckets = LongArray(HOURS_PER_DAY)
+
+    /** Serializes every DB operation (getAll / upsertAll / deleteAll) so writes can't race. */
+    private val dbMutex = Mutex()
+
+    /**
+     * Bumped by [clear] under [lock]; a persist captures it with its snapshot and the DB write
+     * is skipped if it has since advanced. This is what makes a wipe win against a concurrent
+     * or already-queued persist. Volatile because the persist coroutine re-reads it outside
+     * [lock] when deciding whether its write is still current.
+     */
+    @Volatile
+    private var generation = 0L
+
+    /** Wall-clock ms of the last persist; throttles per-event writes. Guarded by [lock]. */
+    private var lastPersistMs = Long.MIN_VALUE
+
+    /**
+     * Own scope for DB load/persist. Mirrors [com.fauxx.engine.PoisonProfileRepository]'s
+     * pattern — fire-and-forget IO that must not block the broadcast/main thread.
+     */
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * True once the persisted histogram has been merged into memory. Until then we do NOT
+     * persist, so an event arriving mid-load can't overwrite the DB with a history-less
+     * snapshot. Volatile: set on the IO scope, read on the broadcast thread.
+     */
+    @Volatile
+    private var loaded = false
+
+    @Volatile
+    private var registered = false
+
+    private val screenReceiver = object : BroadcastReceiver() {
+        override fun onReceive(ctx: Context, intent: Intent) {
+            if (intent.action == Intent.ACTION_SCREEN_ON) onScreenOn()
+        }
+    }
+
+    override fun start() {
+        // Load the persisted rhythm into memory so it is available immediately (and so a
+        // matured histogram keeps modulating from the very first action after a restart).
+        scope.launch { loadFromDb() }
+        registerReceiver()
+    }
+
+    override fun stop() {
+        unregisterReceiver()
+        // Flush any throttled-but-unwritten observations now that the receiver is detached.
+        if (loaded) persistSnapshot()
+    }
+
+    override fun hourlyCounts(): LongArray = synchronized(lock) { buckets.copyOf() }
+
+    /**
+     * Wipe the learned rhythm. Clears the in-memory snapshot synchronously so the modulator
+     * falls back to neutral on the very next action, bumps [generation] so any in-flight
+     * persist is voided, then deletes the persisted rows under [dbMutex]. Part of the
+     * "Clear My Profile" / reset-to-defaults trail wipe.
+     *
+     * The DB delete is best-effort (a failed delete is logged, not thrown, to match the rest
+     * of the reset path which is itself best-effort). If it fails the in-memory snapshot is
+     * still zeroed, so the modulator is neutral immediately, and the next screen-on persists
+     * the zeroed snapshot over the stale rows (REPLACE on every bucket), self-healing the DB.
+     */
+    suspend fun clear() {
+        synchronized(lock) {
+            buckets.fill(0L)
+            // Stay "loaded": an empty histogram is a valid learned state, and we want
+            // subsequent events to persist normally rather than re-merging stale DB rows.
+            loaded = true
+            generation++
+        }
+        dbMutex.withLock {
+            runCatching { dao.deleteAll() }
+                .onFailure { Timber.w(it, "Circadian: failed to clear persisted histogram") }
+        }
+    }
+
+    private fun onScreenOn() {
+        recordEvent(currentHourOfDay())
+        // Throttle writes: at most one persist per PERSIST_THROTTLE_MS. The in-memory buckets
+        // are the authoritative read path, so a coarser flush cadence risks only a handful of
+        // recent observations on an abrupt kill (and stop() flushes on a clean teardown).
+        val shouldPersist = synchronized(lock) {
+            if (!loaded) return
+            val now = clock.currentTimeMillis()
+            if (now - lastPersistMs >= PERSIST_THROTTLE_MS) {
+                lastPersistMs = now
+                true
+            } else {
+                false
+            }
+        }
+        if (shouldPersist) persistSnapshot()
+    }
+
+    /**
+     * Increment the bucket for [hourOfDay] and apply drift rescaling. Pure in-memory mutation,
+     * separated from broadcast/IO plumbing so the histogram logic is unit-testable.
+     */
+    @VisibleForTesting
+    internal fun recordEvent(hourOfDay: Int) {
+        if (hourOfDay !in 0 until HOURS_PER_DAY) return
+        synchronized(lock) {
+            buckets[hourOfDay]++
+            if (buckets[hourOfDay] >= RESCALE_CAP) {
+                for (i in buckets.indices) buckets[i] = buckets[i] / 2
+            }
+        }
+    }
+
+    private suspend fun loadFromDb() {
+        if (loaded) return
+        val rows = dbMutex.withLock {
+            runCatching { dao.getAll() }
+                .onFailure { Timber.w(it, "Circadian: failed to load histogram") }
+                .getOrDefault(emptyList())
+        }
+        val persistNeeded = synchronized(lock) {
+            // A clear() (or another load) may have won the race while getAll was suspended;
+            // if so, leave its state intact rather than re-merging the rows we just read.
+            if (loaded) return
+            // Only the events buffered in memory during the load aren't yet on disk; if none
+            // arrived, the merged state equals what we just read, so skip the redundant write.
+            val hadDuringLoadEvents = buckets.any { it != 0L }
+            for (r in rows) {
+                if (r.hourOfDay in 0 until HOURS_PER_DAY) buckets[r.hourOfDay] += r.count
+            }
+            loaded = true
+            hadDuringLoadEvents
+        }
+        if (persistNeeded) persistSnapshot()
+    }
+
+    private fun persistSnapshot() {
+        val rows: List<CircadianUsageEntity>
+        val gen: Long
+        synchronized(lock) {
+            rows = (0 until HOURS_PER_DAY).map { CircadianUsageEntity(it, buckets[it]) }
+            gen = generation
+        }
+        scope.launch {
+            dbMutex.withLock {
+                // A clear() that ran after this snapshot was taken voids the write, so a wipe
+                // is never silently undone by a stale persist landing after the delete.
+                if (gen != generation) return@withLock
+                runCatching { dao.upsertAll(rows) }
+                    .onFailure { Timber.w(it, "Circadian: failed to persist histogram") }
+            }
+        }
+    }
+
+    private fun registerReceiver() {
+        if (registered) return
+        val filter = IntentFilter(Intent.ACTION_SCREEN_ON)
+        runCatching {
+            // SCREEN_ON is a protected system broadcast (cannot be declared in the manifest
+            // since API 26) and requires dynamic registration. RECEIVER_NOT_EXPORTED on T+:
+            // only the system delivers it, no other app can spoof it.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.registerReceiver(screenReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                context.registerReceiver(screenReceiver, filter)
+            }
+            registered = true
+        }.onFailure { Timber.w(it, "Circadian: screen-on receiver registration failed") }
+    }
+
+    private fun unregisterReceiver() {
+        if (!registered) return
+        runCatching { context.unregisterReceiver(screenReceiver) }
+        registered = false
+    }
+
+    private fun currentHourOfDay(): Int =
+        Calendar.getInstance().apply { timeInMillis = clock.currentTimeMillis() }
+            .get(Calendar.HOUR_OF_DAY)
+
+    /** The wipe-supersedes-persist counter; a persist captured before a [clear] is voided. */
+    @VisibleForTesting
+    internal fun generationForTest(): Long = generation
+
+    companion object {
+        /**
+         * When any bucket reaches this, all buckets are halved (drift decay + overflow guard).
+         * At a heavy ~100 screen-ons/day concentrated in a few hours, a bucket reaches 10k in
+         * a few months, after which each halving keeps the recent shape while fading the past.
+         */
+        @VisibleForTesting
+        internal const val RESCALE_CAP = 10_000L
+
+        /**
+         * Minimum spacing between persists driven by screen-on events. A heavy user fires
+         * ~100 events/day; without throttling that is ~100 full-table encrypted REPLACE writes.
+         * Five minutes collapses bursts to a handful of writes while keeping the on-disk
+         * histogram fresh enough (the in-memory copy is always current for the modulator).
+         */
+        @VisibleForTesting
+        internal const val PERSIST_THROTTLE_MS = 5 * 60 * 1000L
+    }
+}

--- a/app/src/main/java/com/fauxx/engine/scheduling/CircadianRateModulator.kt
+++ b/app/src/main/java/com/fauxx/engine/scheduling/CircadianRateModulator.kt
@@ -1,0 +1,65 @@
+package com.fauxx.engine.scheduling
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * E10 (#177): modulates the synthetic action rate by hour of day so the fake activity curve
+ * tracks the user's own observed screen-on rhythm (from [CircadianObserver]).
+ *
+ * Until [MIN_OBSERVATIONS] screen-on events have accumulated, this returns the neutral 1.0
+ * multiplier for every hour, so the scheduler falls back to its fixed active window and flat
+ * intensity rate. Once enough local data exists, the observed histogram is shaped into a
+ * multiplier curve with a 24-hour mean of exactly 1.0 ([RateShaping.meanPreservingFit]),
+ * honoring the [RateModulator] rate-honesty contract (issue #76): the user's busy hours get a
+ * higher synthetic rate and quiet hours a lower one, with the daily total unchanged.
+ *
+ * The mean-1.0 guarantee is per-snapshot. The histogram keeps accumulating across the day, so
+ * the curve the scheduler reads at hour 8 is normalized against a slightly smaller histogram
+ * than the one read at hour 20; the realized daily mean therefore only *converges* to 1.0 as
+ * the histogram matures and its per-event change shrinks. The drift is bounded and small once
+ * past [MIN_OBSERVATIONS], and the modulation reshapes WHEN actions cluster, not how many.
+ *
+ * This modulator is composed with the persona rhythm in [CompositeRateModulator] — it is not
+ * bound into the scheduler on its own.
+ */
+@Singleton
+class CircadianRateModulator @Inject constructor(
+    private val histogram: UsageHistogram,
+) : RateModulator {
+
+    override fun multiplier(hourOfDay: Int): Float {
+        if (hourOfDay !in 0 until HOURS_PER_DAY) return 1f
+        return curve()[hourOfDay]
+    }
+
+    /**
+     * The full 24-length multiplier curve for the current histogram snapshot: all-neutral
+     * before maturity, otherwise the mean-preserving shaping of the observed counts. Computed
+     * once here (one snapshot read + one shaping pass) so [CompositeRateModulator] can combine
+     * curves without re-shaping per hour.
+     */
+    internal fun curve(): FloatArray {
+        val counts = histogram.hourlyCounts()
+        // Fall back to neutral until the local rhythm is well-enough observed (or if the
+        // histogram is the wrong shape — defensive, the real one is always 24-long).
+        if (counts.size != HOURS_PER_DAY || counts.sum() < MIN_OBSERVATIONS) {
+            return FloatArray(HOURS_PER_DAY) { 1f }
+        }
+        val shaped = RateShaping.meanPreservingFit(
+            DoubleArray(counts.size) { counts[it].toDouble() },
+            RateModulator.MIN_MULTIPLIER.toDouble(),
+            RateModulator.MAX_MULTIPLIER.toDouble(),
+        )
+        return FloatArray(HOURS_PER_DAY) { shaped[it].toFloat() }
+    }
+
+    companion object {
+        /**
+         * Minimum total screen-on observations before the learned rhythm is trusted. A typical
+         * user turns the screen on dozens of times a day, so this is a small number of active
+         * days — enough for a stable daily shape, not so high the feature never engages.
+         */
+        const val MIN_OBSERVATIONS = 50L
+    }
+}

--- a/app/src/main/java/com/fauxx/engine/scheduling/CircadianUsageDao.kt
+++ b/app/src/main/java/com/fauxx/engine/scheduling/CircadianUsageDao.kt
@@ -1,0 +1,49 @@
+package com.fauxx.engine.scheduling
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+
+/**
+ * One row per hour-of-day (0-23) holding the locally-observed screen-on count for that
+ * hour (E10 #177). This is the ONLY persisted form of the circadian signal: a 24-bucket
+ * aggregate histogram, never raw event timestamps, so the stored footprint reveals a coarse
+ * daily rhythm and nothing about *when* any individual unlock happened. Lives in the
+ * SQLCipher-encrypted [com.fauxx.data.db.PhantomDatabase] and is never transmitted off-device.
+ *
+ * @property hourOfDay Local hour of day, 0-23 (primary key — at most 24 rows ever exist).
+ * @property count Decayed observation count for that hour (see [CircadianObserver] rescaling).
+ */
+@Entity(tableName = "circadian_usage")
+data class CircadianUsageEntity(
+    @PrimaryKey val hourOfDay: Int,
+    val count: Long,
+)
+
+/**
+ * DAO for the circadian usage histogram. The in-memory snapshot in [CircadianObserver] is the
+ * read path used by the scheduler; this DAO is the persistence path so a learned rhythm
+ * survives process restarts.
+ */
+@Dao
+interface CircadianUsageDao {
+
+    /** Load the full histogram (0-24 rows). Absent hours mean a zero count. */
+    @Query("SELECT * FROM circadian_usage")
+    suspend fun getAll(): List<CircadianUsageEntity>
+
+    /**
+     * Persist the full 24-bucket snapshot in one transaction. REPLACE on the hour-of-day
+     * primary key, so this upserts every bucket to the current in-memory value — which also
+     * applies the periodic rescale uniformly without a separate decay query.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(rows: List<CircadianUsageEntity>)
+
+    /** Wipe the learned rhythm (part of "Clear My Profile" / reset-to-defaults). */
+    @Query("DELETE FROM circadian_usage")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/fauxx/engine/scheduling/CompositeRateModulator.kt
+++ b/app/src/main/java/com/fauxx/engine/scheduling/CompositeRateModulator.kt
@@ -1,0 +1,49 @@
+package com.fauxx.engine.scheduling
+
+import com.fauxx.targeting.layer3.PersonaRateModulator
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The single rate-modulation seam bound into [PoissonScheduler] (E10 #177).
+ *
+ * Both timing signals feed through here rather than the scheduler gaining a second modulation
+ * point: the persona's deterministic daily rhythm ([PersonaRateModulator], E8 #174) and the
+ * user's observed screen-on rhythm ([CircadianRateModulator], E10). The two are combined
+ * multiplicatively (a quiet hour for the persona AND the user is quieter still) and then
+ * reshaped to a 24-hour mean of exactly 1.0 within the scheduler's clamp band
+ * ([RateShaping.meanPreservingFit]).
+ *
+ * Renormalizing the product matters: each input is individually mean-1.0, but the mean of a
+ * product is not the product of means, so the raw product can drift slightly off 1.0 and its
+ * extremes can exceed the clamp band. Reshaping restores the per-snapshot mean to exactly 1.0
+ * (issue #76) and keeps the curve inside the band so the scheduler's own clamp never has to
+ * skew it. (As with the circadian input, the histogram mutates across the day, so the realized
+ * daily mean converges to 1.0 as the histogram matures rather than being exact every hour.)
+ *
+ * Each input degrades to neutral on its own (no persona / Layer 3 off -> persona returns 1.0;
+ * too little local data -> circadian returns 1.0), so the composite gracefully reduces to
+ * whichever signal is present, or to a flat 1.0 curve when neither is.
+ */
+@Singleton
+class CompositeRateModulator @Inject constructor(
+    private val persona: PersonaRateModulator,
+    private val circadian: CircadianRateModulator,
+) : RateModulator {
+
+    override fun multiplier(hourOfDay: Int): Float {
+        if (hourOfDay !in 0 until HOURS_PER_DAY) return 1f
+        // Compute each input curve ONCE (circadian shapes its histogram a single time), then
+        // combine, rather than re-shaping per hour — keeps this synchronous hot path O(24).
+        val circadianCurve = circadian.curve()
+        val raw = DoubleArray(HOURS_PER_DAY) {
+            persona.multiplier(it).toDouble() * circadianCurve[it].toDouble()
+        }
+        val shaped = RateShaping.meanPreservingFit(
+            raw,
+            RateModulator.MIN_MULTIPLIER.toDouble(),
+            RateModulator.MAX_MULTIPLIER.toDouble(),
+        )
+        return shaped[hourOfDay].toFloat()
+    }
+}

--- a/app/src/main/java/com/fauxx/engine/scheduling/PoissonScheduler.kt
+++ b/app/src/main/java/com/fauxx/engine/scheduling/PoissonScheduler.kt
@@ -37,6 +37,7 @@ import kotlin.random.Random
 class PoissonScheduler @Inject constructor(
     private val clock: Clock,
     private val random: Random = Random.Default,
+    private val rateModulator: RateModulator = RateModulator.NEUTRAL,
 ) {
 
     companion object {
@@ -92,8 +93,13 @@ class PoissonScheduler @Inject constructor(
         }
 
         // Use the target rate directly — actionsPerHour already represents the desired
-        // rate during active hours, no need to scale by active fraction.
-        val effectiveRate = actionsPerHour.toFloat()
+        // rate during active hours, no need to scale by active fraction. The rate
+        // modulator (E8 persona rhythm, later composed with E10's circadian histogram)
+        // softly reshapes WHEN actions cluster; its 24h mean stays ~1.0 and the clamp
+        // bounds the worst case, so the displayed rate stays honest (issue #76).
+        val modulation = rateModulator.multiplier(currentHour)
+            .coerceIn(RateModulator.MIN_MULTIPLIER, RateModulator.MAX_MULTIPLIER)
+        val effectiveRate = actionsPerHour.toFloat() * modulation
 
         val sameTopic = prev == null || next == null || prev == next
 

--- a/app/src/main/java/com/fauxx/engine/scheduling/RateModulator.kt
+++ b/app/src/main/java/com/fauxx/engine/scheduling/RateModulator.kt
@@ -1,0 +1,31 @@
+package com.fauxx.engine.scheduling
+
+/**
+ * Hook for soft, multiplicative modulation of the Poisson target rate by hour of day
+ * (E8 #174). [PoissonScheduler] multiplies its target rate by [multiplier], clamped to
+ * [MIN_MULTIPLIER]..[MAX_MULTIPLIER] regardless of the implementation.
+ *
+ * This is the SINGLE rate-modulation seam: E8 contributes the persona rhythm
+ * ([com.fauxx.targeting.layer3.PersonaRateModulator]); E10 (#177) will compose the
+ * screen-on circadian histogram into the same hook rather than adding a second
+ * modulation point inside the scheduler.
+ *
+ * Contract: implementations must keep the 24-hour mean multiplier close to 1.0 so the
+ * displayed actions/hour stays honest (issue #76) — modulation reshapes WHEN actions
+ * happen, not how many. Note that multipliers above 1.0 can be partially clipped by
+ * the engine's hard per-hour cap (PoisonEngine.recentActionTimestamps), so realized
+ * throughput errs slightly BELOW the displayed rate — the honest direction.
+ */
+fun interface RateModulator {
+
+    /** Rate multiplier for the given local hour of day (0-23). */
+    fun multiplier(hourOfDay: Int): Float
+
+    companion object {
+        const val MIN_MULTIPLIER = 0.5f
+        const val MAX_MULTIPLIER = 1.5f
+
+        /** Identity modulation: scheduler behavior is exactly pre-E8. */
+        val NEUTRAL = RateModulator { 1f }
+    }
+}

--- a/app/src/main/java/com/fauxx/engine/scheduling/RateShaping.kt
+++ b/app/src/main/java/com/fauxx/engine/scheduling/RateShaping.kt
@@ -1,0 +1,53 @@
+package com.fauxx.engine.scheduling
+
+/**
+ * Shared shaping math for the rate modulators (E10 #177).
+ *
+ * Both the circadian histogram and the persona×circadian composite need to turn an arbitrary
+ * per-hour shape into a multiplier curve that (a) has a 24-hour mean of exactly 1.0 — the
+ * [RateModulator] honesty contract (issue #76), modulation reshapes WHEN actions happen, not
+ * how many — and (b) stays within the scheduler's [RateModulator.MIN_MULTIPLIER]..
+ * [RateModulator.MAX_MULTIPLIER] band so the scheduler's own clamp never bites and silently
+ * skews the mean (a hard clamp is not mean-preserving).
+ */
+object RateShaping {
+
+    /**
+     * Map [values] to a multiplier curve with mean exactly 1.0, shaped like [values], scaled
+     * so every entry lies within [[lo], [hi]].
+     *
+     * Method: normalize to the input mean (so the normalized curve has mean 1.0), then
+     * attenuate the deviations from 1.0 by the single largest factor `s` in `[0,1]` that pulls
+     * the most extreme entry inside `[lo, hi]`. Because the attenuation is affine about 1.0
+     * (`1 + s*(norm - 1)`) and `mean(norm) == 1`, the result's mean is exactly 1.0 regardless
+     * of `s`. A flat (or all-zero / negative-mean degenerate) input returns a flat 1.0 curve.
+     *
+     * @param values raw per-hour shape (e.g. observation counts, or a product of curves).
+     * @param lo lower multiplier bound (inclusive), expected < 1.0.
+     * @param hi upper multiplier bound (inclusive), expected > 1.0.
+     * @return a curve the same length as [values]; empty in, empty out.
+     */
+    fun meanPreservingFit(values: DoubleArray, lo: Double, hi: Double): DoubleArray {
+        if (values.isEmpty()) return DoubleArray(0)
+        val mean = values.average()
+        // Degenerate input (no signal yet, or a pathological negative) -> neutral.
+        if (mean <= 0.0) return DoubleArray(values.size) { 1.0 }
+
+        val norm = DoubleArray(values.size) { values[it] / mean } // mean(norm) == 1.0
+
+        var maxDev = 0.0 // largest positive deviation above 1.0
+        var minDev = 0.0 // most negative deviation below 1.0
+        for (v in norm) {
+            val d = v - 1.0
+            if (d > maxDev) maxDev = d
+            if (d < minDev) minDev = d
+        }
+
+        var s = 1.0
+        if (maxDev > 0.0) s = minOf(s, (hi - 1.0) / maxDev)
+        if (minDev < 0.0) s = minOf(s, (1.0 - lo) / -minDev)
+        s = s.coerceIn(0.0, 1.0)
+
+        return DoubleArray(values.size) { 1.0 + s * (norm[it] - 1.0) }
+    }
+}

--- a/app/src/main/java/com/fauxx/logging/LogScrubber.kt
+++ b/app/src/main/java/com/fauxx/logging/LogScrubber.kt
@@ -17,6 +17,9 @@ object LogScrubber {
         Regex("""UserDemographicProfile\([^)]*\)"""),
         Regex("""SyntheticPersona\([^)]*\)"""),
         Regex("""PlatformProfileCache\([^)]*\)"""),
+        // E7: carries (age, profession, region) at generation time; its `age` field
+        // would also slip past the ageRange field pattern below.
+        Regex("""DemographicCell\([^)]*\)"""),
         // Demographic profile fields
         Regex("""(?i)(ageRange|gender|profession|region|interests)\s*[=:]\s*\S+"""),
         // Persona data

--- a/app/src/main/java/com/fauxx/targeting/layer0/UniformEntropyLayer.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer0/UniformEntropyLayer.kt
@@ -11,6 +11,18 @@ import javax.inject.Singleton
  *
  * Returns weight 1.0 for every [CategoryPool] value, providing a uniform baseline that other
  * layers multiply against. Ensures no bias is introduced when higher layers are disabled.
+ *
+ * E9 (#176) note: because the engine combine is multiplicative and the result is
+ * normalized, a constant emitted here is normalization-invariant PROVIDED it keeps
+ * every combined product at or above [com.fauxx.targeting.WeightNormalizer.MIN_WEIGHT]
+ * — the normalizer clamps RAW weights to that floor before summing, which breaks pure
+ * scale-invariance once a small constant pushes products under it (the worst-case
+ * production stack, L1 close 0.15 x L2 sticky 0.02 x L3 misaligned 0.345, sits only
+ * ~3.5% above the floor). Do NOT repurpose this constant as a damping knob. The
+ * "reduce Layer 0's uniform pull" lever lives where the uniform component actually
+ * enters the final shape: the UNIFORM_BASELINE_WEIGHT blend term in
+ * [com.fauxx.targeting.layer3.PersonaRotationLayer]. This layer stays at the
+ * multiplicative identity.
  */
 @Singleton
 class UniformEntropyLayer @Inject constructor() {

--- a/app/src/main/java/com/fauxx/targeting/layer3/PersonaConsistencyRules.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer3/PersonaConsistencyRules.kt
@@ -27,23 +27,28 @@ object PersonaConsistencyRules {
 
     /**
      * Check for known incompatible trait pairs. Returns true if incompatible.
+     *
+     * Age comparisons use [com.fauxx.targeting.layer1.AgeRange] enum names — the
+     * canonical [SyntheticPersona.ageRange] format. Before that canonicalization these
+     * compared display strings ("65+"), which never matched template-sourced personas,
+     * so the rules were silently inert on the dominant generation path.
      */
     private fun hasIncompatibleTraits(persona: SyntheticPersona): Boolean {
         val age = persona.ageRange
         val interests = persona.interests
 
         // Retiree-age personas shouldn't have strong academic/student interests
-        if (age == "65+" && interests.contains(CategoryPool.ACADEMIC) &&
+        if (age == "AGE_65_PLUS" && interests.contains(CategoryPool.ACADEMIC) &&
             interests.size < 3
         ) return true
 
         // Very young persona (18-24) shouldn't dominate retirement interests
-        if (age == "18-24" && interests.contains(CategoryPool.RETIREMENT) &&
+        if (age == "AGE_18_24" && interests.contains(CategoryPool.RETIREMENT) &&
             !interests.any { it in setOf(CategoryPool.FINANCE, CategoryPool.REAL_ESTATE) }
         ) return true
 
         // Parenting interests should co-occur with age groups where parenting is plausible
-        if (interests.contains(CategoryPool.PARENTING) && age == "18-24" &&
+        if (interests.contains(CategoryPool.PARENTING) && age == "AGE_18_24" &&
             interests.size == 1
         ) return true
 

--- a/app/src/main/java/com/fauxx/targeting/layer3/PersonaDistribution.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer3/PersonaDistribution.kt
@@ -1,0 +1,123 @@
+package com.fauxx.targeting.layer3
+
+import android.content.Context
+import androidx.annotation.Keep
+import com.fauxx.targeting.layer1.AgeRange
+import com.fauxx.targeting.layer1.Profession
+import com.fauxx.targeting.layer1.Region
+import com.google.gson.Gson
+import dagger.hilt.android.qualifiers.ApplicationContext
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.random.Random
+
+/**
+ * One (ageRange, profession, region) cell of the joint demographic pmf. All three values
+ * are enum names from the layer-1 taxonomy ("AGE_35_44", "FINANCE_PROF", "US_MIDWEST").
+ *
+ * @Keep: same R8 trap as `PersonaTemplate` (issue #49) — without it, release builds strip
+ * the field names and Gson reflection silently yields `LinkedTreeMap`-backed objects.
+ */
+@Keep
+data class DemographicCell(
+    val age: String = "",
+    val profession: String = "",
+    val region: String = "",
+    val weight: Double = 0.0,
+)
+
+@Keep
+private data class DistributionFile(
+    val version: Int = 0,
+    val cells: List<DemographicCell> = emptyList(),
+)
+
+/**
+ * Joint P(AgeRange, Profession, Region) over US adults, PWGTP-weighted from US Census
+ * ACS PUMS microdata (E7 #173). Built offline by `scripts/build_persona_distribution.py`
+ * and bundled as `assets/persona_distribution.json`.
+ *
+ * [sample] draws a whole cell at once, so the three traits CO-OCCUR the way they do in
+ * the real population — a 22-year-old retiree in a region with no such people cannot be
+ * drawn, unlike independent per-trait sampling.
+ *
+ * US-only by design (hybrid scope, ratified 2026-06-09): es/fr/ru locales keep their
+ * hand-authored persona templates because PUMS covers only the US.
+ *
+ * If the asset is missing, malformed, or contains no usable cells, [sample] returns null
+ * and [PersonaGenerator] falls back to its template path — never a crash.
+ */
+@Singleton
+class PersonaDistribution @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val gson = Gson()
+
+    /** Validated cells with precomputed cumulative weights; null if the asset is unusable. */
+    private val table: Table? by lazy { load() }
+
+    /**
+     * Multinomial-sample one joint (age, profession, region) cell, or null when the
+     * bundled distribution is unavailable.
+     */
+    fun sample(random: Random): DemographicCell? {
+        val t = table ?: return null
+        val x = random.nextDouble() * t.totalWeight
+        // First index whose cumulative weight exceeds x (binary search).
+        var lo = 0
+        var hi = t.cumulative.size - 1
+        while (lo < hi) {
+            val mid = (lo + hi) ushr 1
+            if (t.cumulative[mid] <= x) lo = mid + 1 else hi = mid
+        }
+        return t.cells[lo]
+    }
+
+    private class Table(
+        val cells: List<DemographicCell>,
+        val cumulative: DoubleArray,
+        val totalWeight: Double,
+    )
+
+    // The whole pipeline sits in one try/catch: Gson bypasses constructors, so a corrupt
+    // asset can yield null list ELEMENTS and even null values in non-null String fields —
+    // validation itself can throw and must degrade to the template fallback, not crash.
+    // (`by lazy` re-evaluates after a throw, so an escaped exception here would resurface
+    // on every sample() call.)
+    private fun load(): Table? = try {
+        val parsed = context.assets.open(ASSET_PATH).bufferedReader().use { it.readText() }
+            .let { gson.fromJson(it, DistributionFile::class.java) }
+        val all = parsed?.cells.orEmpty().filterNotNull()
+        val valid = all.filter(::isValidCell)
+        if (valid.size < all.size) {
+            Timber.w("persona_distribution: dropped ${all.size - valid.size} invalid cells")
+        }
+        if (valid.isEmpty()) {
+            Timber.w("persona_distribution: no usable cells, falling back to templates")
+            null
+        } else {
+            val cumulative = DoubleArray(valid.size)
+            var sum = 0.0
+            valid.forEachIndexed { i, cell ->
+                sum += cell.weight
+                cumulative[i] = sum
+            }
+            Table(valid, cumulative, sum)
+        }
+    } catch (e: Exception) {
+        Timber.w(e, "persona_distribution.json unusable, falling back to templates")
+        null
+    }
+
+    private fun isValidCell(cell: DemographicCell): Boolean =
+        cell.weight > 0.0 &&
+            runCatching { AgeRange.valueOf(cell.age) }.isSuccess &&
+            runCatching { Profession.valueOf(cell.profession) }.isSuccess &&
+            runCatching { Region.valueOf(cell.region) }.isSuccess &&
+            cell.region.startsWith("US_")
+
+    companion object {
+        const val ASSET_PATH = "persona_distribution.json"
+    }
+}

--- a/app/src/main/java/com/fauxx/targeting/layer3/PersonaGenerator.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer3/PersonaGenerator.kt
@@ -8,7 +8,9 @@ import com.fauxx.data.model.SyntheticPersona
 import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.locale.LocaleManager
 import com.fauxx.locale.SupportedLocale
+import com.fauxx.targeting.layer1.AgeRange
 import com.fauxx.targeting.layer1.DemographicProfileDao
+import com.fauxx.targeting.layer1.Profession
 import com.fauxx.targeting.layer1.UserDemographicProfile
 import com.fauxx.util.Clock
 import com.fauxx.util.SystemClockImpl
@@ -24,11 +26,22 @@ import kotlin.random.Random
 private val NINETY_DAYS_MS = TimeUnit.DAYS.toMillis(90)
 
 /**
- * Generates coherent [SyntheticPersona] instances by sampling from persona templates
- * and validating against consistency rules and recent history.
+ * Generates coherent [SyntheticPersona] instances and validates them against consistency
+ * rules and recent history.
+ *
+ * Demographics (E7 #173, hybrid scope): for the EN locale, (ageRange, profession, region)
+ * are JOINTLY multinomial-sampled from the bundled ACS PUMS distribution via
+ * [PersonaDistribution], so traits co-occur per real US population data. Non-EN locales
+ * (and EN when the distribution asset is unusable) keep the hand-authored template path.
+ * Interests are still sampled from templates/weight hints independently of the joint
+ * demographics — P(interests | age, profession) is a tracked follow-up.
+ *
+ * All demographic fields are stored as layer-1 enum NAMES ("AGE_35_44", "FINANCE_PROF",
+ * "US_MIDWEST"); display labels are resolved only in the UI via DemographicLabels.
  *
  * A persona is rejected if:
  * - It fails [PersonaConsistencyRules.isValid]
+ * - It matches the user's own demographics on 2+ traits
  * - It shares >60% trait overlap with any persona from the past 90 days
  *
  * Falls back to a built-in generic persona if no valid persona can be generated after
@@ -40,6 +53,7 @@ class PersonaGenerator @Inject constructor(
     private val historyDao: PersonaHistoryDao,
     private val demographicProfileDao: DemographicProfileDao,
     private val localeManager: LocaleManager,
+    private val distribution: PersonaDistribution,
     private val clock: Clock = SystemClockImpl(),
     private val random: Random = Random.Default,
 ) {
@@ -103,12 +117,20 @@ class PersonaGenerator @Inject constructor(
         val interests = selectInterests(template, weightHints)
         val now = clock.currentTimeMillis()
 
+        // US personas joint-sample all three demographics from the same ACS PUMS cell;
+        // null for non-EN locales (hand-authored templates) or when the asset is unusable.
+        val cell = if (localeManager.currentLocale == SupportedLocale.EN) {
+            distribution.sample(random)
+        } else {
+            null
+        }
+
         return SyntheticPersona(
             id = UUID.randomUUID().toString(),
             name = generateName(),
-            ageRange = template?.ageRange ?: pickAgeRange(),
-            profession = template?.profession ?: pickProfession(),
-            region = template?.region ?: pickRegion(),
+            ageRange = cell?.age ?: template?.ageRange ?: pickAgeRange(),
+            profession = cell?.profession ?: template?.profession ?: pickProfession(),
+            region = cell?.region ?: template?.region ?: pickRegion(),
             interests = interests,
             createdAt = now,
             activeUntil = nextRotationTime()
@@ -163,6 +185,10 @@ class PersonaGenerator @Inject constructor(
      * Returns true if the candidate persona matches the user's self-reported demographics
      * on 2 or more traits (ageRange, profession, region). Gender is intentionally excluded.
      * Returns false if the user has no profile (skipped onboarding).
+     *
+     * Candidates store demographics as enum names, so this compares against `enum.name`
+     * directly. Before that canonicalization this method compared display strings, which
+     * NEVER matched template-sourced candidates — the gate was silently inert.
      */
     private fun matchesUserDemographics(
         candidate: SyntheticPersona,
@@ -171,41 +197,9 @@ class PersonaGenerator @Inject constructor(
         if (userProfile == null) return false
 
         var matchCount = 0
-
-        if (userProfile.ageRange != null) {
-            val userAge = when (userProfile.ageRange) {
-                com.fauxx.targeting.layer1.AgeRange.AGE_18_24 -> "18-24"
-                com.fauxx.targeting.layer1.AgeRange.AGE_25_34 -> "25-34"
-                com.fauxx.targeting.layer1.AgeRange.AGE_35_44 -> "35-44"
-                com.fauxx.targeting.layer1.AgeRange.AGE_45_54 -> "45-54"
-                com.fauxx.targeting.layer1.AgeRange.AGE_55_64 -> "55-64"
-                com.fauxx.targeting.layer1.AgeRange.AGE_65_PLUS -> "65+"
-            }
-            if (candidate.ageRange == userAge) matchCount++
-        }
-
-        if (userProfile.profession != null) {
-            val userProf = when (userProfile.profession) {
-                com.fauxx.targeting.layer1.Profession.STUDENT -> "Student"
-                com.fauxx.targeting.layer1.Profession.TEACHER -> "Teacher"
-                com.fauxx.targeting.layer1.Profession.ENGINEER -> "Engineer"
-                com.fauxx.targeting.layer1.Profession.HEALTHCARE -> "Healthcare Worker"
-                com.fauxx.targeting.layer1.Profession.LEGAL -> "Legal"
-                com.fauxx.targeting.layer1.Profession.FINANCE_PROF -> "Business Professional"
-                com.fauxx.targeting.layer1.Profession.RETAIL -> "Retail Worker"
-                com.fauxx.targeting.layer1.Profession.TRADES -> "Trades"
-                com.fauxx.targeting.layer1.Profession.CREATIVE -> "Creative"
-                com.fauxx.targeting.layer1.Profession.RETIRED -> "Retired"
-                com.fauxx.targeting.layer1.Profession.HOMEMAKER -> "Homemaker"
-                com.fauxx.targeting.layer1.Profession.OTHER -> "Professional"
-            }
-            if (candidate.profession == userProf) matchCount++
-        }
-
-        if (userProfile.region != null && candidate.region == userProfile.region.name) {
-            matchCount++
-        }
-
+        if (userProfile.ageRange != null && candidate.ageRange == userProfile.ageRange.name) matchCount++
+        if (userProfile.profession != null && candidate.profession == userProfile.profession.name) matchCount++
+        if (userProfile.region != null && candidate.region == userProfile.region.name) matchCount++
         return matchCount >= MIN_DEMOGRAPHIC_MATCHES
     }
 
@@ -214,8 +208,8 @@ class PersonaGenerator @Inject constructor(
         return SyntheticPersona(
             id = UUID.randomUUID().toString(),
             name = "Alex Johnson",
-            ageRange = "35-44",
-            profession = "Professional",
+            ageRange = AgeRange.AGE_35_44.name,
+            profession = Profession.OTHER.name,
             region = "US_MIDWEST",
             interests = setOf(CategoryPool.COOKING, CategoryPool.TRAVEL, CategoryPool.FITNESS),
             createdAt = now,
@@ -231,12 +225,13 @@ class PersonaGenerator @Inject constructor(
         return "${firstNames.random(random)} ${lastNames.random(random)}"
     }
 
-    private fun pickAgeRange(): String =
-        listOf("18-24", "25-34", "35-44", "45-54", "55-64", "65+").random(random)
+    private fun pickAgeRange(): String = AgeRange.entries.random(random).name
 
     private fun pickProfession(): String =
-        listOf("Engineer", "Teacher", "Healthcare Worker", "Business Professional",
-            "Retail Worker", "Retired", "Student", "Homemaker", "Creative").random(random)
+        listOf(Profession.ENGINEER, Profession.TEACHER, Profession.HEALTHCARE,
+            Profession.FINANCE_PROF, Profession.RETAIL, Profession.RETIRED,
+            Profession.STUDENT, Profession.HOMEMAKER, Profession.CREATIVE)
+            .random(random).name
 
     private fun pickRegion(): String =
         listOf("US_NORTHEAST", "US_SOUTHEAST", "US_MIDWEST", "US_SOUTHWEST", "US_WEST",

--- a/app/src/main/java/com/fauxx/targeting/layer3/PersonaRateModulator.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer3/PersonaRateModulator.kt
@@ -1,0 +1,47 @@
+package com.fauxx.targeting.layer3
+
+import com.fauxx.engine.scheduling.RateModulator
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.PI
+import kotlin.math.cos
+
+/** Peak-activity hours sit in BASE_PEAK_HOUR ± PEAK_JITTER_HOURS, persona-keyed. */
+private const val BASE_PEAK_HOUR = 14
+private const val PEAK_JITTER_HOURS = 3
+
+/** Cosine amplitude: hourly rate swings ±20% around the mean. */
+private const val AMPLITUDE = 0.2
+
+/**
+ * E8 (#174): gives each synthetic persona a consistent daily activity rhythm.
+ *
+ * Identical Poisson timing across persona rotations is itself a fingerprint — every
+ * "different person" this device pretends to be would keep exactly the same hourly
+ * activity profile. This modulator derives a peak-activity hour deterministically from
+ * the persona id, so a given persona keeps the same rhythm for its whole 7±3 day life
+ * and the rhythm shifts when the persona rotates.
+ *
+ * Shape: cosine over the 24h day, peak at 14:00 ± 3h (persona-keyed), amplitude ±20%.
+ * The mean over 24 hours is exactly 1.0, honoring the [RateModulator] honesty contract
+ * (issue #76). Returns 1.0 (neutral) when Layer 3 is disabled or no persona is active,
+ * via [PersonaRotationLayer.activePersona].
+ */
+@Singleton
+class PersonaRateModulator @Inject constructor(
+    private val personaLayer: PersonaRotationLayer,
+) : RateModulator {
+
+    override fun multiplier(hourOfDay: Int): Float {
+        val persona = personaLayer.personaForChannel(PersonaChannel.RHYTHM) ?: return 1f
+        val peakHour = BASE_PEAK_HOUR + peakOffset(persona.id)
+        val radians = 2.0 * PI * (hourOfDay - peakHour) / 24.0
+        return (1.0 + AMPLITUDE * cos(radians)).toFloat()
+    }
+
+    /** Deterministic per-persona offset in -PEAK_JITTER_HOURS..+PEAK_JITTER_HOURS. */
+    private fun peakOffset(personaId: String): Int {
+        val span = 2 * PEAK_JITTER_HOURS + 1
+        return (personaId.hashCode().mod(span)) - PEAK_JITTER_HOURS
+    }
+}

--- a/app/src/main/java/com/fauxx/targeting/layer3/PersonaRotationLayer.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer3/PersonaRotationLayer.kt
@@ -31,19 +31,38 @@ private const val ALIGNED_WEIGHT = 2.0f
 /** Weight for categories misaligned with the current persona. */
 private const val MISALIGNED_WEIGHT = 0.3f
 
-/** Neutral weight. */
+/** Neutral weight (layer disabled / no persona): multiplicative identity. */
 private const val NEUTRAL_WEIGHT = 1.0f
+
+/**
+ * Uniform-baseline component of the persona blend, lowered from 1.0 by E9 (#176).
+ * This term is where the "Layer 0 uniform pull" mechanically lives: UniformEntropyLayer's
+ * own constant is normalization-invariant for any value that keeps combined products
+ * above the normalizer floor (see its KDoc), so reducing the uniform flattening means
+ * shrinking the (1 - PERSONA_FOLLOW_FRACTION) blend-in here.
+ */
+private const val UNIFORM_BASELINE_WEIGHT = 0.6f
 
 /**
  * Layer 3 of the Demographic Distancing Engine — persona rotation targeting.
  *
- * Generates a new [SyntheticPersona] every 7±3 days and returns category weights based on
- * the current persona's interests:
- * - 2.0 for persona-aligned categories
- * - 0.3 for persona-misaligned categories
- * - 1.0 for uncategorized or when layer is disabled
+ * Generates a new [SyntheticPersona] every 7±3 days and returns category weights from the
+ * raw constants (ALIGNED 2.0 / MISALIGNED 0.3) blended at PERSONA_FOLLOW_FRACTION with
+ * the uniform baseline; 1.0 (neutral) when the layer is disabled or has no persona.
  *
- * Uses a 70% persona-following / 30% uniform blend for natural variation.
+ * E9 (#176) rebalance: an 85% persona-following / 15% reduced-uniform (0.6) blend, so
+ * aligned categories land at 2.0*0.85 + 0.6*0.15 = 1.79 and misaligned at
+ * 0.3*0.85 + 0.6*0.15 = 0.345 — a decisively persona-led (peakier) distribution versus
+ * the pre-E9 1.7/0.51. With this layer alone a misaligned category keeps ~1.9% of the
+ * normalized mass (~19x the [com.fauxx.targeting.WeightNormalizer.MIN_WEIGHT] floor;
+ * the floor itself guarantees non-collapse even when L1/L2 shape the stack further).
+ *
+ * The weights channel participates in E8's staggered persona adoption (see
+ * [personaForChannel]): after an automatic rotation it keeps serving the previous
+ * persona's blend until its [PersonaChannel.WEIGHTS] lag elapses, so the category
+ * distribution does not step in the same instant as the other bound channels. A
+ * user-forced [rotateNow] adopts immediately on all channels — an explicit user action
+ * should produce visible change, and it is not the weekly automatic change-point.
  */
 @Singleton
 class PersonaRotationLayer @Inject constructor(
@@ -97,11 +116,24 @@ class PersonaRotationLayer @Inject constructor(
     }
 
     /**
-     * Stable [StateFlow] emitting the current Layer 3 weight map.
-     * Recomputes reactively whenever the current persona or enabled flag changes.
+     * Re-evaluation ticker for [_weights]. Staggered adoption is TIME-based, but a
+     * flow only recomputes on emissions — the periodic check loop bumps this so the
+     * weights channel adopts a rotated persona once its lag elapses (within one
+     * check interval), not only on the next persona/enabled emission.
      */
-    private val _weights = combine(_currentPersona, _enabled) { persona, enabled ->
-        if (!enabled || persona == null) {
+    private val _weightsTick = MutableStateFlow(0L)
+
+    /**
+     * Stable [StateFlow] emitting the current Layer 3 weight map.
+     * Recomputes whenever the persona state, the enabled flag, or the ticker changes;
+     * the persona itself resolves through [personaForChannel] so the category
+     * distribution honors E8's staggered adoption like every other bound channel.
+     */
+    private val _weights = combine(
+        _currentPersona, _previousPersona, _enabled, _weightsTick
+    ) { _, _, _, _ ->
+        val persona = personaForChannel(PersonaChannel.WEIGHTS)
+        if (persona == null) {
             neutralWeights()
         } else {
             try {
@@ -119,6 +151,7 @@ class PersonaRotationLayer @Inject constructor(
         scope.launch {
             while (isActive) {
                 delay(ROTATION_CHECK_INTERVAL_MS)
+                _weightsTick.value = clock.currentTimeMillis()
                 val current = _currentPersona.value
                 if (current != null && clock.currentTimeMillis() > current.activeUntil) {
                     rotatePersona()
@@ -169,10 +202,18 @@ class PersonaRotationLayer @Inject constructor(
     }
 
     /**
-     * Force immediate persona rotation (e.g., user clicked "Rotate Now").
+     * Force immediate persona rotation (e.g., user clicked "Rotate Now"). Unlike the
+     * automatic weekly rotation, the new persona is adopted on ALL channels at once:
+     * an explicit user action should produce visible change, and it is not the
+     * recurring change-point the staggered adoption exists to blur.
      */
     fun rotateNow() {
-        rotatePersona()
+        rotatePersona(immediateAdoption = true)
+    }
+
+    @androidx.annotation.VisibleForTesting
+    internal fun reevaluateWeightsForTest() {
+        _weightsTick.value = clock.currentTimeMillis()
     }
 
     /**
@@ -181,21 +222,8 @@ class PersonaRotationLayer @Inject constructor(
      */
     fun getWeights(): Flow<Map<CategoryPool, Float>> = _weights
 
-    private fun computeWeights(persona: SyntheticPersona): Map<CategoryPool, Float> {
-        return CategoryPool.values().associateWith { category ->
-            when {
-                persona.interests.contains(category) -> {
-                    // 70% persona-following, 30% uniform blend
-                    ALIGNED_WEIGHT * SyntheticPersona.PERSONA_FOLLOW_FRACTION +
-                        NEUTRAL_WEIGHT * (1f - SyntheticPersona.PERSONA_FOLLOW_FRACTION)
-                }
-                else -> {
-                    MISALIGNED_WEIGHT * SyntheticPersona.PERSONA_FOLLOW_FRACTION +
-                        NEUTRAL_WEIGHT * (1f - SyntheticPersona.PERSONA_FOLLOW_FRACTION)
-                }
-            }
-        }
-    }
+    private fun computeWeights(persona: SyntheticPersona): Map<CategoryPool, Float> =
+        weightsFor(persona.interests)
 
     private fun neutralWeights(): Map<CategoryPool, Float> =
         CategoryPool.values().associateWith { NEUTRAL_WEIGHT }
@@ -208,13 +236,13 @@ class PersonaRotationLayer @Inject constructor(
         scope.cancel()
     }
 
-    private fun rotatePersona() {
+    private fun rotatePersona(immediateAdoption: Boolean = false) {
         scope.launch {
             try {
                 val newPersona = generator.generate()
                 // Keep the outgoing persona so channels can phase the new one in
-                // (see personaForChannel).
-                _previousPersona.value = _currentPersona.value
+                // (see personaForChannel); a user-forced rotation adopts instantly.
+                _previousPersona.value = if (immediateAdoption) null else _currentPersona.value
                 _currentPersona.value = newPersona
                 historyDao.insert(
                     PersonaHistoryEntity(
@@ -237,12 +265,28 @@ class PersonaRotationLayer @Inject constructor(
 
         /** Upper bound for per-channel persona adoption lag: 48 hours. */
         internal const val CHANNEL_MAX_LAG_MS = 48L * 60 * 60 * 1000
+
+        /**
+         * The E9 persona blend as a pure function (also the unit-test seam for the
+         * concentration property): persona-following fraction of the aligned/misaligned
+         * weight plus the remaining fraction of the reduced uniform baseline.
+         */
+        internal fun weightsFor(interests: Set<CategoryPool>): Map<CategoryPool, Float> {
+            val follow = SyntheticPersona.PERSONA_FOLLOW_FRACTION
+            val aligned = ALIGNED_WEIGHT * follow + UNIFORM_BASELINE_WEIGHT * (1f - follow)
+            val misaligned = MISALIGNED_WEIGHT * follow + UNIFORM_BASELINE_WEIGHT * (1f - follow)
+            return CategoryPool.values().associateWith { category ->
+                if (category in interests) aligned else misaligned
+            }
+        }
     }
 }
 
 /**
  * Engine channels that bind to the active persona (E8 #174). Each adopts a freshly
  * rotated persona after its own deterministic lag — see
- * [PersonaRotationLayer.personaForChannel].
+ * [PersonaRotationLayer.personaForChannel]. WEIGHTS is the Layer 3 category
+ * distribution itself (added by E9 #176: the peakier blend made an unstaggered
+ * weights flip the sharpest remaining rotation change-point).
  */
-enum class PersonaChannel { LOCATION, APP_SIGNAL, RHYTHM }
+enum class PersonaChannel { LOCATION, APP_SIGNAL, RHYTHM, WEIGHTS }

--- a/app/src/main/java/com/fauxx/targeting/layer3/PersonaRotationLayer.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer3/PersonaRotationLayer.kt
@@ -58,6 +58,44 @@ class PersonaRotationLayer @Inject constructor(
 
     val currentPersona: Flow<SyntheticPersona?> = _currentPersona.asStateFlow()
 
+    /** Persona that was current before the last rotation; in-memory only (see below). */
+    private val _previousPersona = MutableStateFlow<SyntheticPersona?>(null)
+
+    /**
+     * The persona a given engine channel should BIND to (E8 #174): non-null only while
+     * Layer 3 is enabled. The user's Layer 3 toggle is the single persona kill switch —
+     * when off, location spoofing, app signals, and rate modulation must all fall back
+     * to their unbound behavior, not keep following a stale persona.
+     *
+     * STAGGERED ADOPTION: if every channel switched personas at the same instant,
+     * rotation would be a synchronized multi-channel change-point (region, interest
+     * mix, and daily rhythm all stepping together) — a clean segmentation boundary no
+     * real human produces. Each channel therefore keeps serving the PREVIOUS persona
+     * for a deterministic per-(persona, channel) lag of up to [CHANNEL_MAX_LAG_MS]
+     * after rotation, so the new identity phases in channel by channel over hours to
+     * days. The previous persona is held in memory only: after a process restart a
+     * channel still inside its lag window adopts the current persona early, which
+     * degrades smoothly (one fewer staggered step) rather than incoherently.
+     */
+    fun personaForChannel(channel: PersonaChannel): SyntheticPersona? {
+        if (!_enabled.value) return null
+        val current = _currentPersona.value ?: return null
+        val previous = _previousPersona.value ?: return current
+        val sinceRotation = clock.currentTimeMillis() - current.createdAt
+        return if (sinceRotation < adoptionLagMs(current.id, channel)) previous else current
+    }
+
+    /** Deterministic adoption lag in 0..[CHANNEL_MAX_LAG_MS] per (persona, channel). */
+    @androidx.annotation.VisibleForTesting
+    internal fun adoptionLagMs(personaId: String, channel: PersonaChannel): Long =
+        "$personaId:${channel.name}".hashCode().mod(CHANNEL_MAX_LAG_MS.toInt()).toLong()
+
+    @androidx.annotation.VisibleForTesting
+    internal fun setPersonasForTest(current: SyntheticPersona?, previous: SyntheticPersona?) {
+        _currentPersona.value = current
+        _previousPersona.value = previous
+    }
+
     /**
      * Stable [StateFlow] emitting the current Layer 3 weight map.
      * Recomputes reactively whenever the current persona or enabled flag changes.
@@ -174,6 +212,9 @@ class PersonaRotationLayer @Inject constructor(
         scope.launch {
             try {
                 val newPersona = generator.generate()
+                // Keep the outgoing persona so channels can phase the new one in
+                // (see personaForChannel).
+                _previousPersona.value = _currentPersona.value
                 _currentPersona.value = newPersona
                 historyDao.insert(
                     PersonaHistoryEntity(
@@ -193,5 +234,15 @@ class PersonaRotationLayer @Inject constructor(
     companion object {
         /** 90 days in milliseconds. */
         private const val HISTORY_RETENTION_MS = 90L * 24 * 60 * 60 * 1000
+
+        /** Upper bound for per-channel persona adoption lag: 48 hours. */
+        internal const val CHANNEL_MAX_LAG_MS = 48L * 60 * 60 * 1000
     }
 }
+
+/**
+ * Engine channels that bind to the active persona (E8 #174). Each adopts a freshly
+ * rotated persona after its own deterministic lag — see
+ * [PersonaRotationLayer.personaForChannel].
+ */
+enum class PersonaChannel { LOCATION, APP_SIGNAL, RHYTHM }

--- a/app/src/main/java/com/fauxx/ui/format/DemographicLabels.kt
+++ b/app/src/main/java/com/fauxx/ui/format/DemographicLabels.kt
@@ -56,6 +56,21 @@ fun Profession.displayNameRes(): Int = when (this) {
     Profession.OTHER -> R.string.profession_other
 }
 
+/**
+ * Resolve a [com.fauxx.data.model.SyntheticPersona] demographic string — a layer-1 enum
+ * name like "AGE_35_44" or "FINANCE_PROF" — to its label resource. Returns null for
+ * unparseable values (personas persisted before the enum-name canonicalization, or
+ * template-only regions like "RUSSIA" that have no enum entry); callers fall back to
+ * showing the raw stored string.
+ */
+@StringRes
+fun personaAgeRangeRes(raw: String): Int? =
+    runCatching { AgeRange.valueOf(raw) }.getOrNull()?.displayNameRes()
+
+@StringRes
+fun personaProfessionRes(raw: String): Int? =
+    runCatching { Profession.valueOf(raw) }.getOrNull()?.displayNameRes()
+
 @StringRes
 fun Region.displayNameRes(): Int = when (this) {
     Region.US_NORTHEAST -> R.string.region_us_northeast

--- a/app/src/main/java/com/fauxx/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/com/fauxx/ui/screens/DashboardScreen.kt
@@ -61,6 +61,8 @@ import com.fauxx.R
 import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.engine.EngineState
 import com.fauxx.ui.format.displayNameRes
+import com.fauxx.ui.format.personaAgeRangeRes
+import com.fauxx.ui.format.personaProfessionRes
 import com.fauxx.ui.viewmodels.DashboardViewModel
 
 /**
@@ -236,14 +238,18 @@ fun DashboardScreen(
             CategoryDonutCard(distribution = uiState.categoryDistribution)
         }
 
-        // Current persona card
+        // Current persona card. Demographics are stored as enum names ("AGE_35_44");
+        // resolve to localized labels, falling back to the raw string for personas
+        // persisted before the enum-name canonicalization.
         uiState.currentPersona?.let { persona ->
             val interestLabels = persona.interests.take(3)
                 .map { stringResource(it.displayNameRes()) }
             PersonaCard(
                 name = persona.name,
-                ageRange = persona.ageRange,
-                profession = persona.profession,
+                ageRange = personaAgeRangeRes(persona.ageRange)
+                    ?.let { stringResource(it) } ?: persona.ageRange,
+                profession = personaProfessionRes(persona.profession)
+                    ?.let { stringResource(it) } ?: persona.profession,
                 interests = interestLabels.joinToString(", ")
             )
         }

--- a/app/src/main/java/com/fauxx/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/viewmodels/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import com.fauxx.data.db.ActionLogDao
 import com.fauxx.data.model.IntensityLevel
 import com.fauxx.data.querybank.MarkovQueryGenerator
 import com.fauxx.engine.PoisonProfileRepository
+import com.fauxx.engine.scheduling.CircadianObserver
 import com.fauxx.locale.LocaleManager
 import com.fauxx.locale.SupportedLocale
 import com.fauxx.logging.EncryptedFileTree
@@ -63,7 +64,8 @@ class SettingsViewModel @Inject constructor(
     private val targetingEngine: TargetingEngine,
     private val encryptedFileTree: EncryptedFileTree,
     private val localeManager: LocaleManager,
-    private val markovGenerator: MarkovQueryGenerator
+    private val markovGenerator: MarkovQueryGenerator,
+    private val circadianObserver: CircadianObserver
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(loadFromProfile())
@@ -119,6 +121,9 @@ class SettingsViewModel @Inject constructor(
             demographicDao.delete()
             platformDao.deleteAll()
             personaHistoryDao.deleteAll()
+            // Wipe the learned daily-rhythm histogram, in memory and on disk, so the
+            // behavioral profile doesn't survive a "delete all data" (E10 #177).
+            circadianObserver.clear()
             // Clear the recoverable trail too: the encrypted log files (up to 48h of
             // query/persona text) and the Markov model trained from custom interests.
             // Without these, "delete all data" leaves a recoverable activity trail.

--- a/app/src/main/java/com/fauxx/ui/viewmodels/TargetingViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/viewmodels/TargetingViewModel.kt
@@ -11,6 +11,7 @@ import com.fauxx.data.querybank.MarkovQueryGenerator
 import com.fauxx.di.PreferenceKeys
 import com.fauxx.di.fauxxDataStore
 import com.fauxx.engine.PoisonProfileRepository
+import com.fauxx.engine.scheduling.CircadianObserver
 import com.fauxx.logging.EncryptedFileTree
 import com.fauxx.targeting.TargetingEngine
 import com.fauxx.targeting.layer1.AgeRange
@@ -95,6 +96,7 @@ class TargetingViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val encryptedFileTree: EncryptedFileTree,
     private val markovGenerator: MarkovQueryGenerator,
+    private val circadianObserver: CircadianObserver,
     private val clock: Clock = SystemClockImpl(),
 ) : ViewModel() {
 
@@ -274,6 +276,9 @@ class TargetingViewModel @Inject constructor(
             demographicDao.delete()
             platformDao.deleteAll()
             personaHistoryDao.deleteAll()
+            // Wipe the learned daily-rhythm histogram (memory + disk) so the behavioral
+            // profile doesn't survive a profile wipe (E10 #177).
+            circadianObserver.clear()
             // The Markov model is seeded from custom interests on this profile, and the
             // encrypted logs hold persona/profile dumps — clear both so no interest-derived
             // trail survives a profile wipe.

--- a/app/src/test/java/com/fauxx/CircadianObserverTest.kt
+++ b/app/src/test/java/com/fauxx/CircadianObserverTest.kt
@@ -1,0 +1,99 @@
+package com.fauxx
+
+import android.content.Context
+import com.fauxx.engine.scheduling.CircadianObserver
+import com.fauxx.engine.scheduling.CircadianUsageDao
+import com.fauxx.support.FakeClock
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E10 (#177): the in-memory histogram logic of [CircadianObserver] — the bits that don't need
+ * a live screen-on broadcast. The receiver registration and DB round-trip are exercised by the
+ * instrumented tests; here we pin the counting, drift-rescale, snapshot-isolation, and wipe
+ * behavior that the rate modulator depends on.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CircadianObserverTest {
+
+    private fun observer(
+        dao: CircadianUsageDao = mockk(relaxed = true),
+    ): CircadianObserver = CircadianObserver(
+        context = mockk<Context>(relaxed = true),
+        dao = dao,
+        clock = FakeClock(0L),
+    )
+
+    @Test
+    fun `recordEvent increments the bucket for the given hour`() {
+        val o = observer()
+        o.recordEvent(9)
+        o.recordEvent(9)
+        o.recordEvent(14)
+        val counts = o.hourlyCounts()
+        assertEquals(2L, counts[9])
+        assertEquals(1L, counts[14])
+        assertEquals(0L, counts[0])
+        assertEquals(24, counts.size)
+    }
+
+    @Test
+    fun `out-of-range hours are ignored`() {
+        val o = observer()
+        o.recordEvent(-1)
+        o.recordEvent(24)
+        o.recordEvent(99)
+        assertEquals(0L, o.hourlyCounts().sum())
+    }
+
+    @Test
+    fun `reaching the rescale cap halves every bucket - drift decay`() {
+        val o = observer()
+        o.recordEvent(3) // a stale observation in another hour
+        repeat(CircadianObserver.RESCALE_CAP.toInt()) { o.recordEvent(10) }
+        val counts = o.hourlyCounts()
+        // On the cap-th increment hour 10 hit the cap and all buckets were halved.
+        assertEquals(CircadianObserver.RESCALE_CAP / 2, counts[10])
+        // The lone older observation decayed away under the same halving.
+        assertEquals(0L, counts[3])
+    }
+
+    @Test
+    fun `hourlyCounts returns an isolated copy`() {
+        val o = observer()
+        o.recordEvent(5)
+        val snap = o.hourlyCounts()
+        snap[5] = 999L // mutating the returned array must not affect internal state
+        assertEquals(1L, o.hourlyCounts()[5])
+    }
+
+    @Test
+    fun `clear zeroes the histogram and wipes the persisted rows`() = runTest {
+        val dao: CircadianUsageDao = mockk(relaxed = true)
+        val o = observer(dao)
+        o.recordEvent(7)
+        o.recordEvent(7)
+        assertTrue(o.hourlyCounts().sum() > 0)
+
+        o.clear()
+
+        assertEquals(0L, o.hourlyCounts().sum())
+        coVerify { dao.deleteAll() }
+    }
+
+    @Test
+    fun `clear advances the generation so an in-flight persist is voided`() = runTest {
+        // Regression guard for the wipe race: persistSnapshot() captures the generation with
+        // its snapshot and skips the write if it has advanced, so a "Clear My Profile" cannot
+        // be silently undone by a persist that was queued before the wipe.
+        val o = observer()
+        val before = o.generationForTest()
+        o.clear()
+        assertTrue("clear() must bump the generation", o.generationForTest() > before)
+    }
+}

--- a/app/src/test/java/com/fauxx/CircadianRateModulatorTest.kt
+++ b/app/src/test/java/com/fauxx/CircadianRateModulatorTest.kt
@@ -1,0 +1,81 @@
+package com.fauxx
+
+import com.fauxx.engine.scheduling.CircadianRateModulator
+import com.fauxx.engine.scheduling.RateModulator
+import com.fauxx.engine.scheduling.UsageHistogram
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E10 (#177): the observed-rhythm modulator. Acceptance criterion — the synthetic rate curve
+ * tracks a supplied observed usage profile — plus the fallback-to-neutral and rate-honesty
+ * (issue #76) contracts.
+ */
+class CircadianRateModulatorTest {
+
+    private fun histogram(counts: LongArray) = object : UsageHistogram {
+        override fun hourlyCounts(): LongArray = counts
+    }
+
+    private fun curve(m: CircadianRateModulator): List<Float> = (0..23).map { m.multiplier(it) }
+
+    /** Evening-heavy profile: most screen-ons between 18:00 and 22:00. Well above maturity. */
+    private fun eveningProfile(): LongArray = LongArray(24).apply {
+        for (h in 0..23) this[h] = 2L
+        for (h in 18..22) this[h] = 30L
+    }
+
+    @Test
+    fun `neutral until enough observations accumulate`() {
+        val sparse = LongArray(24).apply { this[20] = CircadianRateModulator.MIN_OBSERVATIONS - 1 }
+        val m = CircadianRateModulator(histogram(sparse))
+        curve(m).forEach { assertEquals(1f, it, 0f) }
+    }
+
+    @Test
+    fun `synthetic rate curve tracks the supplied observed profile`() {
+        val m = CircadianRateModulator(histogram(eveningProfile()))
+        val c = curve(m)
+        val peakHour = c.indices.maxBy { c[it] }
+        val troughHour = c.indices.minBy { c[it] }
+        assertTrue("peak $peakHour should fall in the observed busy window 18..22", peakHour in 18..22)
+        assertTrue("trough $troughHour should be a low-usage hour", troughHour !in 18..22)
+        // Busy hours get a higher multiplier than quiet hours.
+        assertTrue("busy hour must out-rate a quiet hour", c[20] > c[4])
+    }
+
+    @Test
+    fun `24-hour mean stays at one - rate honesty`() {
+        val c = curve(CircadianRateModulator(histogram(eveningProfile())))
+        val mean = c.sum() / c.size
+        assertTrue("mean $mean drifted from 1.0", abs(mean - 1f) < 1e-3f)
+    }
+
+    @Test
+    fun `output never leaves the documented multiplier band`() {
+        // A single-hour spike is the most extreme shape the band has to absorb.
+        val spike = LongArray(24).apply { this[9] = 5_000L }
+        val c = curve(CircadianRateModulator(histogram(spike)))
+        c.forEachIndexed { h, v ->
+            assertTrue(
+                "hour $h multiplier $v outside [${RateModulator.MIN_MULTIPLIER}, ${RateModulator.MAX_MULTIPLIER}]",
+                v in RateModulator.MIN_MULTIPLIER..RateModulator.MAX_MULTIPLIER
+            )
+        }
+    }
+
+    @Test
+    fun `a perfectly flat mature profile is neutral`() {
+        val flat = LongArray(24) { 10L } // total 240, well past maturity, but no shape
+        curve(CircadianRateModulator(histogram(flat))).forEach { assertEquals(1f, it, 1e-6f) }
+    }
+
+    @Test
+    fun `out-of-range hours are neutral`() {
+        val m = CircadianRateModulator(histogram(eveningProfile()))
+        assertEquals(1f, m.multiplier(-1), 0f)
+        assertEquals(1f, m.multiplier(24), 0f)
+    }
+}

--- a/app/src/test/java/com/fauxx/CityRegionAssetContractTest.kt
+++ b/app/src/test/java/com/fauxx/CityRegionAssetContractTest.kt
@@ -1,0 +1,175 @@
+package com.fauxx
+
+import android.content.Context
+import com.fauxx.data.location.CityCoord
+import com.fauxx.data.location.CityDatabase
+import com.fauxx.targeting.layer1.Region
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import io.mockk.every
+import io.mockk.mockk
+import java.io.ByteArrayInputStream
+import java.io.File
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E8 (#174) contract test for the city-region backfill: every bundled city must carry
+ * region tokens that persona region hints can match, because
+ * [CityDatabase.randomCity]'s substring filter silently falls back to ALL cities on an
+ * empty match — exactly the dead-code trap (M3 spike, trap 1) the backfill fixes.
+ * Regenerate with scripts/backfill_city_regions.py if this turns red.
+ */
+class CityRegionAssetContractTest {
+
+    private val cities: List<CityCoord> by lazy {
+        val type = object : TypeToken<List<CityCoord>>() {}.type
+        Gson().fromJson(readAsset().decodeToString(), type)
+    }
+
+    // RUSSIA has no Region enum value but is the region string of the ru-locale
+    // persona templates; UNBOUND is the sentinel for cities deliberately excluded
+    // from persona location stories (uninhabited territories). The hint match is
+    // plain substring.
+    private val validTokens =
+        Region.entries.map { it.name }.toSet() + "RUSSIA" + "UNBOUND"
+
+    @Test
+    fun `city count matches the shipped asset`() {
+        assertEquals(806, cities.size)
+    }
+
+    @Test
+    fun `every city has a non-empty region`() {
+        cities.forEach { assertTrue("${it.name} has no region", it.region.isNotBlank()) }
+    }
+
+    @Test
+    fun `every region token is a Region enum name or RUSSIA`() {
+        cities.forEach { city ->
+            city.region.split(" ").forEach { token ->
+                assertTrue("${city.name}: unknown token $token", token in validTokens)
+            }
+        }
+    }
+
+    @Test
+    fun `US cities carry exactly one US region token or the UNBOUND sentinel`() {
+        val us = cities.filter { it.name.endsWith(", United States") }
+        assertTrue(us.isNotEmpty())
+        us.forEach { city ->
+            val tokens = city.region.split(" ")
+            assertTrue("${city.name}: ${city.region}", tokens.size == 1)
+            val token = tokens.single()
+            assertTrue(
+                "${city.name}: ${city.region}",
+                token.startsWith("US_") || token == "UNBOUND"
+            )
+        }
+    }
+
+    @Test
+    fun `every region a shipped persona can carry matches at least one city`() {
+        // Data-driven against the real persona sources: every region string a persona
+        // can be generated with (templates for all locales + the E7 US distribution)
+        // must be matchable, or that persona's location channel silently unbinds.
+        // Region.OTHER is the documented exception: legacy EN templates carry it and
+        // it intentionally falls back to the unfiltered world list.
+        val personaRegions = personaSourceRegions() - "OTHER"
+        assertTrue(personaRegions.size >= 15)
+        personaRegions.forEach { hint ->
+            assertTrue(
+                "persona region $hint matches no city — that persona's location " +
+                    "story would silently unbind",
+                cities.any { it.region.contains(hint, ignoreCase = true) }
+            )
+        }
+    }
+
+    private fun personaSourceRegions(): Set<String> {
+        val gson = Gson()
+        val regions = mutableSetOf<String>()
+        listOf(
+            "persona_templates.json", "persona_templates/es.json",
+            "persona_templates/fr.json", "persona_templates/ru.json"
+        ).forEach { path ->
+            val type = object : TypeToken<List<Map<String, Any>>>() {}.type
+            val templates: List<Map<String, Any>> =
+                gson.fromJson(readAssetText(path), type)
+            templates.mapNotNullTo(regions) { it["region"] as? String }
+        }
+        val distType = object : TypeToken<Map<String, Any>>() {}.type
+        val dist: Map<String, Any> = gson.fromJson(
+            readAssetText("persona_distribution.json"), distType
+        )
+        @Suppress("UNCHECKED_CAST")
+        val dims = dist["dimensions"] as Map<String, List<String>>
+        regions.addAll(dims.getValue("region"))
+        return regions
+    }
+
+    @Test
+    fun `every US persona region can be matched by at least one city`() {
+        val usRegions = listOf(
+            "US_NORTHEAST", "US_SOUTHEAST", "US_MIDWEST", "US_SOUTHWEST", "US_WEST"
+        )
+        usRegions.forEach { region ->
+            assertTrue(
+                "no city tagged $region — EN personas in that region would silently " +
+                    "fall back to the full world list",
+                cities.any { it.region == region }
+            )
+        }
+    }
+
+    @Test
+    fun `randomCity honors persona region hints against the real asset`() {
+        val db = cityDatabase(Random(42))
+
+        repeat(50) {
+            assertTrue(db.randomCity(regionHint = "US_WEST").region.contains("US_WEST"))
+        }
+        repeat(20) {
+            val quebec = db.randomCity(regionHint = "QUEBEC")
+            assertTrue(quebec.name, quebec.name in setOf("Montreal, Canada", "Quebec City, Canada"))
+        }
+        repeat(20) {
+            assertTrue(db.randomCity(regionHint = "RUSSIA").name.endsWith(", Russia"))
+        }
+        // Unknown hints fall back to the WHOLE list, not to a single hardcoded city:
+        // 100 draws must span many distinct regions.
+        val fallbackRegions = (1..100).map { db.randomCity(regionHint = "NO_SUCH_REGION").region }.toSet()
+        assertTrue(
+            "unknown hint should draw from the full world list, saw only $fallbackRegions",
+            fallbackRegions.size > 3
+        )
+    }
+
+    private fun cityDatabase(random: Random): CityDatabase {
+        val bytes = readAsset()
+        val context = mockk<Context>(relaxed = true) {
+            every { assets } returns mockk {
+                every { open("city_coords.json") } answers { ByteArrayInputStream(bytes) }
+            }
+        }
+        return CityDatabase(context, random)
+    }
+
+    private fun readAsset(): ByteArray = readAssetBytes("city_coords.json")
+
+    private fun readAssetText(relativePath: String): String =
+        readAssetBytes(relativePath).decodeToString()
+
+    private fun readAssetBytes(relativePath: String): ByteArray {
+        // :app:testFullDebugUnitTest runs with cwd at the app module root.
+        val candidates = listOf(
+            File("src/main/assets/$relativePath"),
+            File("app/src/main/assets/$relativePath")
+        )
+        val file = candidates.firstOrNull { it.exists() }
+            ?: error("Could not locate $relativePath relative to ${File(".").absolutePath}")
+        return file.readBytes()
+    }
+}

--- a/app/src/test/java/com/fauxx/CompositeRateModulatorTest.kt
+++ b/app/src/test/java/com/fauxx/CompositeRateModulatorTest.kt
@@ -1,0 +1,106 @@
+package com.fauxx
+
+import com.fauxx.data.model.SyntheticPersona
+import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.engine.scheduling.CircadianRateModulator
+import com.fauxx.engine.scheduling.CompositeRateModulator
+import com.fauxx.engine.scheduling.RateModulator
+import com.fauxx.engine.scheduling.UsageHistogram
+import com.fauxx.targeting.layer3.PersonaRateModulator
+import com.fauxx.targeting.layer3.PersonaRotationLayer
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E10 (#177): the single seam composing the persona rhythm (E8) with the observed circadian
+ * rhythm (E10). Verifies the combined curve stays honest (24h mean exactly 1.0, issue #76) and
+ * within the clamp band, that each input degrades to neutral independently, and that the
+ * composite reduces to whichever signal is present.
+ */
+class CompositeRateModulatorTest {
+
+    private fun persona(id: String?) = id?.let {
+        SyntheticPersona(
+            id = it, name = "Test", ageRange = "AGE_25_34", profession = "ENGINEER",
+            region = "US_WEST", interests = setOf(CategoryPool.COOKING), activeUntil = Long.MAX_VALUE
+        )
+    }
+
+    private fun personaModulator(id: String?): PersonaRateModulator {
+        val layer = mockk<PersonaRotationLayer> { every { personaForChannel(any()) } returns persona(id) }
+        return PersonaRateModulator(layer)
+    }
+
+    private fun circadianModulator(counts: LongArray): CircadianRateModulator =
+        CircadianRateModulator(object : UsageHistogram {
+            override fun hourlyCounts(): LongArray = counts
+        })
+
+    private val matureEvening = LongArray(24).apply {
+        for (h in 0..23) this[h] = 2L
+        for (h in 18..22) this[h] = 40L
+    }
+    private val sparse = LongArray(24) // below maturity -> circadian neutral
+
+    private fun curve(m: CompositeRateModulator): List<Float> = (0..23).map { m.multiplier(it) }
+
+    @Test
+    fun `neutral when neither signal is present`() {
+        val c = curve(CompositeRateModulator(personaModulator(null), circadianModulator(sparse)))
+        c.forEach { assertEquals(1f, it, 1e-6f) }
+    }
+
+    @Test
+    fun `reduces to the circadian curve when no persona is active`() {
+        val circadian = circadianModulator(matureEvening)
+        val composite = CompositeRateModulator(personaModulator(null), circadian)
+        (0..23).forEach { h ->
+            assertEquals("hour $h", circadian.multiplier(h), composite.multiplier(h), 1e-5f)
+        }
+    }
+
+    @Test
+    fun `reduces to the persona curve when circadian has too little data`() {
+        val persona = personaModulator("stable-id")
+        val composite = CompositeRateModulator(persona, circadianModulator(sparse))
+        (0..23).forEach { h ->
+            assertEquals("hour $h", persona.multiplier(h), composite.multiplier(h), 1e-5f)
+        }
+    }
+
+    @Test
+    fun `both signals - 24h mean stays at one and stays within the band`() {
+        val c = curve(CompositeRateModulator(personaModulator("stable-id"), circadianModulator(matureEvening)))
+        val mean = c.sum() / c.size
+        assertTrue("mean $mean drifted from 1.0", abs(mean - 1f) < 1e-3f)
+        c.forEachIndexed { h, v ->
+            assertTrue(
+                "hour $h multiplier $v outside band",
+                v in RateModulator.MIN_MULTIPLIER..RateModulator.MAX_MULTIPLIER
+            )
+        }
+    }
+
+    @Test
+    fun `both signals combine - composite differs from either input alone`() {
+        val persona = personaModulator("stable-id")
+        val circadian = circadianModulator(matureEvening)
+        val composite = CompositeRateModulator(persona, circadian)
+        val comp = curve(composite)
+        val personaOnly = (0..23).map { persona.multiplier(it) }
+        val circadianOnly = (0..23).map { circadian.multiplier(it) }
+        assertTrue("composite must not equal persona alone", comp != personaOnly)
+        assertTrue("composite must not equal circadian alone", comp != circadianOnly)
+    }
+
+    @Test
+    fun `out-of-range hours are neutral`() {
+        val m = CompositeRateModulator(personaModulator("stable-id"), circadianModulator(matureEvening))
+        assertEquals(1f, m.multiplier(-1), 0f)
+        assertEquals(1f, m.multiplier(24), 0f)
+    }
+}

--- a/app/src/test/java/com/fauxx/DemographicLabelsTest.kt
+++ b/app/src/test/java/com/fauxx/DemographicLabelsTest.kt
@@ -1,0 +1,33 @@
+package com.fauxx
+
+import com.fauxx.ui.format.personaAgeRangeRes
+import com.fauxx.ui.format.personaProfessionRes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the legacy-tolerance contract on the persona label helpers: enum names resolve
+ * to label resources; anything else (personas persisted before the E7 enum-name
+ * canonicalization, or template-only values with no enum entry) returns null so the UI
+ * falls back to showing the raw stored string instead of crashing.
+ */
+class DemographicLabelsTest {
+
+    @Test
+    fun `enum names resolve to their label resources`() {
+        assertEquals(R.string.age_35_44, personaAgeRangeRes("AGE_35_44"))
+        assertEquals(R.string.age_65_plus, personaAgeRangeRes("AGE_65_PLUS"))
+        assertEquals(R.string.profession_finance_prof, personaProfessionRes("FINANCE_PROF"))
+        assertEquals(R.string.profession_other, personaProfessionRes("OTHER"))
+    }
+
+    @Test
+    fun `legacy display strings return null for raw fallback`() {
+        assertNull(personaAgeRangeRes("35-44"))
+        assertNull(personaAgeRangeRes("65+"))
+        assertNull(personaProfessionRes("Business Professional"))
+        assertNull(personaProfessionRes("Professional"))
+        assertNull(personaProfessionRes(""))
+    }
+}

--- a/app/src/test/java/com/fauxx/DistancingRebalanceTest.kt
+++ b/app/src/test/java/com/fauxx/DistancingRebalanceTest.kt
@@ -1,0 +1,146 @@
+package com.fauxx
+
+import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.targeting.TargetingEngine
+import com.fauxx.targeting.WeightNormalizer
+import com.fauxx.targeting.layer0.UniformEntropyLayer
+import com.fauxx.targeting.layer1.SelfReportLayer
+import com.fauxx.targeting.layer2.AdversarialScraperLayer
+import com.fauxx.targeting.layer3.PersonaRotationLayer
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E9 (#176): the Distancing Engine rebalance toward persona dominance. Pins the
+ * acceptance criteria:
+ *  - the combined, normalized output is measurably peakier toward the persona's
+ *    interests than the pre-E9 blend (concentration strictly increases),
+ *  - coverage never collapses (every category stays at or above the normalizer floor,
+ *    misaligned categories far above it),
+ *  - the multiplicative combine + normalization orchestration is untouched (validated
+ *    end-to-end through the real TargetingEngine).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DistancingRebalanceTest {
+
+    private val normalizer = WeightNormalizer()
+
+    private val interests = setOf(
+        CategoryPool.COOKING, CategoryPool.TRAVEL, CategoryPool.FITNESS,
+        CategoryPool.GAMING, CategoryPool.MUSIC
+    )
+
+    /** Pre-E9 blend, reproduced verbatim: 70% follow, full-strength uniform baseline. */
+    private fun preE9Weights(): Map<CategoryPool, Float> {
+        val follow = 0.70f
+        val aligned = 2.0f * follow + 1.0f * (1f - follow)     // 1.7
+        val misaligned = 0.3f * follow + 1.0f * (1f - follow)  // 0.51
+        return CategoryPool.values().associateWith {
+            if (it in interests) aligned else misaligned
+        }
+    }
+
+    /** Probability mass the normalized distribution puts on the persona's interests. */
+    private fun concentration(weights: Map<CategoryPool, Float>): Float =
+        normalizer.normalizeComplete(weights)
+            .filterKeys { it in interests }.values.sum()
+
+    @Test
+    fun `both E9 levers are pinned - blend values are exact`() {
+        // 2.0*0.85 + 0.6*0.15 = 1.79 and 0.3*0.85 + 0.6*0.15 = 0.345. A regression of
+        // EITHER lever (PERSONA_FOLLOW_FRACTION back to 0.70, or UNIFORM_BASELINE_WEIGHT
+        // back to 1.0) shifts these; threshold-only assertions previously let a
+        // baseline-weight regression (1.85/0.405) slip through every test.
+        val weights = PersonaRotationLayer.weightsFor(interests)
+        org.junit.Assert.assertEquals(1.79f, weights.getValue(CategoryPool.COOKING), 1e-3f)
+        org.junit.Assert.assertEquals(0.345f, weights.getValue(CategoryPool.LEGAL), 1e-3f)
+    }
+
+    @Test
+    fun `rebalanced blend is measurably peakier toward persona interests`() {
+        val before = concentration(preE9Weights())
+        val after = concentration(PersonaRotationLayer.weightsFor(interests))
+
+        assertTrue(
+            "concentration must increase: before=$before after=$after",
+            after > before + 0.05f
+        )
+        // Absolute pin: full E9 yields 0.490 (k=5 of 32 categories); a partial
+        // regression of the uniform baseline alone yields 0.458 and must fail.
+        assertTrue("concentration $after below the full-E9 level", after > 0.47f)
+    }
+
+    @Test
+    fun `aligned-to-misaligned separation exceeds the pre-E9 ratio`() {
+        val weights = PersonaRotationLayer.weightsFor(interests)
+        val aligned = weights.getValue(CategoryPool.COOKING)
+        val misaligned = weights.getValue(CategoryPool.LEGAL)
+        val ratio = aligned / misaligned
+
+        // Pre-E9: 1.7/0.51 = 3.33. Rebalanced: 1.79/0.345 = 5.19. A uniform-baseline
+        // regression to 1.0 gives 1.85/0.405 = 4.57 and must FAIL this threshold.
+        assertTrue("separation ratio $ratio should exceed 5.0", ratio > 5.0f)
+    }
+
+    @Test
+    fun `coverage never collapses - misaligned categories keep sampleable mass`() {
+        val normalized = normalizer.normalizeComplete(PersonaRotationLayer.weightsFor(interests))
+
+        // (The normalizer clamps every output to MIN_WEIGHT by construction, so
+        // asserting >= MIN_WEIGHT would be tautological.) The meaningful guard: with
+        // this layer alone, misaligned categories must sit FAR above the floor —
+        // a floor-pinned category is one layer-stack away from the detectable
+        // absence-signal. 0.345/18.265 = 0.019 per category.
+        normalized.filterKeys { it !in interests }.forEach { (category, w) ->
+            assertTrue("misaligned $category nearly collapsed: $w", w > 0.005f)
+        }
+    }
+
+    @Test
+    fun `end-to-end - engine output is persona-led with L3 enabled`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val layer1 = mockk<SelfReportLayer> {
+            every { getWeights() } returns flowOf(neutral())
+        }
+        val layer2 = mockk<AdversarialScraperLayer> {
+            every { getWeights() } returns flowOf(neutral())
+            every { setEnabled(any()) } returns Unit
+        }
+        val layer3 = mockk<PersonaRotationLayer> {
+            every { getWeights() } returns flowOf(PersonaRotationLayer.weightsFor(interests))
+            every { setEnabled(any()) } returns Unit
+        }
+        val engine = TargetingEngine(
+            UniformEntropyLayer(), layer1, layer2, layer3, normalizer,
+            CoroutineScope(dispatcher), Unit
+        )
+        try {
+            engine.setLayer3Enabled(true)
+
+            val weights = engine.getWeights().first { w ->
+                // Skip the pre-emission uniform default.
+                w.getValue(CategoryPool.COOKING) > w.getValue(CategoryPool.LEGAL)
+            }
+            val interestMass = weights.filterKeys { it in interests }.values.sum()
+            val uniformMass = interests.size.toFloat() / CategoryPool.values().size
+
+            assertTrue(
+                "engine output should be persona-led: interest mass $interestMass vs uniform $uniformMass",
+                interestMass > uniformMass * 2.5f
+            )
+        } finally {
+            engine.close()
+        }
+    }
+
+    private fun neutral(): Map<CategoryPool, Float> =
+        CategoryPool.values().associateWith { 1.0f }
+}

--- a/app/src/test/java/com/fauxx/LogScrubberTest.kt
+++ b/app/src/test/java/com/fauxx/LogScrubberTest.kt
@@ -33,6 +33,16 @@ class LogScrubberTest {
     }
 
     @Test
+    fun `scrubs DemographicCell dumps`() {
+        val input = "sampled DemographicCell(age=AGE_25_34, profession=ENGINEER, " +
+            "region=US_WEST, weight=0.01) for persona"
+        val result = LogScrubber.scrub(input)
+        assertFalse(result.contains("AGE_25_34"))
+        assertFalse(result.contains("ENGINEER"))
+        assertTrue(result.contains("[REDACTED]"))
+    }
+
+    @Test
     fun `scrubs interests field`() {
         val input = "interests: [GAMING, COOKING, SPORTS]"
         val result = LogScrubber.scrub(input)

--- a/app/src/test/java/com/fauxx/PersonaConsistencyRulesTest.kt
+++ b/app/src/test/java/com/fauxx/PersonaConsistencyRulesTest.kt
@@ -11,9 +11,9 @@ import java.util.concurrent.TimeUnit
 class PersonaConsistencyRulesTest {
 
     private fun makePersona(
-        ageRange: String = "35-44",
+        ageRange: String = "AGE_35_44",
         interests: Set<CategoryPool> = setOf(CategoryPool.COOKING, CategoryPool.TRAVEL, CategoryPool.SPORTS),
-        profession: String = "Professional"
+        profession: String = "OTHER"
     ) = SyntheticPersona(
         id = "test",
         name = "Test User",
@@ -40,6 +40,65 @@ class PersonaConsistencyRulesTest {
     fun `persona with blank name fails check`() {
         val persona = makePersona().copy(name = "")
         assertFalse(PersonaConsistencyRules.isValid(persona))
+    }
+
+    // The incompatible-trait rules match on AgeRange enum names — the canonical
+    // SyntheticPersona format. Before the E7 canonicalization they compared display
+    // strings ("65+"), which template-sourced personas never carried, so the rules
+    // were silently inert.
+
+    @Test
+    fun `retiree-age persona with narrow academic interests fails check`() {
+        val persona = makePersona(
+            ageRange = "AGE_65_PLUS",
+            interests = setOf(CategoryPool.ACADEMIC, CategoryPool.COOKING)
+        )
+        assertFalse(PersonaConsistencyRules.isValid(persona))
+    }
+
+    @Test
+    fun `retiree-age persona with broad interests including academic passes check`() {
+        val persona = makePersona(
+            ageRange = "AGE_65_PLUS",
+            interests = setOf(CategoryPool.ACADEMIC, CategoryPool.COOKING, CategoryPool.TRAVEL)
+        )
+        assertTrue(PersonaConsistencyRules.isValid(persona))
+    }
+
+    @Test
+    fun `young persona with retirement interest but no finance context fails check`() {
+        val persona = makePersona(
+            ageRange = "AGE_18_24",
+            interests = setOf(CategoryPool.RETIREMENT, CategoryPool.GAMING)
+        )
+        assertFalse(PersonaConsistencyRules.isValid(persona))
+    }
+
+    @Test
+    fun `young persona with retirement interest and finance context passes check`() {
+        val persona = makePersona(
+            ageRange = "AGE_18_24",
+            interests = setOf(CategoryPool.RETIREMENT, CategoryPool.FINANCE)
+        )
+        assertTrue(PersonaConsistencyRules.isValid(persona))
+    }
+
+    @Test
+    fun `young persona whose sole interest is parenting fails check`() {
+        val persona = makePersona(
+            ageRange = "AGE_18_24",
+            interests = setOf(CategoryPool.PARENTING)
+        )
+        assertFalse(PersonaConsistencyRules.isValid(persona))
+    }
+
+    @Test
+    fun `young persona with parenting among other interests passes check`() {
+        val persona = makePersona(
+            ageRange = "AGE_18_24",
+            interests = setOf(CategoryPool.PARENTING, CategoryPool.COOKING)
+        )
+        assertTrue(PersonaConsistencyRules.isValid(persona))
     }
 
     @Test

--- a/app/src/test/java/com/fauxx/PersonaDistributionTest.kt
+++ b/app/src/test/java/com/fauxx/PersonaDistributionTest.kt
@@ -1,0 +1,177 @@
+package com.fauxx
+
+import android.content.Context
+import com.fauxx.targeting.layer3.PersonaDistribution
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.FileNotFoundException
+import kotlin.random.Random
+
+class PersonaDistributionTest {
+
+    private fun distributionWith(json: String?): PersonaDistribution {
+        val context = mockk<Context>(relaxed = true) {
+            every { assets } returns mockk {
+                if (json == null) {
+                    every { open(PersonaDistribution.ASSET_PATH) } throws FileNotFoundException()
+                } else {
+                    every { open(PersonaDistribution.ASSET_PATH) } answers {
+                        ByteArrayInputStream(json.toByteArray())
+                    }
+                }
+            }
+        }
+        return PersonaDistribution(context)
+    }
+
+    private fun cellJson(age: String, prof: String, region: String, weight: Double) =
+        """{"age":"$age","profession":"$prof","region":"$region","weight":$weight}"""
+
+    @Test
+    fun `sample returns null when asset missing`() {
+        assertNull(distributionWith(null).sample(Random(1)))
+    }
+
+    @Test
+    fun `sample returns null for malformed json`() {
+        assertNull(distributionWith("not json at all {").sample(Random(1)))
+    }
+
+    @Test
+    fun `sample returns null when no cells are usable`() {
+        val json = """{"version":1,"cells":[
+            ${cellJson("AGE_999", "STUDENT", "US_WEST", 0.5)},
+            ${cellJson("AGE_25_34", "ASTRONAUT", "US_WEST", 0.3)},
+            ${cellJson("AGE_25_34", "STUDENT", "UK", 0.1)},
+            ${cellJson("AGE_25_34", "STUDENT", "US_WEST", 0.0)}
+        ]}"""
+        assertNull(distributionWith(json).sample(Random(1)))
+    }
+
+    @Test
+    fun `invalid cells are dropped while valid cells remain samplable`() {
+        val json = """{"version":1,"cells":[
+            ${cellJson("AGE_25_34", "ASTRONAUT", "US_WEST", 0.9)},
+            ${cellJson("AGE_25_34", "STUDENT", "SPAIN", 0.9)},
+            ${cellJson("AGE_45_54", "TEACHER", "US_MIDWEST", 0.1)}
+        ]}"""
+        val distribution = distributionWith(json)
+        repeat(50) {
+            val cell = distribution.sample(Random(it))
+            assertNotNull(cell)
+            assertEquals("AGE_45_54", cell!!.age)
+            assertEquals("TEACHER", cell.profession)
+            assertEquals("US_MIDWEST", cell.region)
+        }
+    }
+
+    @Test
+    fun `sampling frequency tracks cell weights`() {
+        val json = """{"version":1,"cells":[
+            ${cellJson("AGE_25_34", "ENGINEER", "US_WEST", 0.9)},
+            ${cellJson("AGE_65_PLUS", "RETIRED", "US_MIDWEST", 0.1)}
+        ]}"""
+        val distribution = distributionWith(json)
+        val random = Random(42)
+        val draws = 2000
+        val heavy = (1..draws).count { distribution.sample(random)!!.profession == "ENGINEER" }
+        val fraction = heavy.toFloat() / draws
+        assertTrue(
+            "Expected ~0.9 of draws from the 0.9-weight cell, got $fraction",
+            fraction in 0.85f..0.95f
+        )
+    }
+
+    @Test
+    fun `weights that do not sum to one are normalized by total weight`() {
+        // 3.0 vs 1.0: if sample() dropped its totalWeight scaling (correct exactly when
+        // weights sum to 1), the heavy cell would be drawn ~100% instead of ~75%.
+        val json = """{"version":1,"cells":[
+            ${cellJson("AGE_25_34", "ENGINEER", "US_WEST", 3.0)},
+            ${cellJson("AGE_65_PLUS", "RETIRED", "US_MIDWEST", 1.0)}
+        ]}"""
+        val distribution = distributionWith(json)
+        val random = Random(13)
+        val draws = 2000
+        val heavy = (1..draws).count { distribution.sample(random)!!.profession == "ENGINEER" }
+        val fraction = heavy.toFloat() / draws
+        assertTrue(
+            "Expected ~0.75 of draws from the 3.0-weight cell, got $fraction",
+            fraction in 0.70f..0.80f
+        )
+    }
+
+    @Test
+    fun `null cell elements are tolerated`() {
+        val json = """{"version":1,"cells":[
+            null,
+            ${cellJson("AGE_45_54", "TEACHER", "US_MIDWEST", 1.0)}
+        ]}"""
+        val cell = distributionWith(json).sample(Random(1))
+        assertNotNull(cell)
+        assertEquals("TEACHER", cell!!.profession)
+    }
+
+    @Test
+    fun `sampled traits always co-occur as a whole cell`() {
+        val json = """{"version":1,"cells":[
+            ${cellJson("AGE_18_24", "STUDENT", "US_WEST", 0.5)},
+            ${cellJson("AGE_65_PLUS", "RETIRED", "US_MIDWEST", 0.5)}
+        ]}"""
+        val distribution = distributionWith(json)
+        val allowed = setOf(
+            Triple("AGE_18_24", "STUDENT", "US_WEST"),
+            Triple("AGE_65_PLUS", "RETIRED", "US_MIDWEST")
+        )
+        val random = Random(7)
+        repeat(200) {
+            val cell = distribution.sample(random)!!
+            assertTrue(
+                "Cross-cell trait mix: $cell",
+                Triple(cell.age, cell.profession, cell.region) in allowed
+            )
+        }
+    }
+
+    /**
+     * Contract test against the REAL bundled artifact, mirroring
+     * [PersonaTemplateGsonContractTest]: locks the loader <-> asset schema (key names,
+     * enum-name values, positive weights) so schema drift in either the build script or
+     * the loader turns this red. JVM tests don't run R8, so @Keep regressions still need
+     * release smoke testing.
+     */
+    @Test
+    fun `real persona_distribution asset loads and samples valid enum names`() {
+        val real = readAssetFile(PersonaDistribution.ASSET_PATH).decodeToString()
+        val distribution = distributionWith(real)
+        val random = Random(99)
+        repeat(100) {
+            val cell = distribution.sample(random)
+            assertNotNull("Real asset failed to load or had no usable cells", cell)
+            // valueOf throws (failing the test) if the artifact carries unknown names.
+            com.fauxx.targeting.layer1.AgeRange.valueOf(cell!!.age)
+            com.fauxx.targeting.layer1.Profession.valueOf(cell.profession)
+            com.fauxx.targeting.layer1.Region.valueOf(cell.region)
+            assertTrue(cell.region.startsWith("US_"))
+            assertTrue(cell.weight > 0.0)
+        }
+    }
+
+    private fun readAssetFile(relativePath: String): ByteArray {
+        // :app:testFullDebugUnitTest runs with cwd at the app module root.
+        val candidates = listOf(
+            File("src/main/assets/$relativePath"),
+            File("app/src/main/assets/$relativePath")
+        )
+        val file = candidates.firstOrNull { it.exists() }
+            ?: error("Could not locate $relativePath relative to ${File(".").absolutePath}")
+        return file.readBytes()
+    }
+}

--- a/app/src/test/java/com/fauxx/PersonaGeneratorDemographicTest.kt
+++ b/app/src/test/java/com/fauxx/PersonaGeneratorDemographicTest.kt
@@ -11,6 +11,7 @@ import com.fauxx.targeting.layer1.Gender
 import com.fauxx.targeting.layer1.Profession
 import com.fauxx.targeting.layer1.Region
 import com.fauxx.targeting.layer1.UserDemographicProfile
+import com.fauxx.targeting.layer3.PersonaDistribution
 import com.fauxx.targeting.layer3.PersonaGenerator
 import com.fauxx.targeting.layer3.PersonaHistoryDao
 import io.mockk.coEvery
@@ -30,13 +31,16 @@ class PersonaGeneratorDemographicTest {
 
     private val context: Context = mockk(relaxed = true) {
         every { assets } returns mockk {
-            // Both the locale-keyed path and the legacy fallback are missing — the
+            // Templates, and the E7 joint distribution, are all missing — the
             // generator falls back to its built-in random pickers, which is what
             // these tests want to exercise.
             every { open("persona_templates/en.json") } throws java.io.FileNotFoundException()
             every { open("persona_templates.json") } throws java.io.FileNotFoundException()
+            every { open(PersonaDistribution.ASSET_PATH) } throws java.io.FileNotFoundException()
         }
     }
+
+    private val distribution = PersonaDistribution(context)
 
     private val localeManager: LocaleManager = mockk(relaxed = true) {
         every { currentLocale } returns SupportedLocale.EN
@@ -53,7 +57,7 @@ class PersonaGeneratorDemographicTest {
             coEvery { get() } returns userProfile
         }
 
-        val generator = PersonaGenerator(context, historyDao, demographicDao, localeManager)
+        val generator = PersonaGenerator(context, historyDao, demographicDao, localeManager, distribution)
 
         // Generate many personas and verify none match user on 2+ traits
         repeat(20) {
@@ -78,7 +82,7 @@ class PersonaGeneratorDemographicTest {
             coEvery { get() } returns userProfile
         }
 
-        val generator = PersonaGenerator(context, historyDao, demographicDao, localeManager)
+        val generator = PersonaGenerator(context, historyDao, demographicDao, localeManager, distribution)
         val persona = generator.generate()
         assertNotNull(persona)
         assertTrue(persona.name.isNotBlank())
@@ -90,7 +94,7 @@ class PersonaGeneratorDemographicTest {
             coEvery { get() } returns null
         }
 
-        val generator = PersonaGenerator(context, historyDao, demographicDao, localeManager)
+        val generator = PersonaGenerator(context, historyDao, demographicDao, localeManager, distribution)
         val persona = generator.generate()
         assertNotNull(persona)
         assertTrue(persona.name.isNotBlank())
@@ -101,38 +105,11 @@ class PersonaGeneratorDemographicTest {
         persona: SyntheticPersona,
         profile: UserDemographicProfile
     ): Int {
+        // SyntheticPersona stores demographics as enum names (E7 canonicalization).
         var count = 0
-        if (profile.ageRange != null) {
-            val userAge = when (profile.ageRange) {
-                AgeRange.AGE_18_24 -> "18-24"
-                AgeRange.AGE_25_34 -> "25-34"
-                AgeRange.AGE_35_44 -> "35-44"
-                AgeRange.AGE_45_54 -> "45-54"
-                AgeRange.AGE_55_64 -> "55-64"
-                AgeRange.AGE_65_PLUS -> "65+"
-            }
-            if (persona.ageRange == userAge) count++
-        }
-        if (profile.profession != null) {
-            val userProf = when (profile.profession) {
-                Profession.STUDENT -> "Student"
-                Profession.TEACHER -> "Teacher"
-                Profession.ENGINEER -> "Engineer"
-                Profession.HEALTHCARE -> "Healthcare Worker"
-                Profession.LEGAL -> "Legal"
-                Profession.FINANCE_PROF -> "Business Professional"
-                Profession.RETAIL -> "Retail Worker"
-                Profession.TRADES -> "Trades"
-                Profession.CREATIVE -> "Creative"
-                Profession.RETIRED -> "Retired"
-                Profession.HOMEMAKER -> "Homemaker"
-                Profession.OTHER -> "Professional"
-            }
-            if (persona.profession == userProf) count++
-        }
-        if (profile.region != null && persona.region == profile.region.name) {
-            count++
-        }
+        if (profile.ageRange != null && persona.ageRange == profile.ageRange.name) count++
+        if (profile.profession != null && persona.profession == profile.profession.name) count++
+        if (profile.region != null && persona.region == profile.region.name) count++
         return count
     }
 }

--- a/app/src/test/java/com/fauxx/PersonaGeneratorJointSamplingTest.kt
+++ b/app/src/test/java/com/fauxx/PersonaGeneratorJointSamplingTest.kt
@@ -1,0 +1,238 @@
+package com.fauxx
+
+import android.content.Context
+import com.fauxx.locale.LocaleManager
+import com.fauxx.locale.SupportedLocale
+import com.fauxx.targeting.layer1.AgeRange
+import com.fauxx.targeting.layer1.DemographicProfileDao
+import com.fauxx.targeting.layer1.Profession
+import com.fauxx.targeting.layer1.Region
+import com.fauxx.targeting.layer1.UserDemographicProfile
+import com.fauxx.targeting.layer3.DemographicCell
+import com.fauxx.targeting.layer3.PersonaDistribution
+import com.fauxx.targeting.layer3.PersonaGenerator
+import com.fauxx.targeting.layer3.PersonaHistoryDao
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.FileNotFoundException
+
+/**
+ * E7 (#173): EN-locale personas joint-sample (age, profession, region) from the bundled
+ * ACS PUMS distribution; non-EN locales never consult it; every existing gate still
+ * applies to joint-sampled candidates.
+ */
+class PersonaGeneratorJointSamplingTest {
+
+    private val historyDao: PersonaHistoryDao = mockk {
+        coEvery { getRecentPersonas(any()) } returns emptyList()
+    }
+
+    private val noProfileDao: DemographicProfileDao = mockk {
+        coEvery { get() } returns null
+    }
+
+    private fun localeManager(locale: SupportedLocale): LocaleManager =
+        mockk(relaxed = true) { every { currentLocale } returns locale }
+
+    /**
+     * Context with the given distribution JSON (null = missing) and optionally EN
+     * persona templates at the legacy path (null = no templates).
+     */
+    private fun contextWith(
+        distributionJson: String?,
+        enTemplatesJson: String? = null,
+    ): Context = mockk(relaxed = true) {
+        every { assets } returns mockk {
+            every { open("persona_templates/en.json") } throws FileNotFoundException()
+            every { open("persona_templates/es.json") } throws FileNotFoundException()
+            if (enTemplatesJson == null) {
+                every { open("persona_templates.json") } throws FileNotFoundException()
+            } else {
+                every { open("persona_templates.json") } answers {
+                    ByteArrayInputStream(enTemplatesJson.toByteArray())
+                }
+            }
+            if (distributionJson == null) {
+                every { open(PersonaDistribution.ASSET_PATH) } throws FileNotFoundException()
+            } else {
+                every { open(PersonaDistribution.ASSET_PATH) } answers {
+                    ByteArrayInputStream(distributionJson.toByteArray())
+                }
+            }
+        }
+    }
+
+    // Two cells chosen to avoid the AGE_18_24/AGE_65_PLUS consistency rules, so candidate
+    // rejection can only come from the joint-sampling path under test.
+    private val twoCellJson = """{"version":1,"cells":[
+        {"age":"AGE_25_34","profession":"ENGINEER","region":"US_WEST","weight":0.6},
+        {"age":"AGE_45_54","profession":"TEACHER","region":"US_MIDWEST","weight":0.4}
+    ]}"""
+
+    @Test
+    fun `EN personas use whole joint cells - traits never mix across cells`() = runTest {
+        val context = contextWith(twoCellJson)
+        val generator = PersonaGenerator(
+            context, historyDao, noProfileDao, localeManager(SupportedLocale.EN),
+            PersonaDistribution(context)
+        )
+
+        val allowed = setOf(
+            Triple("AGE_25_34", "ENGINEER", "US_WEST"),
+            Triple("AGE_45_54", "TEACHER", "US_MIDWEST")
+        )
+        repeat(30) {
+            val p = generator.generate()
+            assertTrue(
+                "Demographics not from a single joint cell: " +
+                    "age=${p.ageRange}, prof=${p.profession}, region=${p.region}",
+                Triple(p.ageRange, p.profession, p.region) in allowed
+            )
+        }
+    }
+
+    @Test
+    fun `sampled cell overrides template demographics - production EN configuration`() = runTest {
+        // Production EN ships 89 templates AND the distribution; the E7 feature IS the
+        // precedence `cell?.age ?: template?.ageRange` in buildPersona. Template
+        // demographics are disjoint from both cells, so any template-derived value in
+        // the output means the precedence regressed (the suite would otherwise stay
+        // green with templates mocked away). Interests must still come from the
+        // template — that half of the hybrid is unchanged by E7.
+        val enTemplates = """[{
+            "archetype": "decoy", "ageRange": "AGE_55_64", "profession": "LEGAL",
+            "region": "US_SOUTHEAST", "interests": ["COOKING", "TRAVEL", "FITNESS"]
+        }]"""
+        val context = contextWith(twoCellJson, enTemplates)
+        val generator = PersonaGenerator(
+            context, historyDao, noProfileDao, localeManager(SupportedLocale.EN),
+            PersonaDistribution(context)
+        )
+
+        val allowed = setOf(
+            Triple("AGE_25_34", "ENGINEER", "US_WEST"),
+            Triple("AGE_45_54", "TEACHER", "US_MIDWEST")
+        )
+        repeat(30) {
+            val p = generator.generate()
+            assertTrue(
+                "Template demographics leaked past the sampled cell: " +
+                    "age=${p.ageRange}, prof=${p.profession}, region=${p.region}",
+                Triple(p.ageRange, p.profession, p.region) in allowed
+            )
+            assertEquals(
+                "Interests should still come from the template",
+                setOf(
+                    com.fauxx.data.querybank.CategoryPool.COOKING,
+                    com.fauxx.data.querybank.CategoryPool.TRAVEL,
+                    com.fauxx.data.querybank.CategoryPool.FITNESS
+                ),
+                p.interests
+            )
+        }
+    }
+
+    @Test
+    fun `EN falls back to enum-name pickers when distribution asset is missing`() = runTest {
+        val context = contextWith(null)
+        val generator = PersonaGenerator(
+            context, historyDao, noProfileDao, localeManager(SupportedLocale.EN),
+            PersonaDistribution(context)
+        )
+
+        val ageNames = AgeRange.entries.map { it.name }.toSet()
+        val professionNames = Profession.entries.map { it.name }.toSet()
+        repeat(20) {
+            val p = generator.generate()
+            assertTrue("ageRange not an enum name: ${p.ageRange}", p.ageRange in ageNames)
+            assertTrue("profession not an enum name: ${p.profession}", p.profession in professionNames)
+        }
+    }
+
+    @Test
+    fun `non-EN locale never consults the distribution`() = runTest {
+        val distribution = mockk<PersonaDistribution> {
+            every { sample(any()) } returns
+                DemographicCell("AGE_25_34", "ENGINEER", "US_WEST", 1.0)
+        }
+        val generator = PersonaGenerator(
+            contextWith(null), historyDao, noProfileDao, localeManager(SupportedLocale.ES),
+            distribution
+        )
+
+        repeat(10) { generator.generate() }
+        verify(exactly = 0) { distribution.sample(any()) }
+    }
+
+    @Test
+    fun `gate boundary - exactly 2 matching traits rejects, 1 matching trait accepts`() = runTest {
+        val oneCellJson = """{"version":1,"cells":[
+            {"age":"AGE_25_34","profession":"ENGINEER","region":"US_WEST","weight":1.0}
+        ]}"""
+
+        // 2 matches (age + profession; region differs): every candidate rejected -> fallback.
+        val twoTraitDao: DemographicProfileDao = mockk {
+            coEvery { get() } returns UserDemographicProfile(
+                ageRange = AgeRange.AGE_25_34,
+                profession = Profession.ENGINEER,
+                region = Region.US_MIDWEST
+            )
+        }
+        val context = contextWith(oneCellJson)
+        val rejected = PersonaGenerator(
+            context, historyDao, twoTraitDao, localeManager(SupportedLocale.EN),
+            PersonaDistribution(context)
+        ).generate()
+        assertEquals("AGE_35_44", rejected.ageRange)
+
+        // 1 match (age only): the cell passes the gate untouched.
+        val oneTraitDao: DemographicProfileDao = mockk {
+            coEvery { get() } returns UserDemographicProfile(
+                ageRange = AgeRange.AGE_25_34,
+                profession = Profession.TEACHER,
+                region = Region.US_MIDWEST
+            )
+        }
+        val context2 = contextWith(oneCellJson)
+        val accepted = PersonaGenerator(
+            context2, historyDao, oneTraitDao, localeManager(SupportedLocale.EN),
+            PersonaDistribution(context2)
+        ).generate()
+        assertEquals("AGE_25_34", accepted.ageRange)
+        assertEquals("ENGINEER", accepted.profession)
+        assertEquals("US_WEST", accepted.region)
+    }
+
+    @Test
+    fun `user-demographic gate still rejects joint-sampled candidates`() = runTest {
+        // Single-cell distribution that always collides with the user's own profile on
+        // all three traits: every attempt must be rejected, forcing the fallback persona.
+        val oneCellJson = """{"version":1,"cells":[
+            {"age":"AGE_25_34","profession":"ENGINEER","region":"US_WEST","weight":1.0}
+        ]}"""
+        val userProfileDao: DemographicProfileDao = mockk {
+            coEvery { get() } returns UserDemographicProfile(
+                ageRange = AgeRange.AGE_25_34,
+                profession = Profession.ENGINEER,
+                region = Region.US_WEST
+            )
+        }
+        val context = contextWith(oneCellJson)
+        val generator = PersonaGenerator(
+            context, historyDao, userProfileDao, localeManager(SupportedLocale.EN),
+            PersonaDistribution(context)
+        )
+
+        val p = generator.generate()
+        assertEquals("AGE_35_44", p.ageRange)
+        assertEquals("OTHER", p.profession)
+        assertEquals("US_MIDWEST", p.region)
+    }
+}

--- a/app/src/test/java/com/fauxx/PersonaRateModulatorTest.kt
+++ b/app/src/test/java/com/fauxx/PersonaRateModulatorTest.kt
@@ -1,0 +1,86 @@
+package com.fauxx
+
+import com.fauxx.data.model.SyntheticPersona
+import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.targeting.layer3.PersonaRateModulator
+import com.fauxx.targeting.layer3.PersonaRotationLayer
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E8 (#174): persona-keyed daily rhythm. Each persona gets a deterministic activity
+ * profile; the 24h mean must stay ~1.0 (rate honesty, issue #76); no persona -> neutral.
+ */
+class PersonaRateModulatorTest {
+
+    private fun persona(id: String) = SyntheticPersona(
+        id = id, name = "Test", ageRange = "AGE_25_34", profession = "ENGINEER",
+        region = "US_WEST", interests = setOf(CategoryPool.COOKING),
+        activeUntil = Long.MAX_VALUE
+    )
+
+    private fun modulatorFor(p: SyntheticPersona?): PersonaRateModulator {
+        val layer = mockk<PersonaRotationLayer> { every { personaForChannel(any()) } returns p }
+        return PersonaRateModulator(layer)
+    }
+
+    private fun dayProfile(m: PersonaRateModulator): List<Float> =
+        (0..23).map { m.multiplier(it) }
+
+    @Test
+    fun `neutral when no persona is active`() {
+        val profile = dayProfile(modulatorFor(null))
+        profile.forEach { assertEquals(1f, it, 0f) }
+    }
+
+    @Test
+    fun `24-hour mean stays at one - rate honesty`() {
+        val profile = dayProfile(modulatorFor(persona("some-persona-id")))
+        val mean = profile.sum() / profile.size
+        assertTrue("mean $mean drifted from 1.0", abs(mean - 1f) < 1e-3f)
+    }
+
+    @Test
+    fun `hourly swing stays within the documented amplitude`() {
+        val profile = dayProfile(modulatorFor(persona("another-id")))
+        profile.forEachIndexed { hour, m ->
+            assertTrue("hour $hour multiplier $m outside 0.8..1.2", m in 0.8f..1.2f)
+        }
+        assertTrue("rhythm must not be flat", profile.max() > profile.min())
+    }
+
+    @Test
+    fun `same persona keeps the same rhythm for its whole life`() {
+        val a = dayProfile(modulatorFor(persona("stable-id")))
+        val b = dayProfile(modulatorFor(persona("stable-id")))
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `peak hour stays inside the documented 11-17 window for any id hash sign`() {
+        // Includes ids hashing negative (a `%` regression instead of `mod` would push
+        // their peaks to 5..11) — "polygenelubricants" hashes to Int.MIN_VALUE.
+        val ids = (0..99).map { "persona-$it" } + "polygenelubricants" + ""
+        assertTrue("need negative-hash coverage", ids.any { it.hashCode() < 0 })
+        ids.forEach { id ->
+            val profile = dayProfile(modulatorFor(persona(id)))
+            val peakHour = profile.indices.maxBy { profile[it] }
+            assertTrue(
+                "id '$id' (hash ${id.hashCode()}): peak at $peakHour outside 11..17",
+                peakHour in 11..17
+            )
+        }
+    }
+
+    @Test
+    fun `rotation can shift the rhythm - distinct personas may differ`() {
+        // "a" and "b" hash to different peak offsets; locks the persona-keying seam.
+        val a = dayProfile(modulatorFor(persona("a")))
+        val b = dayProfile(modulatorFor(persona("b")))
+        assertTrue("personas with different peak offsets must differ", a != b)
+    }
+}

--- a/app/src/test/java/com/fauxx/PersonaTemplateGsonContractTest.kt
+++ b/app/src/test/java/com/fauxx/PersonaTemplateGsonContractTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.fauxx.locale.LocaleManager
 import com.fauxx.locale.SupportedLocale
 import com.fauxx.targeting.layer1.DemographicProfileDao
+import com.fauxx.targeting.layer3.PersonaDistribution
 import com.fauxx.targeting.layer3.PersonaGenerator
 import com.fauxx.targeting.layer3.PersonaHistoryDao
 import io.mockk.coEvery
@@ -59,7 +60,12 @@ class PersonaTemplateGsonContractTest {
             every { currentLocale } returns SupportedLocale.ES
         }
 
-        val generator = PersonaGenerator(context, historyDao, demographicDao, localeManager)
+        // The ES locale never consults the joint distribution (PersonaGenerator gates
+        // sampling on EN), and PersonaDistribution loads lazily on first sample(), so
+        // the strict assets mock is never asked for persona_distribution.json here.
+        val generator = PersonaGenerator(
+            context, historyDao, demographicDao, localeManager, PersonaDistribution(context)
+        )
 
         // PersonaGenerator.pickRegion() (the no-template fallback) only emits
         // values from this hardcoded set. ES templates exclusively use ES/LatAm

--- a/app/src/test/java/com/fauxx/RateModulatorSchedulerTest.kt
+++ b/app/src/test/java/com/fauxx/RateModulatorSchedulerTest.kt
@@ -1,0 +1,101 @@
+package com.fauxx
+
+import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.engine.scheduling.PoissonScheduler
+import com.fauxx.engine.scheduling.RateModulator
+import com.fauxx.support.FakeClock
+import java.util.Calendar
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E8 (#174): the rate-modulation seam in [PoissonScheduler]. With identical Random
+ * seeds, two schedulers consume identical random sequences and take identical branch
+ * decisions, so delays are pairwise comparable: only the Poisson rate scaling differs.
+ */
+class RateModulatorSchedulerTest {
+
+    private fun epochAtLocalHour(hour: Int): Long = Calendar.getInstance().apply {
+        set(Calendar.HOUR_OF_DAY, hour)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.timeInMillis
+
+    private fun delays(
+        modulator: RateModulator,
+        seed: Long,
+        n: Int = 200,
+        hour: Int = 12,
+    ): List<Long> {
+        val scheduler = PoissonScheduler(
+            FakeClock(epochAtLocalHour(hour)), Random(seed), modulator
+        )
+        return (1..n).map {
+            scheduler.nextDelayMs(
+                actionsPerHour = 60,
+                prev = CategoryPool.COOKING,
+                next = CategoryPool.COOKING
+            )
+        }
+    }
+
+    @Test
+    fun `a higher multiplier never lengthens any delay - same-seed pairwise`() {
+        val slow = delays(RateModulator { 0.5f }, seed = 7)
+        val fast = delays(RateModulator { 1.5f }, seed = 7)
+        slow.zip(fast).forEachIndexed { i, (s, f) ->
+            assertTrue("sample $i: fast delay $f > slow delay $s", f <= s)
+        }
+        assertTrue(
+            "rate modulation must actually change the schedule",
+            fast.sum() < slow.sum()
+        )
+    }
+
+    @Test
+    fun `multipliers are clamped to the documented bounds`() {
+        assertEquals(
+            delays(RateModulator { 1.5f }, seed = 11),
+            delays(RateModulator { 10f }, seed = 11)
+        )
+        assertEquals(
+            delays(RateModulator { 0.5f }, seed = 11),
+            delays(RateModulator { 0.01f }, seed = 11)
+        )
+    }
+
+    @Test
+    fun `scheduler passes the true hour of day to the modulator`() {
+        // Hour-sensitive modulator: behaves like the 1.5 constant ONLY at hour 12 and
+        // like the 0.5 constant elsewhere. If the scheduler passed a wrong hour source
+        // (e.g. Calendar.HOUR, which is 0 at noon), the persona rhythm would silently
+        // become a constant rate bias and break the 24h-mean honesty contract (#76).
+        val hourSensitive = RateModulator { hour -> if (hour == 12) 1.5f else 0.5f }
+
+        assertEquals(
+            delays(RateModulator { 1.5f }, seed = 5, hour = 12),
+            delays(hourSensitive, seed = 5, hour = 12)
+        )
+        assertEquals(
+            delays(RateModulator { 0.5f }, seed = 5, hour = 18),
+            delays(hourSensitive, seed = 5, hour = 18)
+        )
+    }
+
+    @Test
+    fun `omitting the modulator is exactly NEUTRAL - pre-E8 behavior preserved`() {
+        val implicit = PoissonScheduler(FakeClock(epochAtLocalHour(12)), Random(3))
+        val explicit = PoissonScheduler(
+            FakeClock(epochAtLocalHour(12)), Random(3), RateModulator.NEUTRAL
+        )
+        repeat(100) {
+            assertEquals(
+                explicit.nextDelayMs(60, prev = CategoryPool.COOKING, next = CategoryPool.COOKING),
+                implicit.nextDelayMs(60, prev = CategoryPool.COOKING, next = CategoryPool.COOKING)
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/fauxx/RateShapingTest.kt
+++ b/app/src/test/java/com/fauxx/RateShapingTest.kt
@@ -1,0 +1,81 @@
+package com.fauxx
+
+import com.fauxx.engine.scheduling.RateShaping
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E10 (#177): [RateShaping.meanPreservingFit] is the shared shaping primitive behind the
+ * circadian and composite modulators. Its two guarantees — 24h mean exactly 1.0 (rate honesty,
+ * issue #76) and every entry inside the clamp band — are what keep the modulation honest, so
+ * they are pinned directly here rather than only through the modulators that use them.
+ */
+class RateShapingTest {
+
+    private val lo = 0.5
+    private val hi = 1.5
+
+    private fun mean(a: DoubleArray) = a.average()
+
+    @Test
+    fun `mean is exactly one regardless of input shape`() {
+        val inputs = listOf(
+            doubleArrayOf(1.0, 2.0, 3.0, 4.0),
+            doubleArrayOf(0.0, 0.0, 100.0, 0.0, 0.0),
+            DoubleArray(24) { (it % 5).toDouble() },
+            doubleArrayOf(7.0, 7.0, 7.0),
+        )
+        inputs.forEach { input ->
+            val out = RateShaping.meanPreservingFit(input, lo, hi)
+            assertEquals("mean must be 1.0 for ${input.toList()}", 1.0, mean(out), 1e-9)
+        }
+    }
+
+    @Test
+    fun `every entry stays within the clamp band`() {
+        // A single dominant spike is the worst case for the upper bound.
+        val spike = DoubleArray(24).also { it[20] = 1_000.0 }
+        val out = RateShaping.meanPreservingFit(spike, lo, hi)
+        out.forEachIndexed { i, v ->
+            assertTrue("hour $i value $v below lo", v >= lo - 1e-9)
+            assertTrue("hour $i value $v above hi", v <= hi + 1e-9)
+        }
+        // The spike hour is the peak, capped at hi; the rest sit at the attenuated floor.
+        assertEquals(hi, out[20], 1e-9)
+    }
+
+    @Test
+    fun `shape is preserved - ordering of inputs matches ordering of outputs`() {
+        val input = doubleArrayOf(1.0, 5.0, 2.0, 8.0, 3.0)
+        val out = RateShaping.meanPreservingFit(input, lo, hi)
+        // Monotone map: argmax/argmin and pairwise order are preserved.
+        assertEquals(input.indices.maxBy { input[it] }, out.indices.maxBy { out[it] })
+        assertEquals(input.indices.minBy { input[it] }, out.indices.minBy { out[it] })
+        for (i in input.indices) for (j in input.indices) {
+            if (input[i] < input[j]) assertTrue(out[i] <= out[j] + 1e-12)
+        }
+    }
+
+    @Test
+    fun `flat input yields a flat neutral curve`() {
+        val out = RateShaping.meanPreservingFit(DoubleArray(24) { 42.0 }, lo, hi)
+        out.forEach { assertEquals(1.0, it, 1e-12) }
+    }
+
+    @Test
+    fun `degenerate inputs fall back to neutral`() {
+        // All-zero (no signal) and empty inputs must not divide by zero.
+        RateShaping.meanPreservingFit(DoubleArray(24), lo, hi).forEach { assertEquals(1.0, it, 0.0) }
+        assertEquals(0, RateShaping.meanPreservingFit(DoubleArray(0), lo, hi).size)
+    }
+
+    @Test
+    fun `mild shape is not over-attenuated - it actually modulates`() {
+        // A gentle ±25% shape fits inside the band without scaling, so it passes through.
+        val input = doubleArrayOf(0.75, 1.25, 0.75, 1.25)
+        val out = RateShaping.meanPreservingFit(input, lo, hi)
+        assertTrue("output must vary, not collapse to flat", abs(out.max() - out.min()) > 0.1)
+    }
+}

--- a/app/src/test/java/com/fauxx/SearchRefinementsTest.kt
+++ b/app/src/test/java/com/fauxx/SearchRefinementsTest.kt
@@ -1,0 +1,66 @@
+package com.fauxx
+
+import com.fauxx.data.querybank.SearchRefinements
+import com.fauxx.locale.SupportedLocale
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E5 (#175): refinement templates must narrow the session goal, not replace it —
+ * topical relatedness is the property that makes a chain an intent chain, and goal
+ * preservation is what lets the blocklist gate see the full original query content.
+ */
+class SearchRefinementsTest {
+
+    private val goal = "trail running shoes"
+
+    /** Goal or a light reformulation (one edge word dropped) — the relatedness cores. */
+    private val relatedCores = listOf(goal, "running shoes", "trail running")
+
+    @Test
+    fun `every refinement stays topically related to the goal`() {
+        SupportedLocale.entries.forEach { locale ->
+            val refinements = SearchRefinements.refine(goal, locale, count = 3, random = Random(1))
+            assertEquals(3, refinements.size)
+            refinements.forEach { r ->
+                assertTrue(
+                    "[$locale] '$r' is not related to '$goal'",
+                    relatedCores.any { core -> r.contains(core) }
+                )
+                assertTrue("[$locale] '$r' must narrow, not repeat", r != goal)
+            }
+        }
+    }
+
+    @Test
+    fun `short goals are never truncated`() {
+        repeat(50) { seed ->
+            SearchRefinements.refine("hiking boots", SupportedLocale.EN, 3, Random(seed.toLong()))
+                .forEach { r ->
+                    assertTrue("'$r' must contain the 2-word goal verbatim", r.contains("hiking boots"))
+                }
+        }
+    }
+
+    @Test
+    fun `refinements within a session are distinct`() {
+        val refinements = SearchRefinements.refine(goal, SupportedLocale.EN, count = 3, random = Random(7))
+        assertEquals(refinements.size, refinements.toSet().size)
+    }
+
+    @Test
+    fun `refinements are localized`() {
+        val es = SearchRefinements.refine(goal, SupportedLocale.ES, count = 7, random = Random(1))
+        assertTrue("ES templates expected", es.any { it.contains("mejor") || it.contains("opiniones") })
+        val ru = SearchRefinements.refine(goal, SupportedLocale.RU, count = 7, random = Random(1))
+        assertTrue("RU templates expected", ru.any { it.any { ch -> ch in 'а'..'я' } })
+    }
+
+    @Test
+    fun `count is clamped to the template pool and to zero`() {
+        assertTrue(SearchRefinements.refine(goal, SupportedLocale.EN, 99, Random(1)).size <= 16)
+        assertTrue(SearchRefinements.refine(goal, SupportedLocale.EN, -1, Random(1)).isEmpty())
+    }
+}

--- a/app/src/test/java/com/fauxx/SerpLinkSelectorTest.kt
+++ b/app/src/test/java/com/fauxx/SerpLinkSelectorTest.kt
@@ -1,0 +1,130 @@
+package com.fauxx
+
+import com.fauxx.engine.modules.SerpLinkSelector
+import com.google.gson.Gson
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E5 (#175): the SERP link filter decides what the engine is willing to NAVIGATE to.
+ * Engine/ad-infra hosts are never results; every candidate passes the caller's
+ * (fail-closed) blocklist gate; one link per host.
+ */
+class SerpLinkSelectorTest {
+
+    private val allowAll: (String) -> Boolean = { true }
+    private val never: (String) -> Boolean = { false }
+
+    private fun select(
+        hrefs: List<String>,
+        max: Int = 5,
+        random: Random = Random(1),
+        isAllowed: (String) -> Boolean = allowAll,
+        isBlocked: (String) -> Boolean = never,
+    ) = SerpLinkSelector.select(hrefs, random, max, isAllowed, isBlocked)
+
+    @Test
+    fun `engine and ad-infra hosts are never selected`() {
+        val hrefs = listOf(
+            "https://www.google.com/preferences",
+            "https://accounts.google.com/signin",
+            "https://www.googleadservices.com/pagead/x",
+            "https://duckduckgo.com/settings",
+            "https://r.bing.com/rp/abc",
+            "https://yandex.com/support",
+            "https://example.com/article",
+        )
+        assertEquals(listOf("https://example.com/article"), select(hrefs))
+    }
+
+    @Test
+    fun `engine families match whole host labels not substrings`() {
+        // "googleblog.com" contains "google" as a substring but not as a label.
+        val hrefs = listOf("https://googleblog.com/post", "https://blog.google/post")
+        assertEquals(listOf("https://googleblog.com/post"), select(hrefs))
+    }
+
+    @Test
+    fun `only allow-listed hosts survive - the primary gate`() {
+        val hrefs = listOf(
+            "https://curated.example.com/article",
+            "https://random-serp-result.net/page",
+        )
+        val picked = select(hrefs, isAllowed = { it == "curated.example.com" })
+        assertEquals(listOf("https://curated.example.com/article"), picked)
+    }
+
+    @Test
+    fun `non-http schemes and unparseable urls are dropped`() {
+        val hrefs = listOf(
+            "javascript:void(0)",
+            "intent://foo#Intent;end",
+            "ht!tp://broken",
+            "https://ok.example.net/page",
+        )
+        assertEquals(listOf("https://ok.example.net/page"), select(hrefs))
+    }
+
+    @Test
+    fun `one link per host and max respected`() {
+        val hrefs = (1..10).map { "https://same.example.com/p$it" } +
+            listOf("https://a.example.net/1", "https://b.example.org/2")
+        val picked = select(hrefs, max = 2, random = Random(3))
+        assertEquals(2, picked.size)
+        assertEquals(2, picked.map { java.net.URI(it).host }.toSet().size)
+    }
+
+    @Test
+    fun `blocklisted candidates are gated out`() {
+        val hrefs = listOf("https://blocked.example.com/x", "https://fine.example.org/y")
+        val picked = select(hrefs, max = 2, isBlocked = { it.contains("blocked") })
+        assertEquals(listOf("https://fine.example.org/y"), picked)
+    }
+
+    @Test
+    fun `selection is position-biased toward top results`() {
+        val hrefs = listOf(
+            "https://first.example.com/1",
+            "https://second.example.net/2",
+            "https://third.example.org/3",
+        )
+        val random = Random(11)
+        val firstCounts = (1..600).count { select(hrefs, max = 1, random = random).single().contains("first") }
+        assertTrue(
+            "top result should dominate clicks, got $firstCounts/600",
+            firstCounts in 250..450 // ~55% expected
+        )
+    }
+
+    @Test
+    fun `zero max yields nothing`() {
+        assertTrue(select(listOf("https://example.com"), max = 0).isEmpty())
+    }
+
+    @Test
+    fun `click js targets the exact href and escapes quotes`() {
+        val js = SerpLinkSelector.buildClickJs("https://example.com/a?q=it's")
+        assertTrue(js.contains("""https://example.com/a?q=it\'s"""))
+        assertTrue(js.contains(".click()"))
+    }
+
+    @Test
+    fun `parseHrefs decodes the double-encoded evaluateJavascript result`() {
+        val inner = """["https://example.com/a","https://example.org/b"]"""
+        val outer = Gson().toJson(inner)
+        assertEquals(
+            listOf("https://example.com/a", "https://example.org/b"),
+            SerpLinkSelector.parseHrefs(outer)
+        )
+    }
+
+    @Test
+    fun `parseHrefs is safe on null garbage and mismatched json`() {
+        assertTrue(SerpLinkSelector.parseHrefs(null).isEmpty())
+        assertTrue(SerpLinkSelector.parseHrefs("null").isEmpty())
+        assertTrue(SerpLinkSelector.parseHrefs("not json").isEmpty())
+        assertTrue(SerpLinkSelector.parseHrefs("\"not an array\"").isEmpty())
+    }
+}

--- a/app/src/test/java/com/fauxx/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/fauxx/SettingsViewModelTest.kt
@@ -4,6 +4,7 @@ import com.fauxx.data.db.ActionLogDao
 import com.fauxx.data.model.PoisonProfile
 import com.fauxx.data.querybank.MarkovQueryGenerator
 import com.fauxx.engine.PoisonProfileRepository
+import com.fauxx.engine.scheduling.CircadianObserver
 import com.fauxx.locale.LocaleManager
 import com.fauxx.logging.EncryptedFileTree
 import com.fauxx.support.MainDispatcherRule
@@ -52,10 +53,11 @@ class SettingsViewModelTest {
         every { userOverrideFlow } returns MutableStateFlow(null)
     }
     private val markovGenerator: MarkovQueryGenerator = mockk(relaxed = true)
+    private val circadianObserver: CircadianObserver = mockk(relaxed = true)
 
     private fun viewModel() = SettingsViewModel(
         profileRepo, actionLogDao, demographicDao, platformDao, personaHistoryDao,
-        targetingEngine, encryptedFileTree, localeManager, markovGenerator
+        targetingEngine, encryptedFileTree, localeManager, markovGenerator, circadianObserver
     )
 
     @Test
@@ -70,5 +72,7 @@ class SettingsViewModelTest {
         coVerify { demographicDao.delete() }
         coVerify { platformDao.deleteAll() }
         coVerify { personaHistoryDao.deleteAll() }
+        // E10 (#177): the learned daily-rhythm histogram is part of the trail wipe.
+        coVerify { circadianObserver.clear() }
     }
 }

--- a/app/src/test/java/com/fauxx/engine/modules/AppSignalModuleTest.kt
+++ b/app/src/test/java/com/fauxx/engine/modules/AppSignalModuleTest.kt
@@ -3,12 +3,15 @@ package com.fauxx.engine.modules
 import android.content.Context
 import android.webkit.WebView
 import com.fauxx.data.model.ActionType
+import com.fauxx.data.model.SyntheticPersona
 import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.engine.PoisonProfileRepository
 import com.fauxx.engine.webview.PhantomWebViewPool
 import com.fauxx.locale.LocaleManager
 import com.fauxx.locale.SupportedLocale
 import com.fauxx.support.MainDispatcherRule
+import com.fauxx.targeting.layer3.PersonaRotationLayer
+import kotlin.random.Random
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -50,6 +53,9 @@ class AppSignalModuleTest {
     private val webView: WebView = mockk(relaxed = true)
     private val webViewPool: PhantomWebViewPool = mockk(relaxed = true)
     private val localeManager: LocaleManager = mockk(relaxed = true)
+    private val noPersonaLayer: PersonaRotationLayer = mockk {
+        every { personaForChannel(any()) } returns null
+    }
 
     @Before
     fun setup() {
@@ -57,12 +63,36 @@ class AppSignalModuleTest {
         every { localeManager.currentLocale } returns SupportedLocale.EN
     }
 
-    private fun newModule() = AppSignalModule(
+    private fun newModule(
+        personaLayer: PersonaRotationLayer = noPersonaLayer,
+        random: Random = Random.Default,
+    ) = AppSignalModule(
         context = context,
         profileRepo = profileRepo,
         webViewPool = webViewPool,
         localeManager = localeManager,
+        personaLayer = personaLayer,
+        random = random,
     )
+
+    /** Forces the persona-swap branch deterministically. */
+    private class FixedRandom(private val f: Float) : Random() {
+        override fun nextBits(bitCount: Int): Int = 0
+        override fun nextFloat(): Float = f
+    }
+
+    private fun personaLayerWith(interests: Set<CategoryPool>): PersonaRotationLayer {
+        val persona = SyntheticPersona(
+            id = "test-persona",
+            name = "Test",
+            ageRange = "AGE_25_34",
+            profession = "ENGINEER",
+            region = "US_WEST",
+            interests = interests,
+            activeUntil = Long.MAX_VALUE
+        )
+        return mockk { every { personaForChannel(any()) } returns persona }
+    }
 
     @Test
     fun `onAction builds the localized play store URL and reports a successful DEEP_LINK_VISIT`() =
@@ -84,6 +114,83 @@ class AppSignalModuleTest {
             )
             assertTrue("a normal load must report success", result.success)
         }
+
+    // E8 (#174) persona-interest bias: an off-interest action is redirected to a persona
+    // interest with probability PERSONA_INTEREST_SWAP_FRACTION, and the swapped category
+    // is what gets logged. No persona (Layer 3 off) must mean no swap.
+
+    @Test
+    fun `off-interest action swaps to a persona interest when the dice say so`() =
+        runTest(testDispatcher) {
+            val module = newModule(
+                personaLayer = personaLayerWith(setOf(CategoryPool.COOKING)),
+                random = FixedRandom(0f) // 0 < 0.35 -> swap
+            )
+
+            val result = module.onAction(CategoryPool.GAMING)
+
+            assertEquals(
+                "logged category must be the persona interest actually searched",
+                CategoryPool.COOKING,
+                result.category
+            )
+            assertTrue(
+                "URL keywords must match the swapped category; was: ${result.detail}",
+                result.detail.contains("recipe+app")
+            )
+            assertTrue(
+                "host invariant must survive the persona swap; was: ${result.detail}",
+                result.detail.startsWith("https://play.google.com/store/search")
+            )
+        }
+
+    @Test
+    fun `interest-less persona never swaps and never crashes`() = runTest(testDispatcher) {
+        val module = newModule(
+            personaLayer = personaLayerWith(emptySet()),
+            random = FixedRandom(0f) // swap-favorable dice
+        )
+
+        val result = module.onAction(CategoryPool.GAMING)
+
+        assertEquals(CategoryPool.GAMING, result.category)
+    }
+
+    @Test
+    fun `off-interest action keeps its category when the dice say no swap`() =
+        runTest(testDispatcher) {
+            val module = newModule(
+                personaLayer = personaLayerWith(setOf(CategoryPool.COOKING)),
+                random = FixedRandom(0.9f) // 0.9 >= 0.35 -> no swap
+            )
+
+            val result = module.onAction(CategoryPool.GAMING)
+
+            assertEquals(CategoryPool.GAMING, result.category)
+            assertTrue(result.detail.contains("strategy+games"))
+        }
+
+    @Test
+    fun `no active persona means no swap even with swap-favorable dice`() =
+        runTest(testDispatcher) {
+            val module = newModule(random = FixedRandom(0f))
+
+            val result = module.onAction(CategoryPool.GAMING)
+
+            assertEquals(CategoryPool.GAMING, result.category)
+        }
+
+    @Test
+    fun `persona-aligned action is never swapped`() = runTest(testDispatcher) {
+        val module = newModule(
+            personaLayer = personaLayerWith(setOf(CategoryPool.GAMING, CategoryPool.COOKING)),
+            random = FixedRandom(0f)
+        )
+
+        val result = module.onAction(CategoryPool.GAMING)
+
+        assertEquals(CategoryPool.GAMING, result.category)
+    }
 
     @Test
     fun `onAction reports failure when the WebView throws`() = runTest(testDispatcher) {

--- a/app/src/test/java/com/fauxx/engine/modules/LocationSpoofModuleFailureTest.kt
+++ b/app/src/test/java/com/fauxx/engine/modules/LocationSpoofModuleFailureTest.kt
@@ -51,7 +51,8 @@ class LocationSpoofModuleFailureTest {
             context = context,
             routeGenerator = mockk(relaxed = true),
             cityDatabase = mockk(relaxed = true),
-            profileRepo = profileRepo
+            profileRepo = profileRepo,
+            personaLayer = mockk { every { personaForChannel(any()) } returns null }
         )
     }
 

--- a/app/src/test/java/com/fauxx/engine/modules/LocationSpoofPersonaBindingTest.kt
+++ b/app/src/test/java/com/fauxx/engine/modules/LocationSpoofPersonaBindingTest.kt
@@ -1,0 +1,84 @@
+package com.fauxx.engine.modules
+
+import android.app.AppOpsManager
+import android.content.Context
+import android.location.LocationManager
+import com.fauxx.data.location.CityCoord
+import com.fauxx.data.location.CityDatabase
+import com.fauxx.data.model.SyntheticPersona
+import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.engine.PoisonProfileRepository
+import com.fauxx.targeting.layer3.PersonaRotationLayer
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * E8 (#174): spoofed locations must be drawn from the active persona's region so the
+ * location story corroborates the demographic one — and must stay unbound when Layer 3
+ * is off (activePersona == null).
+ */
+class LocationSpoofPersonaBindingTest {
+
+    private lateinit var context: Context
+    private lateinit var locationManager: LocationManager
+    private lateinit var cityDatabase: CityDatabase
+
+    @Before
+    fun setUp() {
+        context = mockk(relaxed = true)
+        val appOps = mockk<AppOpsManager>()
+        locationManager = mockk(relaxed = true)
+        every { context.getSystemService(Context.LOCATION_SERVICE) } returns locationManager
+        every { context.getSystemService(Context.APP_OPS_SERVICE) } returns appOps
+        every { context.packageName } returns "com.fauxx"
+        every {
+            appOps.checkOpNoThrow(AppOpsManager.OPSTR_MOCK_LOCATION, any(), any())
+        } returns AppOpsManager.MODE_ALLOWED
+        every { locationManager.removeTestProvider(any()) } just runs
+
+        cityDatabase = mockk {
+            every { randomCity(any()) } returns CityCoord("Seattle", 47.6062, -122.3321, "US_WEST")
+        }
+    }
+
+    private fun module(persona: SyntheticPersona?) = LocationSpoofModule(
+        context = context,
+        routeGenerator = mockk(relaxed = true),
+        cityDatabase = cityDatabase,
+        profileRepo = mockk<PoisonProfileRepository>(relaxed = true),
+        personaLayer = mockk { every { personaForChannel(any()) } returns persona }
+    )
+
+    @Test
+    fun `onAction passes the active persona region as the city hint`() = runBlocking {
+        val persona = SyntheticPersona(
+            id = "p1", name = "Test", ageRange = "AGE_25_34", profession = "ENGINEER",
+            region = "US_WEST", interests = setOf(CategoryPool.COOKING),
+            activeUntil = Long.MAX_VALUE
+        )
+        val m = module(persona)
+        m.start()
+
+        val result = m.onAction(CategoryPool.COOKING)
+
+        verify(exactly = 1) { cityDatabase.randomCity(regionHint = "US_WEST") }
+        assertTrue(result.detail.contains("Seattle"))
+    }
+
+    @Test
+    fun `onAction stays unbound when no persona is active`() = runBlocking {
+        val m = module(persona = null)
+        m.start()
+
+        m.onAction(CategoryPool.COOKING)
+
+        verify(exactly = 1) { cityDatabase.randomCity(regionHint = null) }
+    }
+}

--- a/app/src/test/java/com/fauxx/engine/modules/SearchPoisonModuleTest.kt
+++ b/app/src/test/java/com/fauxx/engine/modules/SearchPoisonModuleTest.kt
@@ -59,7 +59,10 @@ class SearchPoisonModuleTest {
 
     private val queryBankManager: QueryBankManager = mockk(relaxed = true)
     private val markovGenerator: MarkovQueryGenerator = mockk(relaxed = true)
-    private val profileRepo: PoisonProfileRepository = mockk(relaxed = true)
+    private val profileRepo: PoisonProfileRepository = mockk(relaxed = true) {
+        every { getProfile().intensity } returns com.fauxx.data.model.IntensityLevel.MEDIUM
+        every { getProfile().mobileIntensity } returns null
+    }
     private val webViewPool: PhantomWebViewPool = mockk(relaxed = true)
     private val userAgentPool: UserAgentPool = mockk(relaxed = true)
     private val blocklist: DomainBlocklist = mockk(relaxed = true)
@@ -67,9 +70,13 @@ class SearchPoisonModuleTest {
     private val customInterestMapper: CustomInterestMapper = mockk(relaxed = true)
     private val queryBlocklist: QueryBlocklist = mockk(relaxed = true)
     private val localeManager: LocaleManager = mockk(relaxed = true)
+    private val crawlListManager: com.fauxx.data.crawllist.CrawlListManager = mockk(relaxed = true)
     private val webView: WebView = mockk(relaxed = true)
 
-    private fun newModule() = SearchPoisonModule(
+    private fun newModule(
+        random: kotlin.random.Random = bankBranchRandom,
+        clock: com.fauxx.util.Clock = com.fauxx.support.FakeClock(0L),
+    ) = SearchPoisonModule(
         queryBankManager = queryBankManager,
         markovGenerator = markovGenerator,
         profileRepo = profileRepo,
@@ -80,15 +87,30 @@ class SearchPoisonModuleTest {
         customInterestMapper = customInterestMapper,
         queryBlocklist = queryBlocklist,
         localeManager = localeManager,
+        crawlListManager = crawlListManager,
+        clock = clock,
         // nextFloat()=0.99 forces the query-bank branch (never calls markovGenerator.generate);
         // nextBits()=0 makes SEARCH_ENGINES.random(this) deterministic (first engine = google)
         // and the Accept-Language / dwell draws deterministic.
-        random = bankBranchRandom,
+        random = random,
     )
 
     private val bankBranchRandom = object : kotlin.random.Random() {
         override fun nextBits(bitCount: Int): Int = 0
         override fun nextFloat(): Float = 0.99f
+    }
+
+    /**
+     * Maximizes every bounded draw: bank branch (nextFloat=0.99), LAST search engine
+     * (yandex), MAX refinement/link counts, identity shuffle, no reformulation —
+     * exercises the multi-step session shape FixedRandom-style zeros collapse away.
+     */
+    private val maxRandom = object : kotlin.random.Random() {
+        override fun nextBits(bitCount: Int): Int = 0
+        override fun nextFloat(): Float = 0.99f
+        override fun nextInt(until: Int): Int = until - 1
+        override fun nextInt(from: Int, until: Int): Int = until - 1
+        override fun nextLong(from: Long, until: Long): Long = from
     }
 
     private fun bankReturns(query: String) {
@@ -178,6 +200,243 @@ class SearchPoisonModuleTest {
             result.detail.startsWith("[BLOCKED]")
         )
         assertFalse("a failed load reports failure", result.success)
+    }
+
+    // ---- E5 (#175): intent-chain sessions ----
+
+    /** All loadUrl calls with their headers, in order. */
+    private fun captureLoads(): Pair<MutableList<String>, MutableList<Map<String, String>>> {
+        val urls = mutableListOf<String>()
+        val headers = mutableListOf<Map<String, String>>()
+        every { webView.loadUrl(capture(urls), capture(headers)) } returns Unit
+        return urls to headers
+    }
+
+    private fun safeSession(
+        query: String,
+        intensity: com.fauxx.data.model.IntensityLevel = com.fauxx.data.model.IntensityLevel.MEDIUM,
+        mobileIntensity: com.fauxx.data.model.IntensityLevel? = null,
+    ) {
+        bankReturns(query)
+        every { queryBlocklist.isBlocked(any()) } returns false
+        every { blocklist.isUrlBlocked(any()) } returns false
+        every { localeManager.currentLocale } returns SupportedLocale.EN
+        every { profileRepo.getProfile().intensity } returns intensity
+        every { profileRepo.getProfile().mobileIntensity } returns mobileIntensity
+        coEvery { webViewPool.acquire() } returns webView
+    }
+
+    /** Stubs evaluateJavascript: the harvest JS yields [hrefs]; click JS reports clicked. */
+    private fun stubSerp(hrefs: List<String>): MutableList<String> {
+        val scripts = mutableListOf<String>()
+        val outer = com.google.gson.Gson().toJson(com.google.gson.Gson().toJson(hrefs))
+        every { webView.evaluateJavascript(capture(scripts), any()) } answers {
+            val js = firstArg<String>()
+            val cb = secondArg<android.webkit.ValueCallback<String>>()
+            if (js.contains("JSON.stringify")) cb.onReceiveValue(outer)
+            else cb.onReceiveValue("\"clicked\"")
+        }
+        return scripts
+    }
+
+    // (f) A session issues the goal plus related refinements, each gated individually.
+    @Test
+    fun `session dispatches goal plus in-topic refinements - all gated`() = runTest(testDispatcher) {
+        val goal = "best mechanical keyboards 2026"
+        safeSession(goal)
+        val (urls, _) = captureLoads()
+
+        val result = newModule().onAction(CategoryPool.GAMING)
+
+        assertTrue("session must dispatch more than the goal", urls.size >= 2)
+        val encodedGoal = java.net.URLEncoder.encode(goal, "UTF-8")
+        urls.forEach { url ->
+            assertTrue(
+                "every session query must stay on the chosen SERP and contain the goal; was: $url",
+                url.contains("www.google.com/search") && url.contains(encodedGoal)
+            )
+        }
+        // Each query text (goal + every refinement) hit the final dispatch gate.
+        verify(exactly = urls.size) { queryBlocklist.isBlocked(any()) }
+        // Single action log per session; detail carries only the goal, in the EXACT
+        // shape LogScrubber's export coarsening parses — separator drift would leak
+        // query text un-coarsened into exports.
+        assertTrue(result.detail.contains(goal))
+        assertTrue(
+            "detail must match the scrubber contract; was: ${result.detail}",
+            Regex("""^\[GAMING] .+ · via \S+$""").matches(result.detail)
+        )
+        assertTrue(result.success)
+        coVerify(exactly = 1) { webViewPool.acquire() }
+        coVerify(exactly = 1) { webViewPool.release(webView) }
+    }
+
+    // (g) A blocked refinement is skipped without aborting the session.
+    @Test
+    fun `blocked refinement is skipped while the session continues`() = runTest(testDispatcher) {
+        val goal = "best mechanical keyboards 2026"
+        safeSession(goal)
+        // Goal passes; anything longer (every refinement wraps the goal) is blocked.
+        every { queryBlocklist.isBlocked(any()) } answers { firstArg<String>() != goal }
+        val (urls, _) = captureLoads()
+
+        val result = newModule().onAction(CategoryPool.GAMING)
+
+        assertEquals("only the goal may be dispatched", 1, urls.size)
+        assertFalse(result.detail.startsWith("[BLOCKED]"))
+        assertTrue("goal already dispatched; session reports success", result.success)
+    }
+
+    // (h) Results are CLICKED via the SERP's own anchor: only curated hosts, never
+    // engine-internal or uncurated ones. The allow-list is the diff's primary safety
+    // gate for the new navigate-to-live-results capability.
+    @Test
+    fun `session clicks only curated organic results`() = runTest(testDispatcher) {
+        safeSession("best mechanical keyboards 2026")
+        every { crawlListManager.isCuratedHost(any()) } answers {
+            firstArg<String>().endsWith("example.com")
+        }
+        val scripts = stubSerp(
+            listOf(
+                "https://www.google.com/preferences",
+                "https://reviews.example.com/kb",
+                "https://random-uncurated.net/page",
+            )
+        )
+        captureLoads()
+
+        newModule().onAction(CategoryPool.GAMING)
+
+        val clicks = scripts.filter { it.contains(".click()") }
+        assertTrue(
+            "the curated result must be clicked; clicks: $clicks",
+            clicks.any { it.contains("reviews.example.com/kb") }
+        )
+        assertTrue(
+            "engine-internal links must never be clicked",
+            clicks.none { it.contains("google.com/preferences") }
+        )
+        assertTrue(
+            "uncurated hosts must never be clicked — the allow-list is the primary gate",
+            clicks.none { it.contains("random-uncurated.net") }
+        )
+    }
+
+    // (h2) Module-level wiring of the denylist on followed links.
+    @Test
+    fun `denylisted link is never clicked even when curated`() = runTest(testDispatcher) {
+        safeSession("best mechanical keyboards 2026")
+        every { crawlListManager.isCuratedHost(any()) } returns true
+        every { blocklist.isUrlBlocked(any()) } answers {
+            firstArg<String>().contains("blocked-host.example.com")
+        }
+        val scripts = stubSerp(
+            listOf(
+                "https://blocked-host.example.com/x",
+                "https://fine.example.org/y",
+            )
+        )
+        captureLoads()
+
+        newModule().onAction(CategoryPool.GAMING)
+
+        val clicks = scripts.filter { it.contains(".click()") }
+        assertTrue(clicks.none { it.contains("blocked-host.example.com") })
+        assertTrue(clicks.any { it.contains("fine.example.org") })
+    }
+
+    // (h3) Multi-step session: max draws exercise 3 refinements on the last engine.
+    @Test
+    fun `full session shape - three gated refinements then a click`() = runTest(testDispatcher) {
+        val goal = "best mechanical keyboards 2026"
+        safeSession(goal)
+        every { crawlListManager.isCuratedHost(any()) } returns true
+        val scripts = stubSerp(listOf("https://reviews.example.com/kb"))
+        val (urls, _) = captureLoads()
+
+        newModule(random = maxRandom).onAction(CategoryPool.GAMING)
+
+        assertEquals("goal + 3 refinements", 4, urls.size)
+        assertTrue("maxRandom picks the LAST engine", urls.all { it.contains("yandex.com") })
+        // Every refinement text individually hit the dispatch gate.
+        verify { queryBlocklist.isBlocked(goal) }
+        verify { queryBlocklist.isBlocked("best $goal") }
+        verify { queryBlocklist.isBlocked("$goal reviews") }
+        verify { queryBlocklist.isBlocked("$goal price") }
+        assertTrue(scripts.any { it.contains(".click()") })
+    }
+
+    // (h4) A blocked refinement mid-chain is skipped; the REST of the chain continues.
+    @Test
+    fun `blocked refinement mid-chain does not abort the rest of the session`() = runTest(testDispatcher) {
+        val goal = "best mechanical keyboards 2026"
+        safeSession(goal)
+        every { queryBlocklist.isBlocked(any()) } answers {
+            firstArg<String>().contains("price")
+        }
+        val (urls, _) = captureLoads()
+
+        val result = newModule(random = maxRandom).onAction(CategoryPool.GAMING)
+
+        assertEquals("goal + 2 surviving refinements", 3, urls.size)
+        assertTrue(result.success)
+    }
+
+    // (i) EXTREME intensity degrades to the pre-E5 single query (issue #76 honesty).
+    @Test
+    fun `extreme intensity collapses the session to a single query`() = runTest(testDispatcher) {
+        safeSession(
+            "best mechanical keyboards 2026",
+            intensity = com.fauxx.data.model.IntensityLevel.EXTREME
+        )
+        val (urls, _) = captureLoads()
+
+        newModule().onAction(CategoryPool.GAMING)
+
+        assertEquals(1, urls.size)
+        verify(exactly = 0) { webView.evaluateJavascript(any(), any()) }
+    }
+
+    // (i2) The HIGHEST configured tier governs, not just Wi-Fi: LOW Wi-Fi + EXTREME
+    // mobile must size the session for EXTREME (rate honesty on cellular).
+    @Test
+    fun `mobile tier participates in the session-size ceiling`() = runTest(testDispatcher) {
+        safeSession(
+            "best mechanical keyboards 2026",
+            intensity = com.fauxx.data.model.IntensityLevel.LOW,
+            mobileIntensity = com.fauxx.data.model.IntensityLevel.EXTREME
+        )
+        val (urls, _) = captureLoads()
+
+        newModule().onAction(CategoryPool.GAMING)
+
+        assertEquals(1, urls.size)
+    }
+
+    // (i3) The wall-clock budget trims the session once exhausted.
+    @Test
+    fun `exhausted session budget trims refinements and links`() = runTest(testDispatcher) {
+        safeSession("best mechanical keyboards 2026")
+        val tiredClock = mockk<com.fauxx.util.Clock> {
+            // First read computes the deadline; every later read is past it.
+            every { currentTimeMillis() } returnsMany listOf(0L, 100_000L)
+        }
+        val (urls, _) = captureLoads()
+
+        val result = newModule(clock = tiredClock).onAction(CategoryPool.GAMING)
+
+        assertEquals("only the goal fits in an exhausted budget", 1, urls.size)
+        assertTrue(result.success)
+        verify(exactly = 0) { webView.evaluateJavascript(any(), any()) }
+    }
+
+    // (j) Session bounds per intensity tier (keyed to the enum, not magic numbers).
+    @Test
+    fun `session bounds scale down with intensity`() {
+        assertEquals(2 to 1, SearchPoisonModule.sessionBounds(com.fauxx.data.model.IntensityLevel.LOW.actionsPerHour))
+        assertEquals(3 to 2, SearchPoisonModule.sessionBounds(com.fauxx.data.model.IntensityLevel.MEDIUM.actionsPerHour))
+        assertEquals(1 to 1, SearchPoisonModule.sessionBounds(com.fauxx.data.model.IntensityLevel.HIGH.actionsPerHour))
+        assertEquals(0 to 0, SearchPoisonModule.sessionBounds(com.fauxx.data.model.IntensityLevel.EXTREME.actionsPerHour))
     }
 
     // (e) Toggle-decoupling: start() seeds an Android-Chromium UA even if FingerprintModule is off.

--- a/app/src/test/java/com/fauxx/targeting/layer3/PersonaRotationChannelTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer3/PersonaRotationChannelTest.kt
@@ -5,6 +5,9 @@ import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.support.FakeClock
 import io.mockk.mockk
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -26,9 +29,13 @@ class PersonaRotationChannelTest {
     private fun layer(): PersonaRotationLayer =
         PersonaRotationLayer(mockk(relaxed = true), mockk(relaxed = true), clock)
 
-    private fun persona(id: String, createdAt: Long) = SyntheticPersona(
+    private fun persona(
+        id: String,
+        createdAt: Long,
+        interests: Set<CategoryPool> = setOf(CategoryPool.COOKING),
+    ) = SyntheticPersona(
         id = id, name = "Test", ageRange = "AGE_25_34", profession = "ENGINEER",
-        region = "US_WEST", interests = setOf(CategoryPool.COOKING),
+        region = "US_WEST", interests = interests,
         createdAt = createdAt, activeUntil = createdAt + TimeUnit.DAYS.toMillis(7)
     )
 
@@ -97,6 +104,44 @@ class PersonaRotationChannelTest {
         assertEquals(lags, PersonaChannel.entries.map { layer.adoptionLagMs(id, it) })
         lags.forEach { assertTrue("lag $it out of bounds", it in 0 until PersonaRotationLayer.CHANNEL_MAX_LAG_MS) }
         assertEquals("channels must not adopt simultaneously", lags.size, lags.toSet().size)
+    }
+
+    @Test
+    fun `weights flow staggers adoption and emits the live E9 blend`() = runBlocking {
+        // Pins two review findings at once: the Layer 3 category distribution honors
+        // staggered adoption like every other bound channel (no synchronized
+        // change-point at rotation), and the REAL getWeights() flow emits values from
+        // weightsFor — severing the computeWeights delegation turns this red.
+        val layer = layer()
+        val id = staggeredId(layer)
+        val rotatedAt = clock.nowMs
+        val old = persona("old", rotatedAt - TimeUnit.DAYS.toMillis(8),
+            interests = setOf(CategoryPool.COOKING))
+        val fresh = persona(id, rotatedAt, interests = setOf(CategoryPool.GAMING))
+        layer.setPersonasForTest(current = fresh, previous = old)
+        layer.setEnabled(true)
+
+        val aligned = PersonaRotationLayer
+            .weightsFor(setOf(CategoryPool.COOKING)).getValue(CategoryPool.COOKING)
+        val neutral = 1.0f
+
+        // Inside the WEIGHTS lag: the blend still follows the PREVIOUS persona.
+        val during = withTimeout(5_000) {
+            layer.getWeights().first { it.getValue(CategoryPool.COOKING) != neutral }
+        }
+        assertEquals(aligned, during.getValue(CategoryPool.COOKING), 1e-6f)
+        assertTrue(
+            "new persona's interest must still be misaligned during the lag",
+            during.getValue(CategoryPool.GAMING) < 1f
+        )
+
+        // Past every lag: the blend follows the NEW persona.
+        clock.nowMs = rotatedAt + PersonaRotationLayer.CHANNEL_MAX_LAG_MS
+        layer.reevaluateWeightsForTest()
+        val after = withTimeout(5_000) {
+            layer.getWeights().first { it.getValue(CategoryPool.GAMING) == aligned }
+        }
+        assertTrue(after.getValue(CategoryPool.COOKING) < 1f)
     }
 
     @Test

--- a/app/src/test/java/com/fauxx/targeting/layer3/PersonaRotationChannelTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer3/PersonaRotationChannelTest.kt
@@ -1,0 +1,116 @@
+package com.fauxx.targeting.layer3
+
+import com.fauxx.data.model.SyntheticPersona
+import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.support.FakeClock
+import io.mockk.mockk
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * E8 (#174): exercises the REAL [PersonaRotationLayer.personaForChannel] — the single
+ * binding point for location, app-signal, and rhythm channels. Pins the two safety
+ * properties the module tests can't (they all mock this layer):
+ *  1. Kill switch: Layer 3 disabled means NO channel sees a persona, even a stale one.
+ *  2. Staggered adoption: after rotation, channels phase the new persona in at
+ *     distinct, deterministic lags instead of stepping together (the synchronized
+ *     multi-channel change-point a longitudinal observer could segment on).
+ */
+class PersonaRotationChannelTest {
+
+    private val clock = FakeClock(1_000_000_000_000L)
+
+    private fun layer(): PersonaRotationLayer =
+        PersonaRotationLayer(mockk(relaxed = true), mockk(relaxed = true), clock)
+
+    private fun persona(id: String, createdAt: Long) = SyntheticPersona(
+        id = id, name = "Test", ageRange = "AGE_25_34", profession = "ENGINEER",
+        region = "US_WEST", interests = setOf(CategoryPool.COOKING),
+        createdAt = createdAt, activeUntil = createdAt + TimeUnit.DAYS.toMillis(7)
+    )
+
+    /**
+     * A persona id whose three channel lags are all >1h and pairwise distinct, found
+     * deterministically so the stagger assertions can't be defeated by a lag of 0.
+     */
+    private fun staggeredId(layer: PersonaRotationLayer): String =
+        (0..999).asSequence().map { "persona-$it" }.first { id ->
+            val lags = PersonaChannel.entries.map { layer.adoptionLagMs(id, it) }
+            lags.all { it > TimeUnit.HOURS.toMillis(1) } && lags.toSet().size == lags.size
+        }
+
+    @Test
+    fun `disabled layer yields null for every channel even with personas present`() {
+        val layer = layer()
+        layer.setPersonasForTest(
+            current = persona("current", clock.nowMs),
+            previous = persona("previous", clock.nowMs - TimeUnit.DAYS.toMillis(8))
+        )
+
+        PersonaChannel.entries.forEach { assertNull(layer.personaForChannel(it)) }
+
+        layer.setEnabled(true)
+        PersonaChannel.entries.forEach {
+            assertTrue(layer.personaForChannel(it) != null)
+        }
+
+        layer.setEnabled(false)
+        PersonaChannel.entries.forEach { assertNull(layer.personaForChannel(it)) }
+    }
+
+    @Test
+    fun `channels keep the previous persona during their lag and adopt after it`() {
+        val layer = layer()
+        val id = staggeredId(layer)
+        val rotatedAt = clock.nowMs
+        val old = persona("old", rotatedAt - TimeUnit.DAYS.toMillis(8))
+        val fresh = persona(id, rotatedAt)
+        layer.setPersonasForTest(current = fresh, previous = old)
+        layer.setEnabled(true)
+
+        PersonaChannel.entries.forEach { channel ->
+            val lag = layer.adoptionLagMs(id, channel)
+
+            clock.nowMs = rotatedAt + lag - 1
+            assertEquals(
+                "channel $channel must serve the previous persona inside its lag",
+                old.id, layer.personaForChannel(channel)!!.id
+            )
+
+            clock.nowMs = rotatedAt + lag
+            assertEquals(
+                "channel $channel must adopt the new persona once its lag elapses",
+                fresh.id, layer.personaForChannel(channel)!!.id
+            )
+        }
+    }
+
+    @Test
+    fun `adoption lags are deterministic, bounded, and channel-distinct`() {
+        val layer = layer()
+        val id = staggeredId(layer)
+        val lags = PersonaChannel.entries.map { layer.adoptionLagMs(id, it) }
+
+        assertEquals(lags, PersonaChannel.entries.map { layer.adoptionLagMs(id, it) })
+        lags.forEach { assertTrue("lag $it out of bounds", it in 0 until PersonaRotationLayer.CHANNEL_MAX_LAG_MS) }
+        assertEquals("channels must not adopt simultaneously", lags.size, lags.toSet().size)
+    }
+
+    @Test
+    fun `first persona ever - no previous - is adopted immediately on all channels`() {
+        val layer = layer()
+        val fresh = persona("first", clock.nowMs)
+        layer.setPersonasForTest(current = fresh, previous = null)
+        layer.setEnabled(true)
+
+        PersonaChannel.entries.forEach { channel ->
+            assertEquals(
+                "process-restart degradation: no previous persona means immediate adoption",
+                fresh.id, layer.personaForChannel(channel)!!.id
+            )
+        }
+    }
+}

--- a/scripts/backfill_city_regions.py
+++ b/scripts/backfill_city_regions.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+E8 (#174) offline preprocessing — backfill the `region` field of city_coords.json.
+
+CityDatabase.randomCity(regionHint) filters cities by SUBSTRING match on the region
+field, but the 806 bundled cities ship with no region at all, so any hint filters to
+empty and silently falls back to the full list (M3 spike, trap 1). This developer tool
+(committed, not shipped) tags every city with space-separated Region tokens:
+
+- US cities ("City, United States"): the state is resolved against the Census Gazetteer
+  national places file (name-matched candidates preferred, else nearest place by
+  coordinates), then mapped to fauxx's 5-way US region scheme -> one token, e.g.
+  "US_WEST". Same partition as scripts/build_persona_distribution.py.
+- Non-US cities: the country suffix maps to the coarse Region taxonomy. Countries with
+  their own Region enum value get BOTH tokens so specific and macro persona hints match
+  the same city: "SPAIN WESTERN_EUROPE", "MEXICO LATIN_AMERICA", "QUEBEC CANADA".
+- "RUSSIA EASTERN_EUROPE": RUSSIA is not a Region enum value, but ru-locale persona
+  templates use it as their region string, and the hint match is plain substring.
+
+Taxonomy judgment calls (fauxx's Region enum is deliberately coarse): Caucasus ->
+EASTERN_EUROPE; Central/South Asia and Oceania -> ASIA_PACIFIC; all of Africa and the
+Middle East -> MIDDLE_EAST_AFRICA; Caribbean -> LATIN_AMERICA; UK crown dependencies ->
+UK; Nordic/Mediterranean EU -> WESTERN_EUROPE.
+
+The script fails loudly on any unmapped country or unmatched US city rather than
+writing a partial asset.
+
+Run:  python3 scripts/backfill_city_regions.py
+Out:  app/src/main/assets/city_coords.json  (region field populated in place)
+"""
+import csv
+import io
+import json
+import math
+import os
+import sys
+import urllib.request
+import zipfile
+
+GAZETTEER_URL = ("https://www2.census.gov/geo/docs/maps-data/data/gazetteer/"
+                 "2023_Gazetteer/2023_Gaz_place_national.zip")
+
+# USPS state code -> fauxx Region (same 5-way partition as build_persona_distribution.py).
+USPS_REGION = {
+    "CT": "US_NORTHEAST", "ME": "US_NORTHEAST", "MA": "US_NORTHEAST", "NH": "US_NORTHEAST",
+    "NJ": "US_NORTHEAST", "NY": "US_NORTHEAST", "PA": "US_NORTHEAST", "RI": "US_NORTHEAST",
+    "VT": "US_NORTHEAST",
+    "IL": "US_MIDWEST", "IN": "US_MIDWEST", "IA": "US_MIDWEST", "KS": "US_MIDWEST",
+    "MI": "US_MIDWEST", "MN": "US_MIDWEST", "MO": "US_MIDWEST", "NE": "US_MIDWEST",
+    "ND": "US_MIDWEST", "OH": "US_MIDWEST", "SD": "US_MIDWEST", "WI": "US_MIDWEST",
+    "AL": "US_SOUTHEAST", "AR": "US_SOUTHEAST", "DE": "US_SOUTHEAST", "DC": "US_SOUTHEAST",
+    "FL": "US_SOUTHEAST", "GA": "US_SOUTHEAST", "KY": "US_SOUTHEAST", "LA": "US_SOUTHEAST",
+    "MD": "US_SOUTHEAST", "MS": "US_SOUTHEAST", "NC": "US_SOUTHEAST", "SC": "US_SOUTHEAST",
+    "TN": "US_SOUTHEAST", "VA": "US_SOUTHEAST", "WV": "US_SOUTHEAST",
+    "AZ": "US_SOUTHWEST", "NM": "US_SOUTHWEST", "OK": "US_SOUTHWEST", "TX": "US_SOUTHWEST",
+    "AK": "US_WEST", "CA": "US_WEST", "CO": "US_WEST", "HI": "US_WEST", "ID": "US_WEST",
+    "MT": "US_WEST", "NV": "US_WEST", "OR": "US_WEST", "UT": "US_WEST", "WA": "US_WEST",
+    "WY": "US_WEST",
+}
+
+# Countries with their own Region enum value (or, for RUSSIA, a ru-locale persona
+# region string): tagged "<SPECIFIC> <MACRO>" so both hint styles match.
+SPECIFIC = {
+    "Spain": "SPAIN WESTERN_EUROPE",
+    # Spanish autonomous community; es-locale SPAIN personas must be able to match it.
+    "Canary Islands": "SPAIN WESTERN_EUROPE",
+    "France": "FRANCE WESTERN_EUROPE",
+    "Belgium": "BELGIUM WESTERN_EUROPE",
+    "Switzerland": "SWITZERLAND WESTERN_EUROPE",
+    "Mexico": "MEXICO LATIN_AMERICA",
+    "Argentina": "ARGENTINA LATIN_AMERICA",
+    "Colombia": "COLOMBIA LATIN_AMERICA",
+    "Chile": "CHILE LATIN_AMERICA",
+    "Peru": "PERU LATIN_AMERICA",
+    "Russia": "RUSSIA EASTERN_EUROPE",
+}
+
+# Cities in the Canadian province of Quebec present in the asset (FR-locale personas
+# use the QUEBEC region); the rest of Canada is plain "CANADA".
+QUEBEC_CITIES = {"Montreal, Canada", "Quebec City, Canada"}
+
+# US-suffixed places excluded from persona location stories. UNBOUND is a sentinel
+# token no persona region hint ever matches: the city stays in the unfiltered world
+# pool but never anchors a coherent persona (Midway is an uninhabited wildlife refuge —
+# region-binding would concentrate a US_WEST persona's fixes there ~25x).
+US_NAME_OVERRIDES = {"Midway Atoll, United States": "UNBOUND"}
+
+MACRO = {
+    "CANADA": ["Canada"],
+    "UK": ["United Kingdom", "Guernsey", "Jersey", "Isle of Man", "Gibraltar"],
+    "WESTERN_EUROPE": [
+        "Germany", "Italy", "Netherlands", "Portugal", "Norway", "Sweden", "Finland",
+        "Denmark", "Austria", "Ireland", "Greece", "Iceland", "Luxembourg", "Malta",
+        "Cyprus", "Andorra", "Monaco", "San Marino", "Liechtenstein", "Faroe Islands",
+        "Greenland", "Azores", "Madeira", "Svalbard",
+    ],
+    "EASTERN_EUROPE": [
+        "Poland", "Ukraine", "Romania", "Belarus", "Czech Republic", "Bulgaria",
+        "Croatia", "Hungary", "Serbia", "Slovakia", "Slovenia", "Lithuania", "Latvia",
+        "Estonia", "Moldova", "Bosnia and Herzegovina", "Albania", "Kosovo",
+        "Montenegro", "North Macedonia", "Armenia", "Georgia", "Azerbaijan",
+    ],
+    "LATIN_AMERICA": [
+        "Brazil", "Venezuela", "Cuba", "Ecuador", "Bolivia", "Guatemala", "Costa Rica",
+        "Panama", "Honduras", "Nicaragua", "El Salvador", "Paraguay", "Uruguay",
+        "Dominican Republic", "Haiti", "Jamaica", "Trinidad and Tobago", "Barbados",
+        "Bahamas", "Belize", "Guyana", "Suriname", "French Guiana", "Puerto Rico",
+        "Aruba", "Curaçao", "Martinique", "Guadeloupe", "Antigua",
+        "Antigua and Barbuda", "Dominica", "Grenada", "Saint Lucia",
+        "Saint Kitts and Nevis", "Saint Vincent", "Saint Vincent and the Grenadines",
+        "Saint Martin", "Sint Maarten", "Saint Barthélemy", "British Virgin Islands",
+        "US Virgin Islands",
+    ],
+    "ASIA_PACIFIC": [
+        "China", "India", "Japan", "Australia", "South Korea", "North Korea",
+        "Indonesia", "Philippines", "Thailand", "Malaysia", "Vietnam", "Myanmar",
+        "Sri Lanka", "Pakistan", "Bangladesh", "Nepal", "Bhutan", "Cambodia", "Laos",
+        "Mongolia", "Taiwan", "Singapore", "Brunei", "East Timor", "New Zealand",
+        "Papua New Guinea", "Fiji", "Samoa", "American Samoa", "Tonga", "Vanuatu",
+        "Solomon Islands", "Kiribati", "Tuvalu", "Nauru", "Palau", "Micronesia",
+        "Marshall Islands", "Guam", "Northern Mariana Islands", "New Caledonia",
+        "French Polynesia", "Wallis and Futuna", "Cook Islands", "Maldives",
+        "Kazakhstan", "Kyrgyzstan", "Tajikistan", "Turkmenistan", "Uzbekistan",
+        "Afghanistan",
+    ],
+    "MIDDLE_EAST_AFRICA": [
+        "Turkey", "Iran", "Saudi Arabia", "Nigeria", "South Africa", "Egypt",
+        "Morocco", "United Arab Emirates", "Iraq", "Israel", "Kenya", "Jordan",
+        "Lebanon", "Syria", "Yemen", "Oman", "Qatar", "Kuwait", "Bahrain", "Algeria",
+        "Tunisia", "Libya", "Sudan", "South Sudan", "Ethiopia", "Eritrea", "Djibouti",
+        "Somalia", "Uganda", "Tanzania", "Rwanda", "Burundi", "DR Congo",
+        "Democratic Republic of the Congo", "Republic of the Congo", "Angola",
+        "Zambia", "Zimbabwe", "Malawi", "Mozambique", "Madagascar", "Botswana",
+        "Namibia", "Lesotho", "Eswatini", "Ghana", "Côte d'Ivoire", "Senegal", "Mali",
+        "Burkina Faso", "Niger", "Chad", "Cameroon", "Gabon", "Benin", "Togo",
+        "Guinea", "Guinea-Bissau", "Sierra Leone", "Liberia", "Gambia", "Mauritania",
+        "Cape Verde", "São Tomé and Príncipe", "Equatorial Guinea",
+        "Central African Republic", "Comoros", "Mauritius", "Seychelles", "Réunion",
+        "Mayotte", "Saint Helena", "Ascension Island", "Tristan da Cunha",
+    ],
+}
+
+COUNTRY_REGION = dict(SPECIFIC)
+for region, countries in MACRO.items():
+    for country in countries:
+        if country in COUNTRY_REGION:
+            print(f"Duplicate country mapping: {country}", file=sys.stderr)
+            sys.exit(1)
+        COUNTRY_REGION[country] = region
+
+
+def download(url):
+    for attempt in range(1, 4):
+        try:
+            with urllib.request.urlopen(url, timeout=300) as resp:
+                return resp.read()
+        except Exception as e:  # noqa: BLE001
+            print(f"  ! attempt {attempt}/3 failed: {e}", file=sys.stderr)
+    print(f"Could not download {url}; aborting.", file=sys.stderr)
+    sys.exit(1)
+
+
+def load_gazetteer():
+    """[(usps, normalized_name, lat, lng)] for every US place."""
+    blob = download(GAZETTEER_URL)
+    places = []
+    with zipfile.ZipFile(io.BytesIO(blob)) as z:
+        txt = next(n for n in z.namelist() if n.lower().endswith(".txt"))
+        with z.open(txt) as fh:
+            reader = csv.DictReader(io.TextIOWrapper(fh, encoding="utf-8", errors="replace"),
+                                    delimiter="\t")
+            for r in reader:
+                # Column headers carry trailing whitespace in this file; normalize keys.
+                row = {k.strip(): (v.strip() if v else "") for k, v in r.items() if k}
+                usps = row.get("USPS")
+                name = row.get("NAME", "").lower()
+                try:
+                    lat = float(row.get("INTPTLAT", ""))
+                    lng = float(row.get("INTPTLONG", ""))
+                except ValueError:
+                    continue
+                if usps in USPS_REGION and name:
+                    places.append((usps, name, lat, lng))
+    if len(places) < 10_000:
+        print(f"Gazetteer parse suspicious: only {len(places)} places; aborting.",
+              file=sys.stderr)
+        sys.exit(1)
+    return places
+
+
+def us_region(city_name, lat, lng, places):
+    """Resolve a US city to its region: name-matched candidates first, else nearest."""
+    plain = city_name.removesuffix(", United States").lower()
+
+    def dist2(p):
+        # Scale longitude by cos(latitude): unscaled degrees overweight east-west
+        # distance at high latitudes (Alaska), risking wrong-state nearest matches.
+        dlat = p[2] - lat
+        dlng = (p[3] - lng) * math.cos(math.radians(lat))
+        return dlat * dlat + dlng * dlng
+
+    named = [p for p in places if p[1].startswith(plain)]
+    pool = named if named else places
+    best = min(pool, key=dist2)
+    if dist2(best) > 1.5 ** 2:
+        # Name-matched pool can be a same-named place in another state; retry nearest-only.
+        best = min(places, key=dist2)
+        if dist2(best) > 1.5 ** 2:
+            print(f"No gazetteer place near {city_name} ({lat},{lng}); aborting.",
+                  file=sys.stderr)
+            sys.exit(1)
+    return USPS_REGION[best[0]], best
+
+
+def main():
+    src = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "app", "src",
+                                        "main", "assets", "city_coords.json"))
+    with open(src, encoding="utf-8") as f:
+        cities = json.load(f)
+
+    places = load_gazetteer()
+    unmapped = sorted({
+        c["name"].rsplit(", ", 1)[-1] for c in cities
+        if c["name"].rsplit(", ", 1)[-1] not in COUNTRY_REGION
+        and c["name"].rsplit(", ", 1)[-1] != "United States"
+    })
+    if unmapped:
+        print(f"Unmapped countries: {unmapped}; aborting.", file=sys.stderr)
+        sys.exit(1)
+
+    out = []
+    for c in cities:
+        country = c["name"].rsplit(", ", 1)[-1]
+        if c["name"] in US_NAME_OVERRIDES:
+            region = US_NAME_OVERRIDES[c["name"]]
+        elif country == "United States":
+            region, matched = us_region(c["name"], c["lat"], c["lng"], places)
+            print(f"  {c['name']:<40} -> {region:<14} (via {matched[1]}, {matched[0]})")
+        elif c["name"] in QUEBEC_CITIES:
+            region = "QUEBEC CANADA"
+        else:
+            region = COUNTRY_REGION[country]
+        out.append({"name": c["name"], "lat": c["lat"], "lng": c["lng"], "region": region})
+
+    with open(src, "w", encoding="utf-8") as f:
+        json.dump(out, f, ensure_ascii=False, indent=1)
+        f.write("\n")
+    from collections import Counter
+    print(f"\nWROTE {src}: {len(out)} cities, regions populated")
+    print("region counts:", dict(Counter(o["region"] for o in out).most_common()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_persona_distribution.py
+++ b/scripts/build_persona_distribution.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+E7 (#173) offline preprocessing — build the joint persona distribution from ACS PUMS.
+
+This is a DEVELOPER tool, not shipped in the app. It downloads curated US Census ACS PUMS
+1-Year person files, derives each person's (AgeRange, Profession, Region) in fauxx's own
+taxonomy, PWGTP-weights them, and writes the bundled joint distribution asset that
+PersonaGenerator multinomial-samples from so age/profession/region CO-OCCUR per real data
+(replacing independently-picked hand-authored archetypes for US personas).
+
+Hybrid scope (ratified 2026-06-09): US personas come from this distribution; the hand-authored
+es/fr/ru locale templates are kept as-is (PUMS is US-only). Non-EN microdata regeneration
+(Eurostat/INE/INEGI) is a tracked follow-up.
+
+Privacy / G3: only the AGEP, ST/STATE, SOCP, ESR, SCH, PWGTP columns are ever consulted
+(csv.DictReader materializes whole rows in memory, but no other field is read), and the
+artifact contains only derived (age, profession, region, weight) aggregates. Race,
+ancestry, sex, etc. are never read or persisted.
+
+Region representativeness: pooling raw PWGTP across a 2-states-per-region sample would
+make each region's mass equal its sampled states' share of the pool (TX+AZ would inflate
+US_SOUTHWEST by ~65% relative). main() therefore POST-STRATIFIES: each region's cells are
+rescaled so the region marginal matches its true national population share, computed from
+the Census state population estimates for PUMS_YEAR. Within-region (age, profession)
+composition still reflects only the sampled states — a documented limitation; add states
+to DOWNLOAD_STATES to narrow it.
+
+Run:  python3 scripts/build_persona_distribution.py
+Out:  app/src/main/assets/persona_distribution.json   (~36KB; 6x12x5 = 360 cells max)
+
+Regeneration is a ~2-year chore when a new PUMS vintage lands; bump PUMS_YEAR and re-run.
+(The 2023+ PUMS vintages rename the ST column to STATE; both are handled.)
+"""
+import csv
+import io
+import json
+import os
+import sys
+import urllib.request
+import zipfile
+
+PUMS_YEAR = "2022"
+BASE = f"https://www2.census.gov/programs-surveys/acs/data/pums/{PUMS_YEAR}/1-Year"
+
+# Curated download set: two larger states per region keeps the joint table well-populated
+# without the 591MB national file. Extend with more states (any FIPS in STATE_REGION) for a
+# more representative artifact.
+DOWNLOAD_STATES = ["ny", "ma", "fl", "ga", "il", "oh", "tx", "az", "ca", "wa"]
+
+# State FIPS -> fauxx Region enum (custom 5-way US scheme, not official Census regions).
+STATE_REGION = {
+    9: "US_NORTHEAST", 23: "US_NORTHEAST", 25: "US_NORTHEAST", 33: "US_NORTHEAST",
+    34: "US_NORTHEAST", 36: "US_NORTHEAST", 42: "US_NORTHEAST", 44: "US_NORTHEAST", 50: "US_NORTHEAST",
+    17: "US_MIDWEST", 18: "US_MIDWEST", 19: "US_MIDWEST", 20: "US_MIDWEST", 26: "US_MIDWEST",
+    27: "US_MIDWEST", 29: "US_MIDWEST", 31: "US_MIDWEST", 38: "US_MIDWEST", 39: "US_MIDWEST",
+    46: "US_MIDWEST", 55: "US_MIDWEST",
+    1: "US_SOUTHEAST", 5: "US_SOUTHEAST", 10: "US_SOUTHEAST", 11: "US_SOUTHEAST", 12: "US_SOUTHEAST",
+    13: "US_SOUTHEAST", 21: "US_SOUTHEAST", 22: "US_SOUTHEAST", 24: "US_SOUTHEAST", 28: "US_SOUTHEAST",
+    37: "US_SOUTHEAST", 45: "US_SOUTHEAST", 47: "US_SOUTHEAST", 51: "US_SOUTHEAST", 54: "US_SOUTHEAST",
+    4: "US_SOUTHWEST", 35: "US_SOUTHWEST", 40: "US_SOUTHWEST", 48: "US_SOUTHWEST",
+    2: "US_WEST", 6: "US_WEST", 8: "US_WEST", 15: "US_WEST", 16: "US_WEST", 30: "US_WEST",
+    32: "US_WEST", 41: "US_WEST", 49: "US_WEST", 53: "US_WEST", 56: "US_WEST",
+}
+
+# SOC major group (first 2 digits of SOCP) -> Profession enum.
+# 11 (Management) joins 13 (Business/Financial Ops) under FINANCE_PROF, whose
+# user-facing label is "Business Professional".
+SOC_MAJOR = {
+    "11": "FINANCE_PROF", "13": "FINANCE_PROF", "15": "ENGINEER", "17": "ENGINEER",
+    "25": "TEACHER", "29": "HEALTHCARE", "31": "HEALTHCARE", "23": "LEGAL",
+    "41": "RETAIL", "47": "TRADES", "49": "TRADES", "51": "TRADES", "27": "CREATIVE",
+}
+
+
+# Census state population estimates (SUMLEV 040 rows, POPESTIMATE<year> column) — used
+# to post-stratify region marginals to true national shares.
+POPEST_URL = ("https://www2.census.gov/programs-surveys/popest/datasets/"
+              "2020-2023/state/totals/NST-EST2023-ALLDATA.csv")
+
+
+def region_population_targets():
+    """True share of national population per fauxx Region, from Census state estimates."""
+    blob = download(POPEST_URL)
+    if blob is None:
+        print("Could not download state population estimates; aborting — without "
+              "post-stratification the artifact would carry the sampled-states region "
+              "skew.", file=sys.stderr)
+        sys.exit(1)
+    totals = {}
+    reader = csv.DictReader(io.StringIO(blob.decode("utf-8", errors="replace")))
+    for r in reader:
+        if r.get("SUMLEV") != "040":
+            continue
+        region = STATE_REGION.get(parse_int(r.get("STATE")))
+        pop = parse_int(r.get(f"POPESTIMATE{PUMS_YEAR}"))
+        if region and pop:
+            totals[region] = totals.get(region, 0) + pop
+    expected = set(STATE_REGION.values())
+    if set(totals) != expected:
+        print(f"Population estimates incomplete: got {sorted(totals)}, "
+              f"expected {sorted(expected)}; aborting.", file=sys.stderr)
+        sys.exit(1)
+    national = sum(totals.values())
+    return {region: pop / national for region, pop in totals.items()}
+
+
+def age_bin(agep):
+    if agep < 18:
+        return None
+    if agep <= 24:
+        return "AGE_18_24"
+    if agep <= 34:
+        return "AGE_25_34"
+    if agep <= 44:
+        return "AGE_35_44"
+    if agep <= 54:
+        return "AGE_45_54"
+    if agep <= 64:
+        return "AGE_55_64"
+    return "AGE_65_PLUS"
+
+
+def profession(agep, esr, sch, socp):
+    # Bucket semantics are deliberately coarse to fit fauxx's 12-value Profession enum:
+    # - STUDENT: enrolled (SCH 2/3) and <=34, even if also employed.
+    # - RETIRED: not in labor force and >=62 (early Social Security age); NILF under 62
+    #   maps to HOMEMAKER, which therefore also absorbs disabled adults, discouraged
+    #   workers, and early retirees — it overstates literal homemakers by design.
+    # - Armed forces (ESR 4/5) carry SOC major group 55, absent from SOC_MAJOR, so they
+    #   land in OTHER alongside unemployed and unmapped civilian occupations.
+    enrolled = sch in (2, 3)
+    if enrolled and agep <= 34:
+        return "STUDENT"
+    if esr == 6:  # not in labor force
+        return "RETIRED" if agep >= 62 else "HOMEMAKER"
+    if esr in (1, 2, 4, 5):  # employed (civilian or armed forces)
+        mg = socp[:2] if socp and socp[:2].isdigit() else None
+        return SOC_MAJOR.get(mg, "OTHER")
+    return "OTHER"  # unemployed / not determinable
+
+
+def parse_int(s):
+    try:
+        return int(float(s))
+    except (ValueError, TypeError):
+        return None
+
+
+def download(url, attempts=3):
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=300) as resp:
+                return resp.read()
+        except Exception as e:  # noqa: BLE001
+            print(f"  ! attempt {attempt}/{attempts} failed: {e}", file=sys.stderr)
+    return None
+
+
+def process_state(abbr, counts):
+    url = f"{BASE}/csv_p{abbr}.zip"
+    print(f"  downloading {url} ...", flush=True)
+    blob = download(url)
+    if blob is None:
+        print(f"  ! skip {abbr}: all download attempts failed", file=sys.stderr)
+        return 0
+    rows = 0
+    try:
+        z = zipfile.ZipFile(io.BytesIO(blob))
+    except zipfile.BadZipFile as e:
+        # census.gov can answer 200 with an HTML maintenance page; skip, don't abort.
+        print(f"  ! skip {abbr}: not a zip ({e})", file=sys.stderr)
+        return 0
+    with z:
+        csv_name = max((n for n in z.namelist() if n.lower().endswith(".csv")),
+                       key=lambda n: z.getinfo(n).file_size, default=None)
+        if not csv_name:
+            print(f"  ! no csv in {abbr}", file=sys.stderr)
+            return 0
+        with z.open(csv_name) as fh:
+            reader = csv.DictReader(io.TextIOWrapper(fh, encoding="utf-8", errors="replace"))
+            for r in reader:
+                agep = parse_int(r.get("AGEP"))
+                st = parse_int(r.get("ST") or r.get("STATE"))  # renamed in 2023+ vintages
+                w = parse_int(r.get("PWGTP"))
+                if agep is None or st is None or not w:
+                    continue
+                age = age_bin(agep)
+                region = STATE_REGION.get(st)
+                if age is None or region is None:
+                    continue
+                esr = parse_int(r.get("ESR"))
+                sch = parse_int(r.get("SCH"))
+                prof = profession(agep, esr if esr is not None else -1,
+                                  sch if sch is not None else -1, (r.get("SOCP") or "").strip())
+                counts[(age, prof, region)] = counts.get((age, prof, region), 0) + w
+                rows += 1
+    print(f"  {abbr}: {rows} persons", flush=True)
+    return rows
+
+
+def main():
+    counts = {}
+    included = []
+    for abbr in DOWNLOAD_STATES:
+        if process_state(abbr, counts) > 0:
+            included.append(abbr)
+    total = sum(counts.values())
+    if total == 0:
+        print("No data collected; aborting.", file=sys.stderr)
+        sys.exit(1)
+    skipped = [s for s in DOWNLOAD_STATES if s not in included]
+    if skipped:
+        # A partial artifact silently reshapes within-region composition even after
+        # post-stratification; refuse to write one.
+        print(f"FATAL: states skipped (download/parse failure): {skipped} — "
+              f"re-run rather than committing a skewed artifact.", file=sys.stderr)
+        sys.exit(1)
+
+    # Post-stratify region marginals to true national shares (see module docstring).
+    targets = region_population_targets()
+    observed = {}
+    for (_, _, region), w in counts.items():
+        observed[region] = observed.get(region, 0) + w
+    factors = {region: targets[region] / (observed[region] / total) for region in observed}
+    print("post-stratification factors:",
+          {region: round(f, 4) for region, f in sorted(factors.items())}, flush=True)
+    counts = {key: w * factors[key[2]] for key, w in counts.items()}
+    total = sum(counts.values())
+
+    # Full-precision weights: rounding to 8 decimals would silently zero (and the app
+    # loader would then drop) any cell with true probability below 5e-9.
+    cells = [
+        {"age": a, "profession": p, "region": r, "weight": w / total}
+        for (a, p, r), w in sorted(counts.items(), key=lambda kv: -kv[1])
+    ]
+    out = {
+        "version": 1,
+        "source": f"US Census ACS PUMS {PUMS_YEAR} 1-Year, states={included}",
+        "note": "Joint P(AgeRange, Profession, Region) over US adults, PWGTP-weighted, "
+                "region marginals post-stratified to Census state population estimates. "
+                "Within-region composition reflects only the sampled states. US-only by "
+                "design (hybrid: es/fr/ru keep hand-authored templates).",
+        "dimensions": {
+            "age": ["AGE_18_24", "AGE_25_34", "AGE_35_44", "AGE_45_54", "AGE_55_64", "AGE_65_PLUS"],
+            "profession": ["STUDENT", "TEACHER", "ENGINEER", "HEALTHCARE", "LEGAL", "FINANCE_PROF",
+                           "RETAIL", "TRADES", "CREATIVE", "RETIRED", "HOMEMAKER", "OTHER"],
+            "region": ["US_NORTHEAST", "US_SOUTHEAST", "US_MIDWEST", "US_SOUTHWEST", "US_WEST"],
+        },
+        "cells": cells,
+    }
+    dest = os.path.join(os.path.dirname(__file__), "..", "app", "src", "main", "assets",
+                        "persona_distribution.json")
+    dest = os.path.normpath(dest)
+    with open(dest, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=1)
+    print(f"\nWROTE {dest}: {len(cells)} non-zero cells, {os.path.getsize(dest)} bytes, "
+          f"total weighted persons={total}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## M3: Coherent Persona (the strategic pivot)

Pivots the engine from "statistical fog" toward **one coherent, credible synthetic person**, since a single convincing persona is harder for a broker to filter out than diffuse noise. Core chain E7 → E8 → E9, with E5 and E10 as parallel tracks.

Closes #173, #174, #175, #176, #177. Completes milestone **M3**.

### Epics

**E7 — Joint-sampled US personas from ACS PUMS (#173)** `d1a61ab`
Personas are sampled jointly over (age, profession, region) from a bundled pmf built offline from real ACS PUMS 2022 microdata (post-stratified to Census state population totals), so demographics are internally coherent (no 18-24 retirees). Hand-authored es/fr/ru templates retained (hybrid). Canonicalized all `SyntheticPersona` demographics to enum names.

**E8 — Bind persona across modules (#174)** `e75fb5d`
The active persona drives location (`region` → city pool), app-signal (off-interest → interest swap), and timing (persona-keyed daily rhythm) through one kill switch (`PersonaRotationLayer.activePersona`). Staggered per-channel adoption (0-48h lag) so rotation isn't a synchronized change-point. City→region backfill for all 806 cities.

**E9 — Rebalance the Distancing Engine (#176)** `ce756ab`
`PERSONA_FOLLOW_FRACTION` 0.70→0.85 and a uniform-baseline weight in the L3 blend; concentration 0.37→0.49, aligned/misaligned separation 3.3→5.2. Weights flow as a staggered channel so the category distribution doesn't step at rotation.

**E5 — Intent-chain search sessions (#175)** `148348f`
Search becomes a goal → 1-3 in-topic refinements → click 1-2 results session (one held WebView), so queries read like a real research session rather than disconnected one-shots. Link-following is gated to the curated crawl-corpus hosts (allow-list, fail-closed) and re-gated through the query blocklist.

**E10 — Circadian rhythm from screen-on (#177)** `c5ed5d7`
Learns the user's own daily rhythm from locally-observed `ACTION_SCREEN_ON` events (24-bucket aggregate histogram, no timestamps, SQLCipher, never uploaded) and modulates the synthetic rate by hour of day, composed with the E8 persona rhythm into the single rate seam. Mean-preserving shaping keeps the 24h mean at 1.0 (rate honesty, #76); falls back to neutral until 50 observations. Both reset paths wipe the learned rhythm in memory and on disk. DB `v5 → v6` (`MIGRATION_5_6`).

### Carve-outs (not in this PR)
- E13 (#178, cross-device) → M3.5
- E3 (#172, control-profile A/B) → M4 (spike-first)
- E7 non-EN microdata regeneration and P(interests | age, profession) → follow-ups

### Testing
- Full-flavor unit suite green (**531 tests**, 0 failures), lint clean.
- Each epic went through an adversarial multi-agent review before commit; E10's 15-agent Opus review found 1 major (a "Clear My Profile" DB wipe race) + 9 minors, all fixed.
- Room `MIGRATION_5_6` DDL verified byte-for-byte against the generated `6.json`; migration + DAO round-trip instrumented tests updated for v6.
- Instrumented (emulator) tests are exercised by the existing `instrumented-tests.yml` workflow; per the project's known emulator flakiness, the unit suite + lint are the green gate.
