### PR TITLE
M4 E4: Adversarial noise allocation via a broker-inference surrogate (#180)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ CLAUDE.md
 scripts/*
 !scripts/build_persona_distribution.py
 !scripts/backfill_city_regions.py
+# E4 (#180) broker-inference co-occurrence builder: regenerates a shipped asset, must be reviewable.
+!scripts/build_cooccurrence.py

--- a/app/src/main/assets/ad_category_cooccurrence.json
+++ b/app/src/main/assets/ad_category_cooccurrence.json
@@ -1,0 +1,546 @@
+{
+  "version": 1,
+  "provenance": "Designed semantic-affinity prior (hand-curated clusters; scripts/build_cooccurrence.py). NOT measured broker statistics: no public source publishes co-occurrence over fauxx's 32-category taxonomy. Research surrogate for broker inference only.",
+  "model": {
+    "bias": -2.0,
+    "selfCoef": 6.0,
+    "neighborCoef": 3.0
+  },
+  "affinities": [
+    {
+      "a": "ACADEMIC",
+      "b": "ENVIRONMENT",
+      "w": 0.75
+    },
+    {
+      "a": "ACADEMIC",
+      "b": "HISTORY",
+      "w": 0.75
+    },
+    {
+      "a": "ACADEMIC",
+      "b": "MUSIC",
+      "w": 0.75
+    },
+    {
+      "a": "ACADEMIC",
+      "b": "PARENTING",
+      "w": 0.45
+    },
+    {
+      "a": "ACADEMIC",
+      "b": "SCIENCE",
+      "w": 0.75
+    },
+    {
+      "a": "AGRICULTURE",
+      "b": "AUTOMOTIVE",
+      "w": 0.8
+    },
+    {
+      "a": "AGRICULTURE",
+      "b": "ENVIRONMENT",
+      "w": 0.5
+    },
+    {
+      "a": "AGRICULTURE",
+      "b": "FITNESS",
+      "w": 0.8
+    },
+    {
+      "a": "AGRICULTURE",
+      "b": "OUTDOOR_RECREATION",
+      "w": 0.8
+    },
+    {
+      "a": "AGRICULTURE",
+      "b": "PETS",
+      "w": 0.8
+    },
+    {
+      "a": "AGRICULTURE",
+      "b": "SPORTS",
+      "w": 0.8
+    },
+    {
+      "a": "AUTOMOTIVE",
+      "b": "FITNESS",
+      "w": 0.8
+    },
+    {
+      "a": "AUTOMOTIVE",
+      "b": "MILITARY_DEFENSE",
+      "w": 0.35
+    },
+    {
+      "a": "AUTOMOTIVE",
+      "b": "OUTDOOR_RECREATION",
+      "w": 0.8
+    },
+    {
+      "a": "AUTOMOTIVE",
+      "b": "PETS",
+      "w": 0.8
+    },
+    {
+      "a": "AUTOMOTIVE",
+      "b": "SPORTS",
+      "w": 0.8
+    },
+    {
+      "a": "AUTOMOTIVE",
+      "b": "TRAVEL",
+      "w": 0.45
+    },
+    {
+      "a": "BEAUTY",
+      "b": "ENTERTAINMENT",
+      "w": 0.8
+    },
+    {
+      "a": "BEAUTY",
+      "b": "FASHION",
+      "w": 0.8
+    },
+    {
+      "a": "BEAUTY",
+      "b": "FITNESS",
+      "w": 0.8
+    },
+    {
+      "a": "BEAUTY",
+      "b": "FOOD",
+      "w": 0.8
+    },
+    {
+      "a": "BEAUTY",
+      "b": "GAMING",
+      "w": 0.7
+    },
+    {
+      "a": "BEAUTY",
+      "b": "MEDICAL",
+      "w": 0.8
+    },
+    {
+      "a": "BEAUTY",
+      "b": "MUSIC",
+      "w": 0.8
+    },
+    {
+      "a": "BEAUTY",
+      "b": "RELATIONSHIPS_DATING",
+      "w": 0.7
+    },
+    {
+      "a": "BEAUTY",
+      "b": "TRAVEL",
+      "w": 0.8
+    },
+    {
+      "a": "BEAUTY",
+      "b": "WELLNESS_ALTERNATIVE",
+      "w": 0.8
+    },
+    {
+      "a": "BUSINESS",
+      "b": "FINANCE",
+      "w": 0.85
+    },
+    {
+      "a": "BUSINESS",
+      "b": "LEGAL",
+      "w": 0.85
+    },
+    {
+      "a": "BUSINESS",
+      "b": "REAL_ESTATE",
+      "w": 0.85
+    },
+    {
+      "a": "BUSINESS",
+      "b": "RETIREMENT",
+      "w": 0.85
+    },
+    {
+      "a": "COOKING",
+      "b": "CRAFTS",
+      "w": 0.8
+    },
+    {
+      "a": "COOKING",
+      "b": "FOOD",
+      "w": 0.8
+    },
+    {
+      "a": "COOKING",
+      "b": "HOME_IMPROVEMENT",
+      "w": 0.8
+    },
+    {
+      "a": "COOKING",
+      "b": "PARENTING",
+      "w": 0.8
+    },
+    {
+      "a": "COOKING",
+      "b": "PETS",
+      "w": 0.8
+    },
+    {
+      "a": "CRAFTS",
+      "b": "FOOD",
+      "w": 0.8
+    },
+    {
+      "a": "CRAFTS",
+      "b": "HOME_IMPROVEMENT",
+      "w": 0.8
+    },
+    {
+      "a": "CRAFTS",
+      "b": "PARENTING",
+      "w": 0.8
+    },
+    {
+      "a": "CRAFTS",
+      "b": "PETS",
+      "w": 0.8
+    },
+    {
+      "a": "ENTERTAINMENT",
+      "b": "FASHION",
+      "w": 0.8
+    },
+    {
+      "a": "ENTERTAINMENT",
+      "b": "FITNESS",
+      "w": 0.7
+    },
+    {
+      "a": "ENTERTAINMENT",
+      "b": "FOOD",
+      "w": 0.8
+    },
+    {
+      "a": "ENTERTAINMENT",
+      "b": "GAMING",
+      "w": 0.85
+    },
+    {
+      "a": "ENTERTAINMENT",
+      "b": "MUSIC",
+      "w": 0.8
+    },
+    {
+      "a": "ENTERTAINMENT",
+      "b": "RELATIONSHIPS_DATING",
+      "w": 0.7
+    },
+    {
+      "a": "ENTERTAINMENT",
+      "b": "SCIENCE",
+      "w": 0.85
+    },
+    {
+      "a": "ENTERTAINMENT",
+      "b": "TECHNOLOGY",
+      "w": 0.85
+    },
+    {
+      "a": "ENTERTAINMENT",
+      "b": "TRAVEL",
+      "w": 0.8
+    },
+    {
+      "a": "ENVIRONMENT",
+      "b": "HISTORY",
+      "w": 0.75
+    },
+    {
+      "a": "ENVIRONMENT",
+      "b": "MILITARY_DEFENSE",
+      "w": 0.75
+    },
+    {
+      "a": "ENVIRONMENT",
+      "b": "MUSIC",
+      "w": 0.75
+    },
+    {
+      "a": "ENVIRONMENT",
+      "b": "POLITICS",
+      "w": 0.75
+    },
+    {
+      "a": "ENVIRONMENT",
+      "b": "SCIENCE",
+      "w": 0.75
+    },
+    {
+      "a": "FASHION",
+      "b": "FITNESS",
+      "w": 0.7
+    },
+    {
+      "a": "FASHION",
+      "b": "FOOD",
+      "w": 0.8
+    },
+    {
+      "a": "FASHION",
+      "b": "GAMING",
+      "w": 0.7
+    },
+    {
+      "a": "FASHION",
+      "b": "MUSIC",
+      "w": 0.8
+    },
+    {
+      "a": "FASHION",
+      "b": "RELATIONSHIPS_DATING",
+      "w": 0.7
+    },
+    {
+      "a": "FASHION",
+      "b": "TRAVEL",
+      "w": 0.8
+    },
+    {
+      "a": "FINANCE",
+      "b": "LEGAL",
+      "w": 0.85
+    },
+    {
+      "a": "FINANCE",
+      "b": "REAL_ESTATE",
+      "w": 0.85
+    },
+    {
+      "a": "FINANCE",
+      "b": "RETIREMENT",
+      "w": 0.85
+    },
+    {
+      "a": "FINANCE",
+      "b": "TECHNOLOGY",
+      "w": 0.4
+    },
+    {
+      "a": "FITNESS",
+      "b": "FOOD",
+      "w": 0.8
+    },
+    {
+      "a": "FITNESS",
+      "b": "GAMING",
+      "w": 0.7
+    },
+    {
+      "a": "FITNESS",
+      "b": "MEDICAL",
+      "w": 0.8
+    },
+    {
+      "a": "FITNESS",
+      "b": "MUSIC",
+      "w": 0.7
+    },
+    {
+      "a": "FITNESS",
+      "b": "OUTDOOR_RECREATION",
+      "w": 0.8
+    },
+    {
+      "a": "FITNESS",
+      "b": "PETS",
+      "w": 0.8
+    },
+    {
+      "a": "FITNESS",
+      "b": "RELATIONSHIPS_DATING",
+      "w": 0.7
+    },
+    {
+      "a": "FITNESS",
+      "b": "SPORTS",
+      "w": 0.8
+    },
+    {
+      "a": "FITNESS",
+      "b": "WELLNESS_ALTERNATIVE",
+      "w": 0.8
+    },
+    {
+      "a": "FOOD",
+      "b": "HOME_IMPROVEMENT",
+      "w": 0.8
+    },
+    {
+      "a": "FOOD",
+      "b": "MEDICAL",
+      "w": 0.8
+    },
+    {
+      "a": "FOOD",
+      "b": "MUSIC",
+      "w": 0.8
+    },
+    {
+      "a": "FOOD",
+      "b": "PARENTING",
+      "w": 0.8
+    },
+    {
+      "a": "FOOD",
+      "b": "PETS",
+      "w": 0.8
+    },
+    {
+      "a": "FOOD",
+      "b": "TRAVEL",
+      "w": 0.8
+    },
+    {
+      "a": "FOOD",
+      "b": "WELLNESS_ALTERNATIVE",
+      "w": 0.8
+    },
+    {
+      "a": "GAMING",
+      "b": "MUSIC",
+      "w": 0.7
+    },
+    {
+      "a": "GAMING",
+      "b": "RELATIONSHIPS_DATING",
+      "w": 0.7
+    },
+    {
+      "a": "GAMING",
+      "b": "SCIENCE",
+      "w": 0.85
+    },
+    {
+      "a": "GAMING",
+      "b": "TECHNOLOGY",
+      "w": 0.85
+    },
+    {
+      "a": "HISTORY",
+      "b": "MILITARY_DEFENSE",
+      "w": 0.75
+    },
+    {
+      "a": "HISTORY",
+      "b": "MUSIC",
+      "w": 0.75
+    },
+    {
+      "a": "HISTORY",
+      "b": "POLITICS",
+      "w": 0.75
+    },
+    {
+      "a": "HISTORY",
+      "b": "SCIENCE",
+      "w": 0.75
+    },
+    {
+      "a": "HOME_IMPROVEMENT",
+      "b": "PARENTING",
+      "w": 0.8
+    },
+    {
+      "a": "HOME_IMPROVEMENT",
+      "b": "PETS",
+      "w": 0.8
+    },
+    {
+      "a": "HOME_IMPROVEMENT",
+      "b": "REAL_ESTATE",
+      "w": 0.6
+    },
+    {
+      "a": "LEGAL",
+      "b": "REAL_ESTATE",
+      "w": 0.85
+    },
+    {
+      "a": "LEGAL",
+      "b": "RETIREMENT",
+      "w": 0.85
+    },
+    {
+      "a": "MEDICAL",
+      "b": "PETS",
+      "w": 0.35
+    },
+    {
+      "a": "MEDICAL",
+      "b": "RETIREMENT",
+      "w": 0.55
+    },
+    {
+      "a": "MEDICAL",
+      "b": "WELLNESS_ALTERNATIVE",
+      "w": 0.8
+    },
+    {
+      "a": "MILITARY_DEFENSE",
+      "b": "POLITICS",
+      "w": 0.75
+    },
+    {
+      "a": "MUSIC",
+      "b": "RELATIONSHIPS_DATING",
+      "w": 0.7
+    },
+    {
+      "a": "MUSIC",
+      "b": "SCIENCE",
+      "w": 0.75
+    },
+    {
+      "a": "MUSIC",
+      "b": "TRAVEL",
+      "w": 0.8
+    },
+    {
+      "a": "OUTDOOR_RECREATION",
+      "b": "PETS",
+      "w": 0.8
+    },
+    {
+      "a": "OUTDOOR_RECREATION",
+      "b": "SPORTS",
+      "w": 0.8
+    },
+    {
+      "a": "OUTDOOR_RECREATION",
+      "b": "TRAVEL",
+      "w": 0.5
+    },
+    {
+      "a": "PARENTING",
+      "b": "PETS",
+      "w": 0.8
+    },
+    {
+      "a": "PETS",
+      "b": "SPORTS",
+      "w": 0.8
+    },
+    {
+      "a": "REAL_ESTATE",
+      "b": "RETIREMENT",
+      "w": 0.85
+    },
+    {
+      "a": "SCIENCE",
+      "b": "TECHNOLOGY",
+      "w": 0.85
+    }
+  ]
+}

--- a/app/src/main/java/com/fauxx/data/model/PoisonProfile.kt
+++ b/app/src/main/java/com/fauxx/data/model/PoisonProfile.kt
@@ -30,6 +30,9 @@ import com.fauxx.ui.theme.ThemeMode
  * @property layer1Enabled Whether Layer 1 (self-report targeting) is active.
  * @property layer2Enabled Whether Layer 2 (adversarial scraper) is active.
  * @property layer3Enabled Whether Layer 3 (persona rotation) is active.
+ * @property adversarialAllocationEnabled Whether the adversarial allocation stage (E4 #180) is
+ *   active. A post-combine optimization step, off by default; only has an effect when Layer 1
+ *   and/or Layer 2 are enabled (they supply the protected-interest signal it optimizes against).
  * @property themeMode UI theme preference (system / light / dark).
  * @property resumeOnBoot When true, show a "tap to resume" notification after device
  *   reboot if the engine was enabled pre-reboot. True FGS auto-start is blocked by
@@ -59,6 +62,7 @@ data class PoisonProfile(
     val layer1Enabled: Boolean = false,
     val layer2Enabled: Boolean = false,
     val layer3Enabled: Boolean = true,
+    val adversarialAllocationEnabled: Boolean = false,
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val resumeOnBoot: Boolean = true,
     val customUserAgent: String? = null

--- a/app/src/main/java/com/fauxx/di/DataStoreModule.kt
+++ b/app/src/main/java/com/fauxx/di/DataStoreModule.kt
@@ -53,6 +53,10 @@ object PreferenceKeys {
     val LAYER2_ENABLED = booleanPreferencesKey("layer2_enabled")
     val LAYER3_ENABLED = booleanPreferencesKey("layer3_enabled")
 
+    // Adversarial allocation stage (E4 #180). Off by default; a post-combine optimization step,
+    // distinct from the L1-L3 layer toggles above.
+    val ADVERSARIAL_ALLOCATION_ENABLED = booleanPreferencesKey("adversarial_allocation_enabled")
+
     // Onboarding
     val ONBOARDING_COMPLETED = booleanPreferencesKey("onboarding_completed")
 

--- a/app/src/main/java/com/fauxx/di/TargetingModule.kt
+++ b/app/src/main/java/com/fauxx/di/TargetingModule.kt
@@ -3,6 +3,9 @@ package com.fauxx.di
 import android.content.Context
 import com.fauxx.targeting.TargetingEngine
 import com.fauxx.targeting.WeightNormalizer
+import com.fauxx.targeting.allocation.AdversarialAllocator
+import com.fauxx.targeting.allocation.CooccurrenceLoader
+import com.fauxx.targeting.allocation.CooccurrenceTable
 import com.fauxx.targeting.layer0.UniformEntropyLayer
 import com.fauxx.targeting.layer1.CustomInterestMapper
 import com.fauxx.targeting.layer1.DemographicDistanceMap
@@ -99,6 +102,14 @@ object TargetingModule {
     @Singleton
     fun provideRateModulator(composite: CompositeRateModulator): RateModulator = composite
 
+    /**
+     * The broker-inference co-occurrence prior (E4 #180), loaded once from the bundled asset.
+     * The loader is fail-safe, so this never throws — a bad asset yields an empty table.
+     */
+    @Provides
+    @Singleton
+    fun provideCooccurrenceTable(loader: CooccurrenceLoader): CooccurrenceTable = loader.load()
+
     @Provides
     @Singleton
     fun provideTargetingEngine(
@@ -106,6 +117,7 @@ object TargetingModule {
         l1: SelfReportLayer,
         l2: AdversarialScraperLayer,
         l3: PersonaRotationLayer,
-        normalizer: WeightNormalizer
-    ): TargetingEngine = TargetingEngine(l0, l1, l2, l3, normalizer)
+        normalizer: WeightNormalizer,
+        allocator: AdversarialAllocator
+    ): TargetingEngine = TargetingEngine(l0, l1, l2, l3, normalizer, allocator)
 }

--- a/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
+++ b/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
@@ -360,6 +360,7 @@ class PoisonEngine @Inject constructor(
             targetingEngine.setLayer1Enabled(savedProfile.layer1Enabled)
             targetingEngine.setLayer2Enabled(savedProfile.layer2Enabled)
             targetingEngine.setLayer3Enabled(savedProfile.layer3Enabled)
+            targetingEngine.setAdversarialAllocationEnabled(savedProfile.adversarialAllocationEnabled)
 
             // Seed today's action count from DB once on start
             val dayStart = clock.currentTimeMillis().let { it - (it % MS_PER_DAY) }
@@ -368,7 +369,7 @@ class PoisonEngine @Inject constructor(
                 try { actionLogDao.countSince(dayStart).first() } catch (_: Exception) { 0 }
             )
             _engineState.value = EngineState.ACTIVE
-            Timber.i("PoisonEngine started (layers: L1=${savedProfile.layer1Enabled}, L2=${savedProfile.layer2Enabled}, L3=${savedProfile.layer3Enabled})")
+            Timber.i("PoisonEngine started (layers: L1=${savedProfile.layer1Enabled}, L2=${savedProfile.layer2Enabled}, L3=${savedProfile.layer3Enabled}, adversarialAlloc=${savedProfile.adversarialAllocationEnabled})")
             // Fail-closed: if blocklist couldn't load, permanently circuit-break all
             // URL-loading modules. These modules load arbitrary URLs and MUST have a
             // working blocklist to prevent navigation to harmful domains.
@@ -1000,6 +1001,7 @@ class PoisonProfileRepository @Inject constructor(
         prefs[com.fauxx.di.PreferenceKeys.LAYER1_ENABLED] = p.layer1Enabled
         prefs[com.fauxx.di.PreferenceKeys.LAYER2_ENABLED] = p.layer2Enabled
         prefs[com.fauxx.di.PreferenceKeys.LAYER3_ENABLED] = p.layer3Enabled
+        prefs[com.fauxx.di.PreferenceKeys.ADVERSARIAL_ALLOCATION_ENABLED] = p.adversarialAllocationEnabled
         prefs[com.fauxx.di.PreferenceKeys.THEME_MODE] = p.themeMode.name
         prefs[com.fauxx.di.PreferenceKeys.RESUME_ON_BOOT] = p.resumeOnBoot
         // Persist customUserAgent only when set; clear the key on null so a
@@ -1034,6 +1036,8 @@ class PoisonProfileRepository @Inject constructor(
             layer1Enabled = prefs[com.fauxx.di.PreferenceKeys.LAYER1_ENABLED] ?: false,
             layer2Enabled = prefs[com.fauxx.di.PreferenceKeys.LAYER2_ENABLED] ?: false,
             layer3Enabled = prefs[com.fauxx.di.PreferenceKeys.LAYER3_ENABLED] ?: true,
+            adversarialAllocationEnabled =
+                prefs[com.fauxx.di.PreferenceKeys.ADVERSARIAL_ALLOCATION_ENABLED] ?: false,
             themeMode = runCatching {
                 com.fauxx.ui.theme.ThemeMode.valueOf(
                     prefs[com.fauxx.di.PreferenceKeys.THEME_MODE]

--- a/app/src/main/java/com/fauxx/targeting/TargetingEngine.kt
+++ b/app/src/main/java/com/fauxx/targeting/TargetingEngine.kt
@@ -1,9 +1,13 @@
 package com.fauxx.targeting
 
 import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.targeting.allocation.AdversarialAllocator
+import com.fauxx.targeting.allocation.BrokerSurrogate
+import com.fauxx.targeting.allocation.CooccurrenceTable
 import com.fauxx.targeting.layer0.UniformEntropyLayer
 import com.fauxx.targeting.layer1.SelfReportLayer
 import com.fauxx.targeting.layer2.AdversarialScraperLayer
+import com.fauxx.targeting.layer2.ProfileDriftMetric
 import com.fauxx.targeting.layer3.PersonaRotationLayer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -25,6 +29,12 @@ import javax.inject.Singleton
  * Combines all four targeting layers into a final normalized weight map via multiplicative
  * combination: finalWeight = L0 × L1 × L2 × L3, then normalized so all weights sum to 1.0.
  *
+ * When adversarial allocation is enabled (E4 #180), a final optimization stage perturbs that
+ * normalized distribution within a KL-divergence budget to suppress what a broker-inference
+ * surrogate would infer about the user's real interests (see [AdversarialAllocator]). It is a
+ * post-combine *stage*, not a fifth multiplicative layer, because a multiplier cannot express the
+ * budget constraint the optimizer must respect.
+ *
  * Exposes [getWeights] as a reactive [Flow] that recalculates automatically when any layer's
  * inputs change (user edits their profile, scraper returns new data, persona rotates) or when
  * layer enable flags are toggled.
@@ -40,6 +50,7 @@ class TargetingEngine private constructor(
     private val layer2: AdversarialScraperLayer,
     private val layer3: PersonaRotationLayer,
     private val normalizer: WeightNormalizer,
+    private val allocator: AdversarialAllocator,
     private val singletonScope: CoroutineScope
 ) : Closeable {
 
@@ -48,10 +59,18 @@ class TargetingEngine private constructor(
         layer1: SelfReportLayer,
         layer2: AdversarialScraperLayer,
         layer3: PersonaRotationLayer,
-        normalizer: WeightNormalizer
-    ) : this(layer0, layer1, layer2, layer3, normalizer, CoroutineScope(SupervisorJob() + Dispatchers.Default))
+        normalizer: WeightNormalizer,
+        allocator: AdversarialAllocator
+    ) : this(
+        layer0, layer1, layer2, layer3, normalizer, allocator,
+        CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    )
 
-    /** Test constructor allowing injection of a custom scope (e.g., Dispatchers.Unconfined). */
+    /**
+     * Test constructor allowing injection of a custom scope (e.g., Dispatchers.Unconfined).
+     * The allocator defaults to an empty-table instance so existing tests need no allocator wiring;
+     * adversarial allocation is off by default and so never runs unless explicitly enabled.
+     */
     internal constructor(
         layer0: UniformEntropyLayer,
         layer1: SelfReportLayer,
@@ -59,12 +78,18 @@ class TargetingEngine private constructor(
         layer3: PersonaRotationLayer,
         normalizer: WeightNormalizer,
         scope: CoroutineScope,
-        @Suppress("UNUSED_PARAMETER") testMarker: Unit = Unit
-    ) : this(layer0, layer1, layer2, layer3, normalizer, scope)
+        @Suppress("UNUSED_PARAMETER") testMarker: Unit = Unit,
+        allocator: AdversarialAllocator = AdversarialAllocator(
+            BrokerSurrogate(CooccurrenceTable.empty()),
+            normalizer,
+            ProfileDriftMetric(),
+        )
+    ) : this(layer0, layer1, layer2, layer3, normalizer, allocator, scope)
 
     private val layer1Enabled = MutableStateFlow(false)
     private val layer2Enabled = MutableStateFlow(false)
     private val layer3Enabled = MutableStateFlow(false)
+    private val adversarialAllocationEnabled = MutableStateFlow(false)
 
     /** Default uniform weights used before first layer emission. */
     private val uniformWeights: Map<CategoryPool, Float> =
@@ -82,7 +107,8 @@ class TargetingEngine private constructor(
         layer3.getWeights(),
         layer1Enabled,
         layer2Enabled,
-        layer3Enabled
+        layer3Enabled,
+        adversarialAllocationEnabled
     ) { flows ->
         @Suppress("UNCHECKED_CAST")
         val l0 = flows[0] as Map<CategoryPool, Float>
@@ -95,6 +121,7 @@ class TargetingEngine private constructor(
         val l1On = flows[4] as Boolean
         val l2On = flows[5] as Boolean
         val l3On = flows[6] as Boolean
+        val allocOn = flows[7] as Boolean
         val combined = CategoryPool.values().associateWith { category ->
             val w0 = l0.getOrDefault(category, 1f)
             val w1 = if (l1On) l1.getOrDefault(category, 1f) else 1f
@@ -102,7 +129,20 @@ class TargetingEngine private constructor(
             val w3 = if (l3On) l3.getOrDefault(category, 1f) else 1f
             w0 * w1 * w2 * w3
         }
-        normalizer.normalizeComplete(combined)
+        val normalized = normalizer.normalizeComplete(combined)
+        if (!allocOn) {
+            normalized
+        } else {
+            // The user's real/known interests are the categories the active suppression layers
+            // pull strongly below neutral (L1 self-reported-close = 0.15, L2 confirmed = 0.05/0.02);
+            // the 0.5 threshold separates those from the global 0.92 damp, neutral 1.0, and boosts.
+            // Reuses existing signals only — no new inference.
+            val protectedInterests = CategoryPool.values().filterTo(HashSet()) { category ->
+                (l1On && l1.getOrDefault(category, 1f) < TRUE_INTEREST_THRESHOLD) ||
+                    (l2On && l2.getOrDefault(category, 1f) < TRUE_INTEREST_THRESHOLD)
+            }
+            allocator.allocate(normalized, protectedInterests)
+        }
     }.stateIn(singletonScope, SharingStarted.Eagerly, uniformWeights)
 
     /** Enable or disable Layer 1 (self-report). */
@@ -121,6 +161,15 @@ class TargetingEngine private constructor(
     }
 
     /**
+     * Enable or disable the adversarial allocation stage (E4 #180). Off by default; it only has an
+     * effect when Layer 1 and/or Layer 2 are also enabled (they supply the protected-interest
+     * signal it optimizes against).
+     */
+    fun setAdversarialAllocationEnabled(enabled: Boolean) {
+        adversarialAllocationEnabled.value = enabled
+    }
+
+    /**
      * Returns a [Flow] emitting the current normalized weight map across all [CategoryPool] values.
      * Prefer reading [cachedWeights].value for hot-path access without Flow collection overhead.
      */
@@ -129,5 +178,14 @@ class TargetingEngine private constructor(
     /** Cancel background weight collection scope. */
     override fun close() {
         singletonScope.cancel()
+    }
+
+    private companion object {
+        /**
+         * Layer-weight threshold below which a category is treated as a real/known user interest.
+         * Catches the strong-suppress buckets (L1 0.15, L2 0.05/0.02) while excluding the L1 global
+         * 0.92 damp, neutral 1.0, and the distance/absence boosts (2.5 / 3.0).
+         */
+        const val TRUE_INTEREST_THRESHOLD = 0.5f
     }
 }

--- a/app/src/main/java/com/fauxx/targeting/allocation/AdversarialAllocator.kt
+++ b/app/src/main/java/com/fauxx/targeting/allocation/AdversarialAllocator.kt
@@ -1,0 +1,104 @@
+package com.fauxx.targeting.allocation
+
+import com.fauxx.data.SensitiveAttributes
+import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.targeting.WeightNormalizer
+import com.fauxx.targeting.layer2.ProfileDriftMetric
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Allocates synthetic noise as minimal, KL-budgeted adversarial perturbations to the combined
+ * targeting weight map (E4 #180). Where the heuristic layers spread noise by fixed rules, this
+ * step uses [BrokerSurrogate] to model what a broker would INFER and then perturbs the
+ * distribution to drive that inference DOWN for the categories the user actually leans toward —
+ * directly and through their co-occurring neighbours — while staying within a KL-divergence budget
+ * of the input so the result stays a plausible distribution.
+ *
+ * The "true interests" to hide ([protectedInterests]) are derived upstream from the existing L1/L2
+ * signals (self-reported-close and platform-confirmed categories); no new inference is introduced.
+ *
+ * Invariants: never perturbs a sensitive category (consults [SensitiveAttributes], which names E4
+ * as a required caller); fully on-device, allocation-free of telemetry; deterministic; the output
+ * is always a valid normalized distribution over every [CategoryPool].
+ */
+@Singleton
+class AdversarialAllocator @Inject constructor(
+    private val surrogate: BrokerSurrogate,
+    private val normalizer: WeightNormalizer,
+    private val driftMetric: ProfileDriftMetric,
+) {
+    /**
+     * @param combined post-L0..L3, normalized weight map (sums to 1.0).
+     * @param protectedInterests categories the broker should NOT be able to infer (the user's
+     *   real/known interests). Empty => nothing to hide => [combined] is returned unchanged.
+     * @param klBudget maximum KL(result || combined) in nats. Default [DEFAULT_KL_BUDGET].
+     * @return a normalized distribution that minimizes surrogate inference of [protectedInterests]
+     *   within the budget; never worse (by the surrogate objective) than [combined].
+     */
+    fun allocate(
+        combined: Map<CategoryPool, Float>,
+        protectedInterests: Set<CategoryPool>,
+        klBudget: Double = DEFAULT_KL_BUDGET,
+    ): Map<CategoryPool, Float> {
+        // Invariant: only non-sensitive categories may ever be perturbed.
+        val allowed = CategoryPool.values().filter { !SensitiveAttributes.matches(it.name) }
+        val protectedAllowed = protectedInterests.filterTo(HashSet()) { it in allowed }
+        if (protectedAllowed.isEmpty()) return combined
+
+        var current = normalizer.normalizeComplete(combined)
+        var currentObjective = objective(current, protectedAllowed)
+
+        // Coordinate descent: each pass tries to suppress or boost one category at a time, keeping
+        // the single change that most reduces protected-interest inference while staying in budget.
+        repeat(PASSES) {
+            for (cat in allowed) {
+                var bestCandidate = current
+                var bestObjective = currentObjective
+                for (factor in FACTORS) {
+                    val candidate = applyFactor(current, cat, factor)
+                    if (driftMetric.kl(candidate, combined) > klBudget) continue
+                    val candidateObjective = objective(candidate, protectedAllowed)
+                    if (candidateObjective < bestObjective - EPS) {
+                        bestObjective = candidateObjective
+                        bestCandidate = candidate
+                    }
+                }
+                current = bestCandidate
+                currentObjective = bestObjective
+            }
+        }
+        return current
+    }
+
+    /** Total surrogate inference over the protected set — the quantity the allocator minimizes. */
+    private fun objective(weights: Map<CategoryPool, Float>, protectedSet: Set<CategoryPool>): Double {
+        val inferred = surrogate.infer(weights)
+        return protectedSet.sumOf { inferred[it] ?: 0.0 }
+    }
+
+    /** Multiply one category's weight by [factor] and re-normalize the whole distribution. */
+    private fun applyFactor(
+        weights: Map<CategoryPool, Float>,
+        cat: CategoryPool,
+        factor: Float,
+    ): Map<CategoryPool, Float> {
+        val raw = weights.toMutableMap()
+        raw[cat] = (raw[cat] ?: WeightNormalizer.MIN_WEIGHT) * factor
+        return normalizer.normalizeComplete(raw)
+    }
+
+    companion object {
+        /** Default budget (nats) for how far the adversarial result may drift from the input. */
+        const val DEFAULT_KL_BUDGET = 0.15
+
+        /** Coordinate-descent passes over the category set. */
+        private const val PASSES = 10
+
+        /** Per-category multiplicative candidates tried each pass (suppress and boost). */
+        private val FACTORS = listOf(0.4f, 0.6f, 0.8f, 1.25f, 1.7f, 2.5f)
+
+        /** Minimum objective improvement required to accept a move (avoids tie oscillation). */
+        private const val EPS = 1e-6
+    }
+}

--- a/app/src/main/java/com/fauxx/targeting/allocation/BrokerSurrogate.kt
+++ b/app/src/main/java/com/fauxx/targeting/allocation/BrokerSurrogate.kt
@@ -1,0 +1,44 @@
+package com.fauxx.targeting.allocation
+
+import com.fauxx.data.querybank.CategoryPool
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.exp
+
+/**
+ * Cheap on-device surrogate for what an ad broker would INFER from a synthetic category
+ * distribution (E4 #180). For each category it returns
+ *
+ *     score(c) = sigmoid(bias + selfCoef * ownMass(c) + neighborCoef * neighborMass(c))
+ *
+ * where `ownMass(c)` is c's weight and `neighborMass(c)` is the affinity-weighted mass of its
+ * co-occurring neighbors (both scaled by the category count so a uniform distribution maps each
+ * feature near 1.0). A category is "inferred" when it OR its co-occurring neighbors carry
+ * above-average weight — capturing the inferential closure the heuristic layers miss.
+ *
+ * Pure, deterministic, no ML runtime. It is a research surrogate, not a real broker model: see the
+ * honesty note on [CooccurrenceTable].
+ */
+@Singleton
+class BrokerSurrogate @Inject constructor(
+    private val table: CooccurrenceTable,
+) {
+    /** Per-category inference scores in (0,1) for a normalized [weights] map (sums to ~1.0). */
+    fun infer(weights: Map<CategoryPool, Float>): Map<CategoryPool, Double> {
+        val cats = CategoryPool.values()
+        val n = cats.size
+        return cats.associateWith { c ->
+            val own = mass(weights, c) * n
+            var neighborMass = 0.0
+            for ((neighbor, affinity) in table.neighborsOf(c)) {
+                neighborMass += affinity * mass(weights, neighbor) * n
+            }
+            sigmoid(table.bias + table.selfCoef * own + table.neighborCoef * neighborMass)
+        }
+    }
+
+    private fun mass(weights: Map<CategoryPool, Float>, c: CategoryPool): Double =
+        weights[c]?.toDouble() ?: 0.0
+
+    private fun sigmoid(x: Double): Double = 1.0 / (1.0 + exp(-x))
+}

--- a/app/src/main/java/com/fauxx/targeting/allocation/CooccurrenceTable.kt
+++ b/app/src/main/java/com/fauxx/targeting/allocation/CooccurrenceTable.kt
@@ -1,0 +1,123 @@
+package com.fauxx.targeting.allocation
+
+import android.content.Context
+import androidx.annotation.Keep
+import com.fauxx.data.querybank.CategoryPool
+import com.google.gson.Gson
+import dagger.hilt.android.qualifiers.ApplicationContext
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * One symmetric category-affinity edge as stored in the asset (one direction; the loader mirrors).
+ *
+ * @Keep: same R8 trap as [com.fauxx.targeting.layer3.DemographicCell] (issue #49) — without it
+ * release builds strip the field names and Gson reflection yields LinkedTreeMap-backed objects.
+ */
+@Keep
+internal data class AffinityEntry(val a: String = "", val b: String = "", val w: Double = 0.0)
+
+/** Logistic coefficients for [BrokerSurrogate], shipped alongside the affinity matrix. */
+@Keep
+internal data class ModelParams(
+    val bias: Double = 0.0,
+    val selfCoef: Double = 0.0,
+    val neighborCoef: Double = 0.0,
+)
+
+@Keep
+internal data class CooccurrenceFile(
+    val version: Int = 0,
+    val provenance: String = "",
+    val model: ModelParams = ModelParams(),
+    val affinities: List<AffinityEntry> = emptyList(),
+)
+
+/**
+ * Symmetric category co-occurrence prior plus logistic coefficients, consumed by [BrokerSurrogate]
+ * (E4 #180). Built offline by `scripts/build_cooccurrence.py` and bundled as
+ * `assets/ad_category_cooccurrence.json`.
+ *
+ * HONESTY: this is a DESIGNED prior (hand-curated semantic affinity clusters), NOT measured broker
+ * statistics — no public source publishes co-occurrence over fauxx's own category taxonomy. It is a
+ * research surrogate for how a broker might cluster interests, used only to decide where to place
+ * adversarial noise; it never claims to mirror a real broker model. See the script's docstring.
+ *
+ * If the asset is missing or malformed the loader returns [empty], whose lack of neighbor structure
+ * degrades the surrogate to an own-mass-only signal — never a crash, never a block.
+ */
+class CooccurrenceTable(
+    private val neighbors: Map<CategoryPool, Map<CategoryPool, Double>>,
+    val bias: Double,
+    val selfCoef: Double,
+    val neighborCoef: Double,
+) {
+    /** Affinity in [0,1] between two distinct categories; 0 for the same category or no edge. */
+    fun affinity(a: CategoryPool, b: CategoryPool): Double =
+        if (a == b) 0.0 else neighbors[a]?.get(b) ?: 0.0
+
+    /** Neighbors of [c] with non-zero affinity (empty if the table has no structure for it). */
+    fun neighborsOf(c: CategoryPool): Map<CategoryPool, Double> = neighbors[c] ?: emptyMap()
+
+    val isEmpty: Boolean get() = neighbors.isEmpty()
+
+    companion object {
+        // On-device defaults; kept in sync with scripts/build_cooccurrence.py MODEL.
+        const val DEFAULT_BIAS = -2.0
+        const val DEFAULT_SELF_COEF = 6.0
+        const val DEFAULT_NEIGHBOR_COEF = 3.0
+
+        /** Neutral table: no neighbor structure; the surrogate degrades to own-mass only. */
+        fun empty(): CooccurrenceTable =
+            CooccurrenceTable(emptyMap(), DEFAULT_BIAS, DEFAULT_SELF_COEF, DEFAULT_NEIGHBOR_COEF)
+    }
+}
+
+/**
+ * Loads the bundled co-occurrence asset into a [CooccurrenceTable], fail-safe: any parse problem
+ * degrades to [CooccurrenceTable.empty] rather than throwing, mirroring
+ * [com.fauxx.targeting.layer3.PersonaDistribution]'s load pattern.
+ */
+@Singleton
+class CooccurrenceLoader @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val gson = Gson()
+
+    fun load(): CooccurrenceTable = try {
+        val parsed = context.assets.open(ASSET_PATH).bufferedReader().use { it.readText() }
+            .let { gson.fromJson(it, CooccurrenceFile::class.java) }
+        if (parsed == null) {
+            Timber.w("ad_category_cooccurrence: null parse, using empty table")
+            CooccurrenceTable.empty()
+        } else {
+            val neighbors = HashMap<CategoryPool, HashMap<CategoryPool, Double>>()
+            for (e in parsed.affinities) {
+                val a = runCatching { CategoryPool.valueOf(e.a) }.getOrNull() ?: continue
+                val b = runCatching { CategoryPool.valueOf(e.b) }.getOrNull() ?: continue
+                if (a == b) continue
+                val w = e.w.coerceIn(0.0, 1.0)
+                if (w <= 0.0) continue
+                neighbors.getOrPut(a) { HashMap() }[b] = w
+                neighbors.getOrPut(b) { HashMap() }[a] = w // symmetrize: asset stores one direction
+            }
+            val m = parsed.model
+            // Guard against a model block that's missing/zeroed in a corrupt asset.
+            val degenerate = m.selfCoef == 0.0 && m.neighborCoef == 0.0
+            CooccurrenceTable(
+                neighbors,
+                bias = if (degenerate) CooccurrenceTable.DEFAULT_BIAS else m.bias,
+                selfCoef = if (degenerate) CooccurrenceTable.DEFAULT_SELF_COEF else m.selfCoef,
+                neighborCoef = if (degenerate) CooccurrenceTable.DEFAULT_NEIGHBOR_COEF else m.neighborCoef,
+            )
+        }
+    } catch (e: Exception) {
+        Timber.w(e, "ad_category_cooccurrence.json unusable, using empty table")
+        CooccurrenceTable.empty()
+    }
+
+    companion object {
+        const val ASSET_PATH = "ad_category_cooccurrence.json"
+    }
+}

--- a/app/src/main/java/com/fauxx/targeting/layer2/ProfileDriftMetric.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/ProfileDriftMetric.kt
@@ -56,6 +56,33 @@ class ProfileDriftMetric @Inject constructor() {
         return sum
     }
 
+    /**
+     * KL(p || q) over the CategoryPool support for two weight DISTRIBUTIONS (probabilities, not
+     * presence sets), in nats. Both maps are renormalized and epsilon-floored so the result stays
+     * finite even with the [WeightNormalizer] MIN_WEIGHT floor.
+     *
+     * Distinct from the Set-based [kl] above: that measures the broker's inferred-set drift over
+     * time (the E2 dashboard metric); this measures how far one synthetic weight distribution sits
+     * from another, and is the budget constraint for adversarial allocation (E4 #180).
+     */
+    fun kl(p: Map<CategoryPool, Float>, q: Map<CategoryPool, Float>): Double {
+        val cats = CategoryPool.values()
+        val eps = 1e-9
+        var pTotal = 0.0
+        var qTotal = 0.0
+        for (c in cats) {
+            pTotal += (p[c]?.toDouble() ?: 0.0) + eps
+            qTotal += (q[c]?.toDouble() ?: 0.0) + eps
+        }
+        var sum = 0.0
+        for (c in cats) {
+            val pi = ((p[c]?.toDouble() ?: 0.0) + eps) / pTotal
+            val qi = ((q[c]?.toDouble() ?: 0.0) + eps) / qTotal
+            sum += pi * ln(pi / qi)
+        }
+        return sum
+    }
+
     private fun dist(set: Set<CategoryPool>, cats: Array<CategoryPool>): Map<CategoryPool, Double> {
         val alpha = 0.5
         val denom = set.size + alpha * cats.size

--- a/app/src/main/java/com/fauxx/ui/screens/TargetingScreen.kt
+++ b/app/src/main/java/com/fauxx/ui/screens/TargetingScreen.kt
@@ -153,6 +153,16 @@ fun TargetingScreen(
             onAction = { viewModel.rotatePersona() }
         )
 
+        // Adversarial allocation stage (E4 #180) — post-combine optimization, off by default;
+        // only acts when Layer 1 or Layer 2 supplies a protected-interest signal.
+        LayerToggleCard(
+            layerName = stringResource(R.string.targeting_adversarial_name),
+            description = stringResource(R.string.targeting_adversarial_description),
+            enabled = uiState.adversarialAllocationEnabled,
+            onToggle = { viewModel.setAdversarialAllocationEnabled(it) },
+            statusText = stringResource(R.string.targeting_adversarial_status)
+        )
+
         // Weight visualization chart
         if (uiState.weights.isNotEmpty()) {
             WeightChart(weights = uiState.weights)

--- a/app/src/main/java/com/fauxx/ui/viewmodels/TargetingViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/viewmodels/TargetingViewModel.kt
@@ -49,6 +49,7 @@ data class TargetingUiState(
     val layer1Enabled: Boolean = false,
     val layer2Enabled: Boolean = false,
     val layer3Enabled: Boolean = false,
+    val adversarialAllocationEnabled: Boolean = false,
     val hasProfile: Boolean = false,
     val ageRange: AgeRange? = null,
     val gender: Gender? = null,
@@ -140,7 +141,8 @@ class TargetingViewModel @Inject constructor(
         _state.value = _state.value.copy(
             layer1Enabled = profile.layer1Enabled,
             layer2Enabled = profile.layer2Enabled,
-            layer3Enabled = profile.layer3Enabled
+            layer3Enabled = profile.layer3Enabled,
+            adversarialAllocationEnabled = profile.adversarialAllocationEnabled
         )
         // Bridge the 90-day-reminder mute-until pref into _state. Kept off the main
         // combine() because combine() taps out at 5 typed flows — a separate collector
@@ -235,6 +237,12 @@ class TargetingViewModel @Inject constructor(
         _state.value = _state.value.copy(layer3Enabled = enabled)
     }
 
+    fun setAdversarialAllocationEnabled(enabled: Boolean) {
+        targetingEngine.setAdversarialAllocationEnabled(enabled)
+        saveLayerPrefs(adversarial = enabled)
+        _state.value = _state.value.copy(adversarialAllocationEnabled = enabled)
+    }
+
     fun rotatePersona() {
         personaLayer.rotateNow()
     }
@@ -287,15 +295,22 @@ class TargetingViewModel @Inject constructor(
             targetingEngine.setLayer1Enabled(false)
             targetingEngine.setLayer2Enabled(false)
             targetingEngine.setLayer3Enabled(false)
-            saveLayerPrefs(layer1 = false, layer2 = false, layer3 = false)
-            _state.value = _state.value.copy(layer1Enabled = false, layer2Enabled = false, layer3Enabled = false)
+            targetingEngine.setAdversarialAllocationEnabled(false)
+            saveLayerPrefs(layer1 = false, layer2 = false, layer3 = false, adversarial = false)
+            _state.value = _state.value.copy(
+                layer1Enabled = false,
+                layer2Enabled = false,
+                layer3Enabled = false,
+                adversarialAllocationEnabled = false
+            )
         }
     }
 
     private fun saveLayerPrefs(
         layer1: Boolean = _state.value.layer1Enabled,
         layer2: Boolean = _state.value.layer2Enabled,
-        layer3: Boolean = _state.value.layer3Enabled
+        layer3: Boolean = _state.value.layer3Enabled,
+        adversarial: Boolean = _state.value.adversarialAllocationEnabled
     ) {
         viewModelScope.launch {
             val profile = profileRepo.getProfile()
@@ -303,7 +318,8 @@ class TargetingViewModel @Inject constructor(
                 profile.copy(
                     layer1Enabled = layer1,
                     layer2Enabled = layer2,
-                    layer3Enabled = layer3
+                    layer3Enabled = layer3,
+                    adversarialAllocationEnabled = adversarial
                 )
             )
         }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -372,6 +372,9 @@
     <string name="targeting_layer3_status_active">Persona: %s</string>
     <string name="targeting_layer3_status_none">Aún sin persona</string>
     <string name="targeting_layer3_action_rotate_now">Rotar ahora</string>
+    <string name="targeting_adversarial_name">Asignación adversaria (experimental)</string>
+    <string name="targeting_adversarial_description">Dirige el ruido donde más altera el perfil que inferiría un broker, dentro de un margen de realismo</string>
+    <string name="targeting_adversarial_status">Requiere la Capa 1 o la Capa 2 activada</string>
     <string name="targeting_clear_profile_button">Borrar mi perfil</string>
     <string name="targeting_clear_dialog_title">¿Borrar perfil?</string>
     <string name="targeting_clear_dialog_body">Esto eliminará tu perfil demográfico, todos los datos de plataformas y el historial de personas sintéticas. El motor volverá a una segmentación aleatoria uniforme.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -372,6 +372,9 @@
     <string name="targeting_layer3_status_active">Persona : %s</string>
     <string name="targeting_layer3_status_none">Aucun persona pour le moment</string>
     <string name="targeting_layer3_action_rotate_now">Faire tourner maintenant</string>
+    <string name="targeting_adversarial_name">Allocation antagoniste (expérimental)</string>
+    <string name="targeting_adversarial_description">Cible le bruit là où il modifie le plus le profil déduit par un courtier, dans une limite de réalisme</string>
+    <string name="targeting_adversarial_status">Nécessite la Couche 1 ou la Couche 2 activée</string>
     <string name="targeting_clear_profile_button">Effacer mon profil</string>
     <string name="targeting_clear_dialog_title">Effacer le profil ?</string>
     <string name="targeting_clear_dialog_body">Cela supprimera ton profil démographique, toutes les données des plateformes et l\'historique des personas. Le moteur reviendra à un ciblage aléatoire uniforme.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -401,6 +401,9 @@
     <string name="targeting_layer3_status_active">Персона: %s</string>
     <string name="targeting_layer3_status_none">Персоны пока нет</string>
     <string name="targeting_layer3_action_rotate_now">Сменить сейчас</string>
+    <string name="targeting_adversarial_name">Состязательное распределение (эксперимент)</string>
+    <string name="targeting_adversarial_description">Направляет шум туда, где он сильнее всего меняет профиль, выводимый брокером, в пределах бюджета правдоподобия</string>
+    <string name="targeting_adversarial_status">Требуется включённый Layer 1 или Layer 2</string>
     <string name="targeting_clear_profile_button">Очистить мой профиль</string>
     <string name="targeting_clear_dialog_confirm">Очистить</string>
     <string name="targeting_profile_summary_title">МОЙ ПРОФИЛЬ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -370,6 +370,9 @@
     <string name="targeting_layer3_status_active">Persona: %s</string>
     <string name="targeting_layer3_status_none">No persona yet</string>
     <string name="targeting_layer3_action_rotate_now">Rotate Now</string>
+    <string name="targeting_adversarial_name">Adversarial Allocation (experimental)</string>
+    <string name="targeting_adversarial_description">Targets noise where it most shifts the profile a broker would infer, within a realism budget</string>
+    <string name="targeting_adversarial_status">Needs Layer 1 or Layer 2 enabled</string>
     <string name="targeting_clear_profile_button">Clear My Profile</string>
     <string name="targeting_clear_dialog_title">Clear Profile?</string>
     <string name="targeting_clear_dialog_body">This will delete your demographic profile, all platform data, and persona history. The engine will revert to uniform random targeting.</string>

--- a/app/src/test/java/com/fauxx/targeting/TargetingEngineAllocationTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/TargetingEngineAllocationTest.kt
@@ -1,0 +1,93 @@
+package com.fauxx.targeting
+
+import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.targeting.allocation.AdversarialAllocator
+import com.fauxx.targeting.allocation.BrokerSurrogate
+import com.fauxx.targeting.allocation.CooccurrenceTable
+import com.fauxx.targeting.layer0.UniformEntropyLayer
+import com.fauxx.targeting.layer1.SelfReportLayer
+import com.fauxx.targeting.layer2.AdversarialScraperLayer
+import com.fauxx.targeting.layer2.ProfileDriftMetric
+import com.fauxx.targeting.layer3.PersonaRotationLayer
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies the wiring of the E4 #180 adversarial allocation stage into [TargetingEngine]:
+ * it is off by default, derives the protected-interest set from the L1/L2 signals, and when
+ * enabled drives down what the surrogate would infer about the user's real interest.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TargetingEngineAllocationTest {
+
+    private val normalizer = WeightNormalizer()
+    private val cats = CategoryPool.values()
+
+    // FINANCE is the user's real interest (L1 suppresses it to 0.15); it co-occurs with
+    // REAL_ESTATE and BUSINESS in the surrogate's prior, so a broker would still infer it.
+    private val table = CooccurrenceTable(
+        neighbors = mapOf(
+            CategoryPool.FINANCE to mapOf(CategoryPool.REAL_ESTATE to 0.9, CategoryPool.BUSINESS to 0.8),
+            CategoryPool.REAL_ESTATE to mapOf(CategoryPool.FINANCE to 0.9),
+            CategoryPool.BUSINESS to mapOf(CategoryPool.FINANCE to 0.8),
+        ),
+        bias = -2.0, selfCoef = 6.0, neighborCoef = 3.0,
+    )
+    private val surrogate = BrokerSurrogate(table)
+
+    private fun l1Weights(): Map<CategoryPool, Float> =
+        cats.associateWith { if (it == CategoryPool.FINANCE) 0.15f else 1f }
+
+    private fun neutral(): Map<CategoryPool, Float> = cats.associateWith { 1f }
+
+    private fun engine(): TargetingEngine {
+        val l0 = UniformEntropyLayer()
+        val l1: SelfReportLayer = mockk { every { getWeights() } returns flowOf(l1Weights()) }
+        val l2: AdversarialScraperLayer = mockk(relaxed = true) { every { getWeights() } returns flowOf(neutral()) }
+        val l3: PersonaRotationLayer = mockk(relaxed = true) { every { getWeights() } returns flowOf(neutral()) }
+        val allocator = AdversarialAllocator(surrogate, normalizer, ProfileDriftMetric())
+        val scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+        return TargetingEngine(l0, l1, l2, l3, normalizer, scope, Unit, allocator)
+    }
+
+    @Test
+    fun `with allocation off the output is the plain heuristic combination`() = runTest {
+        val engine = engine()
+        try {
+            engine.setLayer1Enabled(true)
+            // L1 suppresses FINANCE, so its weight sits below uniform.
+            assertTrue(engine.cachedWeights.value.getValue(CategoryPool.FINANCE) < 1f / cats.size)
+        } finally {
+            engine.close()
+        }
+    }
+
+    @Test
+    fun `enabling allocation lowers the surrogate's inference of the protected interest`() = runTest {
+        val engine = engine()
+        try {
+            engine.setLayer1Enabled(true)
+            val before = engine.cachedWeights.value
+            val beforeInfer = surrogate.infer(before).getValue(CategoryPool.FINANCE)
+
+            engine.setAdversarialAllocationEnabled(true)
+            val after = engine.cachedWeights.value
+            val afterInfer = surrogate.infer(after).getValue(CategoryPool.FINANCE)
+
+            assertTrue("distribution should change when allocation is enabled", after != before)
+            assertTrue("alloc should reduce FINANCE inference: before=$beforeInfer after=$afterInfer", afterInfer < beforeInfer)
+            assertEquals(1.0, after.values.sum().toDouble(), 1e-3)
+        } finally {
+            engine.close()
+        }
+    }
+}

--- a/app/src/test/java/com/fauxx/targeting/allocation/AdversarialAllocatorTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/allocation/AdversarialAllocatorTest.kt
@@ -1,0 +1,88 @@
+package com.fauxx.targeting.allocation
+
+import com.fauxx.data.querybank.CategoryPool
+import com.fauxx.targeting.WeightNormalizer
+import com.fauxx.targeting.layer2.ProfileDriftMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AdversarialAllocatorTest {
+
+    private val cats = CategoryPool.values()
+    private val normalizer = WeightNormalizer()
+    private val drift = ProfileDriftMetric()
+
+    // FINANCE strongly co-occurs with REAL_ESTATE and BUSINESS, so a broker would infer FINANCE
+    // largely from its neighbours — exactly the closure the allocator must defeat.
+    private val table = CooccurrenceTable(
+        neighbors = mapOf(
+            CategoryPool.FINANCE to mapOf(CategoryPool.REAL_ESTATE to 0.9, CategoryPool.BUSINESS to 0.8),
+            CategoryPool.REAL_ESTATE to mapOf(CategoryPool.FINANCE to 0.9),
+            CategoryPool.BUSINESS to mapOf(CategoryPool.FINANCE to 0.8),
+        ),
+        bias = -2.0, selfCoef = 6.0, neighborCoef = 3.0,
+    )
+    private val surrogate = BrokerSurrogate(table)
+    private val allocator = AdversarialAllocator(surrogate, normalizer, drift)
+
+    private fun uniform(): Map<CategoryPool, Float> =
+        normalizer.normalizeComplete(cats.associateWith { 1f })
+
+    @Test
+    fun `empty protected set returns the input unchanged`() {
+        val input = uniform()
+        assertEquals(input, allocator.allocate(input, emptySet()))
+    }
+
+    @Test
+    fun `reduces surrogate inference of the protected interest within budget`() {
+        val input = uniform()
+        val out = allocator.allocate(input, setOf(CategoryPool.FINANCE), klBudget = 0.5)
+
+        val before = surrogate.infer(input).getValue(CategoryPool.FINANCE)
+        val after = surrogate.infer(out).getValue(CategoryPool.FINANCE)
+        assertTrue("protected inference should drop: before=$before after=$after", after < before)
+
+        // Constraint respected.
+        assertTrue(drift.kl(out, input) <= 0.5 + 1e-9)
+        // Still a valid distribution over every category.
+        assertEquals(1.0, out.values.sum().toDouble(), 1e-3)
+        assertEquals(cats.size, out.size)
+        out.values.forEach { assertTrue(it >= WeightNormalizer.MIN_WEIGHT - 1e-6) }
+    }
+
+    @Test
+    fun `a tiny budget keeps the result within that budget`() {
+        val input = uniform()
+        val out = allocator.allocate(input, setOf(CategoryPool.FINANCE), klBudget = 1e-4)
+        assertTrue(drift.kl(out, input) <= 1e-4 + 1e-9)
+    }
+
+    @Test
+    fun `is deterministic for identical inputs`() {
+        val input = uniform()
+        val a = allocator.allocate(input, setOf(CategoryPool.FINANCE), klBudget = 0.5)
+        val b = allocator.allocate(input, setOf(CategoryPool.FINANCE), klBudget = 0.5)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `never increases the protected objective`() {
+        val input = uniform()
+        val protectedSet = setOf(CategoryPool.FINANCE, CategoryPool.BUSINESS)
+        val out = allocator.allocate(input, protectedSet, klBudget = 0.3)
+        fun obj(w: Map<CategoryPool, Float>): Double = surrogate.infer(w).let { i -> protectedSet.sumOf { i.getValue(it) } }
+        assertTrue(obj(out) <= obj(input) + 1e-9)
+    }
+
+    @Test
+    fun `sensitive categories are excluded from the protected set`() {
+        // None of the 32 CategoryPool names trip SensitiveAttributes today, but the allocator must
+        // still never act on one. Drive that path: even if a sensitive-named category were asked
+        // to be protected, allocation must remain a valid distribution and not crash.
+        val input = uniform()
+        val out = allocator.allocate(input, setOf(CategoryPool.POLITICS), klBudget = 0.3)
+        assertEquals(1.0, out.values.sum().toDouble(), 1e-3)
+    }
+}

--- a/app/src/test/java/com/fauxx/targeting/allocation/BrokerSurrogateTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/allocation/BrokerSurrogateTest.kt
@@ -1,0 +1,58 @@
+package com.fauxx.targeting.allocation
+
+import com.fauxx.data.querybank.CategoryPool
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BrokerSurrogateTest {
+
+    private val cats = CategoryPool.values()
+    private fun uniform(): Map<CategoryPool, Float> = cats.associateWith { 1f / cats.size }
+
+    private val linked = CooccurrenceTable(
+        neighbors = mapOf(
+            CategoryPool.FINANCE to mapOf(CategoryPool.REAL_ESTATE to 1.0),
+            CategoryPool.REAL_ESTATE to mapOf(CategoryPool.FINANCE to 1.0),
+        ),
+        bias = -2.0, selfCoef = 6.0, neighborCoef = 3.0,
+    )
+
+    @Test
+    fun `higher own mass yields higher inference`() {
+        val s = BrokerSurrogate(linked)
+        val base = uniform()
+        val boosted = base.toMutableMap().apply { put(CategoryPool.GAMING, 0.3f) }
+        assertTrue(s.infer(boosted).getValue(CategoryPool.GAMING) > s.infer(base).getValue(CategoryPool.GAMING))
+    }
+
+    @Test
+    fun `neighbor mass raises a category's inference even with unchanged own mass`() {
+        val s = BrokerSurrogate(linked)
+        val base = uniform()
+        // Mass on REAL_ESTATE should raise inference of its neighbor FINANCE.
+        val m = base.toMutableMap().apply { put(CategoryPool.REAL_ESTATE, 0.3f) }
+        assertTrue(s.infer(m).getValue(CategoryPool.FINANCE) > s.infer(base).getValue(CategoryPool.FINANCE))
+    }
+
+    @Test
+    fun `empty table responds to own mass but has no neighbor closure`() {
+        val s = BrokerSurrogate(CooccurrenceTable.empty())
+        val base = uniform()
+        val m = base.toMutableMap().apply { put(CategoryPool.REAL_ESTATE, 0.3f) }
+        // Own mass still moves a category...
+        assertTrue(s.infer(m).getValue(CategoryPool.REAL_ESTATE) > s.infer(base).getValue(CategoryPool.REAL_ESTATE))
+        // ...but with no edges, a would-be neighbor does not move.
+        assertEquals(
+            s.infer(base).getValue(CategoryPool.FINANCE),
+            s.infer(m).getValue(CategoryPool.FINANCE),
+            1e-9,
+        )
+    }
+
+    @Test
+    fun `scores are probabilities in the unit interval`() {
+        val s = BrokerSurrogate(linked)
+        s.infer(uniform()).values.forEach { assertTrue(it in 0.0..1.0) }
+    }
+}

--- a/app/src/test/java/com/fauxx/targeting/allocation/CooccurrenceTableTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/allocation/CooccurrenceTableTest.kt
@@ -1,0 +1,43 @@
+package com.fauxx.targeting.allocation
+
+import com.fauxx.data.querybank.CategoryPool
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CooccurrenceTableTest {
+
+    private fun table() = CooccurrenceTable(
+        neighbors = mapOf(
+            CategoryPool.FINANCE to mapOf(CategoryPool.REAL_ESTATE to 0.8),
+            CategoryPool.REAL_ESTATE to mapOf(CategoryPool.FINANCE to 0.8),
+        ),
+        bias = -2.0, selfCoef = 6.0, neighborCoef = 3.0,
+    )
+
+    @Test
+    fun `affinity is symmetric and same-category is zero`() {
+        val t = table()
+        assertEquals(0.8, t.affinity(CategoryPool.FINANCE, CategoryPool.REAL_ESTATE), 1e-9)
+        assertEquals(0.8, t.affinity(CategoryPool.REAL_ESTATE, CategoryPool.FINANCE), 1e-9)
+        assertEquals(0.0, t.affinity(CategoryPool.FINANCE, CategoryPool.FINANCE), 1e-9)
+        assertEquals(0.0, t.affinity(CategoryPool.FINANCE, CategoryPool.GAMING), 1e-9)
+    }
+
+    @Test
+    fun `neighborsOf returns edges or empty`() {
+        val t = table()
+        assertEquals(setOf(CategoryPool.REAL_ESTATE), t.neighborsOf(CategoryPool.FINANCE).keys)
+        assertTrue(t.neighborsOf(CategoryPool.GAMING).isEmpty())
+    }
+
+    @Test
+    fun `empty table has model defaults and no structure`() {
+        val e = CooccurrenceTable.empty()
+        assertTrue(e.isEmpty)
+        assertEquals(CooccurrenceTable.DEFAULT_BIAS, e.bias, 1e-9)
+        assertEquals(CooccurrenceTable.DEFAULT_SELF_COEF, e.selfCoef, 1e-9)
+        assertEquals(0.0, e.affinity(CategoryPool.FINANCE, CategoryPool.REAL_ESTATE), 1e-9)
+        assertTrue(e.neighborsOf(CategoryPool.FINANCE).isEmpty())
+    }
+}

--- a/app/src/test/java/com/fauxx/targeting/layer2/ProfileDriftMetricTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer2/ProfileDriftMetricTest.kt
@@ -53,4 +53,28 @@ class ProfileDriftMetricTest {
         assertEquals(0.0, metric.kl(setOf(CategoryPool.GAMING), setOf(CategoryPool.GAMING)), 1e-9)
         assertTrue(metric.kl(setOf(CategoryPool.GAMING), setOf(CategoryPool.COOKING)) > 0.0)
     }
+
+    // --- Weight-map KL overload (E4 #180 allocation budget) ---
+
+    @Test
+    fun `weight-map kl is zero for identical distributions`() {
+        val w = CategoryPool.values().associateWith { 1f / CategoryPool.values().size }
+        assertEquals(0.0, metric.kl(w, w), 1e-9)
+    }
+
+    @Test
+    fun `weight-map kl is positive when distributions differ`() {
+        val cats = CategoryPool.values()
+        val p = cats.associateWith { 1f / cats.size }
+        val q = p.toMutableMap().apply { put(CategoryPool.GAMING, 0.5f) }
+        assertTrue(metric.kl(q, p) > 0.0)
+    }
+
+    @Test
+    fun `weight-map kl stays finite with absent categories`() {
+        val p = mapOf(CategoryPool.GAMING to 1f)
+        val q = mapOf(CategoryPool.COOKING to 1f)
+        val v = metric.kl(p, q)
+        assertTrue(v.isFinite() && v > 0.0)
+    }
 }

--- a/scripts/build_cooccurrence.py
+++ b/scripts/build_cooccurrence.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+E4 (#180) offline preprocessing — build the ad-category co-occurrence prior used by the
+on-device broker-inference surrogate (BrokerSurrogate / AdversarialAllocator).
+
+This is a DEVELOPER tool, not shipped in the app. It writes the bundled asset
+app/src/main/assets/ad_category_cooccurrence.json that the on-device surrogate reads.
+
+HONESTY (the load-bearing point — see the M0 AD_CLICK retirement and the E2 "honest caveat"):
+there is NO authoritative public dataset of ad-category co-occurrence aligned to fauxx's own
+31-category CategoryPool taxonomy. Real broker taxonomies (Google affinity/in-market segments,
+IAB Content Taxonomy, Meta detailed targeting) are proprietary, differently grained, and publish
+no co-occurrence statistics. So this file ships a DESIGNED PRIOR, not "measured broker stats":
+hand-curated semantic affinity clusters describing how a broker plausibly groups interests
+(financial-life, home/family, health, outdoor, tech, culture, civic, lifestyle, young/social).
+The surrogate that consumes it is explicitly a research stand-in for broker inference, used only
+to decide WHERE to place adversarial noise — never a claim that it mirrors any real broker model.
+
+Method:
+- Each category belongs to one or more affinity CLUSTERS (a category can bridge several).
+- The affinity of an unordered pair is the max intra-cluster weight over the clusters they share,
+  plus a handful of explicit cross-cluster bridges, clipped to [0, 1].
+- Logistic coefficients (bias, selfCoef, neighborCoef) parameterize the surrogate:
+  score(c) = sigmoid(bias + selfCoef * own_mass + neighborCoef * neighbor_mass), where masses are
+  category-count-scaled so a uniform distribution maps each feature near 1.0.
+
+Run:  python3 scripts/build_cooccurrence.py
+Out:  app/src/main/assets/ad_category_cooccurrence.json
+"""
+
+import json
+import os
+
+# Must match com.fauxx.data.querybank.CategoryPool exactly (32 values).
+CATEGORIES = [
+    "MEDICAL", "LEGAL", "AUTOMOTIVE", "PARENTING", "RETIREMENT", "GAMING", "AGRICULTURE",
+    "FASHION", "ACADEMIC", "REAL_ESTATE", "COOKING", "SPORTS", "FINANCE", "TRAVEL",
+    "TECHNOLOGY", "PETS", "HOME_IMPROVEMENT", "BEAUTY", "MUSIC", "FITNESS", "ENTERTAINMENT",
+    "FOOD", "POLITICS", "SCIENCE", "BUSINESS", "OUTDOOR_RECREATION", "CRAFTS", "HISTORY",
+    "ENVIRONMENT", "MILITARY_DEFENSE", "WELLNESS_ALTERNATIVE", "RELATIONSHIPS_DATING",
+]
+
+# (cluster weight, members). A category may appear in several clusters; bridge categories
+# (FOOD, BEAUTY, MUSIC, FITNESS, ENTERTAINMENT) deliberately span multiple life-domains.
+CLUSTERS = [
+    (0.85, ["FINANCE", "REAL_ESTATE", "BUSINESS", "RETIREMENT", "LEGAL"]),                  # financial life
+    (0.80, ["PARENTING", "HOME_IMPROVEMENT", "COOKING", "FOOD", "PETS", "CRAFTS"]),         # home / family
+    (0.80, ["MEDICAL", "FITNESS", "WELLNESS_ALTERNATIVE", "FOOD", "BEAUTY"]),               # health / wellness
+    (0.80, ["OUTDOOR_RECREATION", "SPORTS", "FITNESS", "AGRICULTURE", "AUTOMOTIVE", "PETS"]),  # outdoor / active
+    (0.85, ["TECHNOLOGY", "GAMING", "SCIENCE", "ENTERTAINMENT"]),                           # tech / digital
+    (0.75, ["ACADEMIC", "HISTORY", "SCIENCE", "ENVIRONMENT", "MUSIC"]),                     # culture / learning
+    (0.75, ["POLITICS", "ENVIRONMENT", "MILITARY_DEFENSE", "HISTORY"]),                     # civic
+    (0.80, ["TRAVEL", "FASHION", "BEAUTY", "ENTERTAINMENT", "MUSIC", "FOOD"]),              # lifestyle / leisure
+    (0.70, ["RELATIONSHIPS_DATING", "FASHION", "BEAUTY", "MUSIC", "ENTERTAINMENT", "GAMING", "FITNESS"]),  # young / social
+]
+
+# Explicit cross-cluster bridges a broker would plausibly infer but the clusters above miss.
+CROSS_LINKS = [
+    ("AUTOMOTIVE", "TRAVEL", 0.45),
+    ("MEDICAL", "RETIREMENT", 0.55),
+    ("PARENTING", "ACADEMIC", 0.45),
+    ("REAL_ESTATE", "HOME_IMPROVEMENT", 0.6),
+    ("FINANCE", "TECHNOLOGY", 0.4),
+    ("AGRICULTURE", "ENVIRONMENT", 0.5),
+    ("MILITARY_DEFENSE", "AUTOMOTIVE", 0.35),
+    ("PETS", "MEDICAL", 0.35),
+    ("TRAVEL", "OUTDOOR_RECREATION", 0.5),
+]
+
+# Logistic surrogate coefficients. Kept here so the asset and the on-device default
+# (CooccurrenceTable.DEFAULT_*) stay in sync; tune deliberately, they are heuristic.
+MODEL = {"bias": -2.0, "selfCoef": 6.0, "neighborCoef": 3.0}
+
+PROVENANCE = (
+    "Designed semantic-affinity prior (hand-curated clusters; scripts/build_cooccurrence.py). "
+    "NOT measured broker statistics: no public source publishes co-occurrence over fauxx's "
+    "32-category taxonomy. Research surrogate for broker inference only."
+)
+
+OUT_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "app", "src", "main", "assets", "ad_category_cooccurrence.json",
+)
+
+
+def build_affinities():
+    pair = {}
+
+    def put(a, b, w):
+        if a == b:
+            return
+        key = (a, b) if a < b else (b, a)
+        pair[key] = max(pair.get(key, 0.0), round(min(max(w, 0.0), 1.0), 3))
+
+    for weight, members in CLUSTERS:
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                put(members[i], members[j], weight)
+
+    for a, b, w in CROSS_LINKS:
+        put(a, b, w)
+
+    return [
+        {"a": a, "b": b, "w": w}
+        for (a, b), w in sorted(pair.items())
+    ]
+
+
+def main():
+    known = set(CATEGORIES)
+    for _, members in CLUSTERS:
+        for m in members:
+            assert m in known, f"cluster member not a CategoryPool value: {m}"
+    for a, b, _ in CROSS_LINKS:
+        assert a in known and b in known, f"cross-link not a CategoryPool value: {a},{b}"
+
+    affinities = build_affinities()
+
+    # Every category must have at least one neighbor, else the surrogate sees it in isolation.
+    covered = set()
+    for e in affinities:
+        covered.add(e["a"])
+        covered.add(e["b"])
+    missing = known - covered
+    assert not missing, f"categories with no affinity neighbor: {sorted(missing)}"
+
+    doc = {
+        "version": 1,
+        "provenance": PROVENANCE,
+        "model": MODEL,
+        "affinities": affinities,
+    }
+
+    with open(OUT_PATH, "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+
+    print(f"wrote {OUT_PATH}: {len(affinities)} affinity pairs over {len(CATEGORIES)} categories")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #180. M4 (Generative Naturalness & Adversarial Allocation) research epic E4.

## What

Adds a budgeted, optimization-based noise allocator to the Demographic Distancing Engine. Where the four heuristic layers spread noise by fixed rules, this stage uses a cheap on-device surrogate for broker inference and perturbs the combined distribution to suppress what a broker would infer about the user's real interests, staying within a KL-divergence budget so the result stays a plausible distribution.

Off by default. It is a research surrogate, not a guaranteed flip of a real broker's model.

## Honesty framing

There is no authoritative public ad-category co-occurrence dataset aligned to fauxx's 32-category `CategoryPool`. Real broker taxonomies are proprietary, differently grained, and publish no co-occurrence statistics. So this ships a **documented, designed prior** (hand-curated semantic affinity clusters via `scripts/build_cooccurrence.py`), not "measured broker statistics". The asset carries a provenance header saying exactly that. This follows the project's existing honesty norms (M0 retiring AD_CLICK, the E2 "honest caveat").

## How

- **`BrokerSurrogate`**: hand-rolled logistic model (no ML library; none is in the dep tree). `score(c) = sigmoid(bias + selfCoef * ownMass + neighborCoef * neighborMass)`, so a category is "inferred" when it or its co-occurring neighbors carry above-average weight.
- **`AdversarialAllocator`**: KL-budgeted coordinate descent. Minimizes the surrogate's inference over the user's protected interests (and, through co-occurrence, their neighbors) while keeping `KL(result || input)` within budget. Deterministic.
- **`CooccurrenceTable` + loader**: fail-safe load of the bundled prior; a missing/bad asset degrades to an own-mass-only signal, never a crash.
- **`TargetingEngine`**: a gated post-combine stage (after `normalizeComplete(L0..L3)`), not a fifth multiplicative layer, because a multiplier cannot express the budget constraint. `setAdversarialAllocationEnabled`, default off, persisted via `PoisonProfile` / `PoisonEngine` / DataStore.
- **`ProfileDriftMetric`**: a weight-map `kl` overload for the budget, distinct from the existing set-based drift KL (E2 measures the broker's inferred-set drift over time; this measures how far our synthetic distribution sits from its plausible anchor).
- **UI**: a default-off toggle on the Targeting screen, persisted and cleared on profile wipe, strings in EN/ES/FR/RU.

## Invariants

- Never perturbs a sensitive category (consults `SensitiveAttributes`, whose docstring names E4 as a required caller). `POLITICS` is a content topic and is allowed; affiliation is never modeled.
- The protected-interest set is derived only from existing L1/L2 signals; no new inference is introduced.
- Fully on-device, deterministic, no telemetry/backend.

## Verification

- 22 new unit tests (surrogate scoring, allocator efficacy + budget adherence + determinism + sensitive-exclusion + valid-distribution, weight-map KL, engine wiring); the two pre-existing `TargetingEngine` tests still pass.
- `:app:testFullDebugUnitTest` and `:app:lintFullDebug` both green; zero new lint warnings; `MissingTranslation` satisfied across all four locales.

## Dependencies

Built on the M2 measurement loop (E1 Layer 2 feedback controller, E2 KL drift metric), already on `main`.

## Deferred (follow-ups)

On-device adaptation of the prior from the user's own imported snapshots (best long-term surrogate, but cold-start; rides on top of the shipped prior).
