### PR TITLE
M4 E3: Control-profile A/B by import (#172)

### DIFF
--- a/app/schemas/com.fauxx.data.db.PhantomDatabase/7.json
+++ b/app/schemas/com.fauxx.data.db.PhantomDatabase/7.json
@@ -1,0 +1,271 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "4cde0e476dc011c4136e4639543dfc06",
+    "entities": [
+      {
+        "tableName": "action_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `actionType` TEXT NOT NULL, `category` TEXT NOT NULL, `detail` TEXT NOT NULL, `success` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionType",
+            "columnName": "actionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detail",
+            "columnName": "detail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "success",
+            "columnName": "success",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_action_log_timestamp_success",
+            "unique": false,
+            "columnNames": [
+              "timestamp",
+              "success"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_action_log_timestamp_success` ON `${TABLE_NAME}` (`timestamp`, `success`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_demographic_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ageRange` TEXT, `gender` TEXT, `profession` TEXT, `region` TEXT, `interestsJson` TEXT, `customInterestsJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ageRange",
+            "columnName": "ageRange",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "profession",
+            "columnName": "profession",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "region",
+            "columnName": "region",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "interestsJson",
+            "columnName": "interestsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customInterestsJson",
+            "columnName": "customInterestsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "platform_profile_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platformName` TEXT NOT NULL, `scrapedCategoriesJson` TEXT NOT NULL, `lastScraped` INTEGER NOT NULL, PRIMARY KEY(`platformName`))",
+        "fields": [
+          {
+            "fieldPath": "platformName",
+            "columnName": "platformName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrapedCategoriesJson",
+            "columnName": "scrapedCategoriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastScraped",
+            "columnName": "lastScraped",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platformName"
+          ]
+        }
+      },
+      {
+        "tableName": "profile_snapshot",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `platformName` TEXT NOT NULL, `source` TEXT NOT NULL, `scrapedCategoriesJson` TEXT NOT NULL, `capturedAt` INTEGER NOT NULL, `series` TEXT NOT NULL DEFAULT 'POISONED')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformName",
+            "columnName": "platformName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrapedCategoriesJson",
+            "columnName": "scrapedCategoriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "series",
+            "columnName": "series",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'POISONED'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_profile_snapshot_platformName_capturedAt",
+            "unique": false,
+            "columnNames": [
+              "platformName",
+              "capturedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_profile_snapshot_platformName_capturedAt` ON `${TABLE_NAME}` (`platformName`, `capturedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "persona_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `personaJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaJson",
+            "columnName": "personaJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "circadian_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hourOfDay` INTEGER NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`hourOfDay`))",
+        "fields": [
+          {
+            "fieldPath": "hourOfDay",
+            "columnName": "hourOfDay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "hourOfDay"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4cde0e476dc011c4136e4639543dfc06')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/fauxx/data/db/PhantomDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/fauxx/data/db/PhantomDatabaseMigrationTest.kt
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith
  * Exercises [PhantomDatabase]'s real migrations under SQLCipher on a device — the path that
  * actually runs on a user's phone when they update the app. A broken migration here is silent
  * data loss or an open-time crash for every existing install, so this verifies both that the
- * 1->2->3->4->5->6 chain applies its schema changes AND that rows written before the update survive it.
+ * 1->2->3->4->5->6->7 chain applies its schema changes AND that rows written before the update survive it.
  *
  * Room's exported schemas only include 3.json, so [androidx.room.testing.MigrationTestHelper]
  * (which needs 1.json/2.json to stand up an old DB) can't be used. Instead we hand-seed an
@@ -47,12 +47,12 @@ class PhantomDatabaseMigrationTest {
     }
 
     @Test
-    fun migrate1To6_preservesSeededRows_andAppliesSchemaChanges() {
+    fun migrate1To7_preservesSeededRows_andAppliesSchemaChanges() {
         seedEncryptedV1Database()
 
         val db = buildRoomDatabase()
         try {
-            // First access runs the 1->2->3->4->5->6 migration chain and validates the result against v6.
+            // First access runs the 1->2->3->4->5->6->7 migration chain and validates against v7.
             val sdb = db.openHelper.writableDatabase
 
             // Rows written at v1 must survive the migration.
@@ -100,13 +100,18 @@ class PhantomDatabaseMigrationTest {
             ).use { c ->
                 assertTrue("MIGRATION_5_6 must create circadian_usage", c.moveToFirst())
             }
+            // MIGRATION_6_7 added the series discriminator to profile_snapshot (issue #172 E3).
+            assertTrue(
+                "MIGRATION_6_7 must add profile_snapshot.series",
+                columnExists(sdb, "profile_snapshot", "series")
+            )
         } finally {
             db.close()
         }
     }
 
     @Test
-    fun freshCreateAtV6_roundTripsThroughSqlcipher() {
+    fun freshCreateAtV7_roundTripsThroughSqlcipher() {
         val db = buildRoomDatabase()
         try {
             val sdb = db.openHelper.writableDatabase
@@ -133,8 +138,13 @@ class PhantomDatabaseMigrationTest {
             sdb.query(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='circadian_usage'"
             ).use { c ->
-                assertTrue("fresh v6 create must include circadian_usage", c.moveToFirst())
+                assertTrue("fresh create must include circadian_usage", c.moveToFirst())
             }
+            // A fresh create at v7 ships profile_snapshot.series directly (issue #172 E3).
+            assertTrue(
+                "fresh create must include profile_snapshot.series",
+                columnExists(sdb, "profile_snapshot", "series")
+            )
         } finally {
             db.close()
         }
@@ -143,7 +153,7 @@ class PhantomDatabaseMigrationTest {
     private fun buildRoomDatabase(): PhantomDatabase =
         Room.databaseBuilder(context, PhantomDatabase::class.java, TEST_DB)
             .openHelperFactory(SupportOpenHelperFactory(passphrase))
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
             .build()
 
     /**

--- a/app/src/main/java/com/fauxx/data/db/PhantomDatabase.kt
+++ b/app/src/main/java/com/fauxx/data/db/PhantomDatabase.kt
@@ -16,6 +16,7 @@ import com.fauxx.targeting.layer2.PlatformProfileCache
 import com.fauxx.targeting.layer2.PlatformProfileDao
 import com.fauxx.targeting.layer2.ProfileSnapshot
 import com.fauxx.targeting.layer2.ProfileSnapshotDao
+import com.fauxx.targeting.layer2.SnapshotSeries
 import com.fauxx.targeting.layer2.SnapshotSource
 import com.fauxx.targeting.layer3.PersonaHistoryDao
 import com.fauxx.targeting.layer3.PersonaHistoryEntity
@@ -39,7 +40,7 @@ import com.fauxx.targeting.layer3.PersonaHistoryEntity
         PersonaHistoryEntity::class,
         CircadianUsageEntity::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = true
 )
 @TypeConverters(PhantomTypeConverters::class)
@@ -103,6 +104,18 @@ val MIGRATION_5_6 = object : Migration(5, 6) {
     }
 }
 
+/**
+ * Migration from v6 to v7: add the `series` discriminator to profile_snapshot (issue #172 E3).
+ * Existing rows are the user's poisoned account, so they backfill to POISONED. The NOT NULL +
+ * DEFAULT matches the entity's `@ColumnInfo(defaultValue = "POISONED")` so Room's schema validation
+ * passes.
+ */
+val MIGRATION_6_7 = object : Migration(6, 7) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `profile_snapshot` ADD COLUMN `series` TEXT NOT NULL DEFAULT 'POISONED'")
+    }
+}
+
 /** Room type converters for enum types. */
 class PhantomTypeConverters {
     @TypeConverter
@@ -126,4 +139,11 @@ class PhantomTypeConverters {
     @TypeConverter
     fun toSnapshotSource(value: String): SnapshotSource =
         runCatching { SnapshotSource.valueOf(value) }.getOrDefault(SnapshotSource.IMPORT)
+
+    @TypeConverter
+    fun fromSnapshotSeries(value: SnapshotSeries): String = value.name
+
+    @TypeConverter
+    fun toSnapshotSeries(value: String): SnapshotSeries =
+        runCatching { SnapshotSeries.valueOf(value) }.getOrDefault(SnapshotSeries.POISONED)
 }

--- a/app/src/main/java/com/fauxx/di/AppModule.kt
+++ b/app/src/main/java/com/fauxx/di/AppModule.kt
@@ -16,6 +16,7 @@ import com.fauxx.data.db.MIGRATION_2_3
 import com.fauxx.data.db.MIGRATION_3_4
 import com.fauxx.data.db.MIGRATION_4_5
 import com.fauxx.data.db.MIGRATION_5_6
+import com.fauxx.data.db.MIGRATION_6_7
 import com.fauxx.data.db.PhantomDatabase
 import com.fauxx.engine.scheduling.CircadianUsageDao
 import com.fauxx.targeting.layer1.DemographicProfileDao
@@ -79,7 +80,7 @@ object AppModule {
             "phantom.db"
         )
             .openHelperFactory(factory)
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
             .build()
     }
 

--- a/app/src/main/java/com/fauxx/targeting/layer2/AdversarialScraperLayer.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/AdversarialScraperLayer.kt
@@ -72,7 +72,11 @@ class AdversarialScraperLayer @Inject constructor(
             // Confirmed categories not budging across the two most recent import snapshots: the
             // current noise is not moving them, so push harder (#170 E1). Empty until a platform
             // has >=2 snapshots, so this is a no-op on a fresh install (falls back to static weights).
-            val sticky = driftCalculator.stickyConfirmed(snapshots, ::parseCategories)
+            // Control-series snapshots (#172) are excluded: the control account must never feed targeting.
+            val sticky = driftCalculator.stickyConfirmed(
+                snapshots.filter { it.series == SnapshotSeries.POISONED },
+                ::parseCategories,
+            )
 
             CategoryPool.values().associateWith { category ->
                 when {

--- a/app/src/main/java/com/fauxx/targeting/layer2/ProfileDriftMetric.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/ProfileDriftMetric.kt
@@ -42,6 +42,32 @@ class ProfileDriftMetric @Inject constructor() {
         return DriftResult(DriftState.AVAILABLE, kl(current, baseline))
     }
 
+    /**
+     * Poisoned-vs-control divergence (E3 #172): KL of the latest POISONED ad-interest distribution
+     * from the latest CONTROL one, over the CategoryPool support. COLLECTING until both an imported
+     * poisoned profile and an imported control profile exist. Quantifies how far Fauxx has moved the
+     * poisoned account away from an untouched control account.
+     */
+    fun computeControlDivergence(snapshots: List<ProfileSnapshot>): DriftResult {
+        val poisoned = latestCategories(snapshots, SnapshotSeries.POISONED)
+        val control = latestCategories(snapshots, SnapshotSeries.CONTROL)
+        if (poisoned.isEmpty() || control.isEmpty()) return DriftResult(DriftState.COLLECTING, null)
+        return DriftResult(DriftState.AVAILABLE, kl(poisoned, control))
+    }
+
+    /** Union of the latest snapshot's categories per platform, within one series. */
+    private fun latestCategories(
+        snapshots: List<ProfileSnapshot>,
+        series: SnapshotSeries,
+    ): Set<CategoryPool> =
+        snapshots.asSequence()
+            .filter { it.series == series }
+            .groupBy { it.platformName }
+            .values
+            .mapNotNull { perPlatform -> perPlatform.maxByOrNull { it.capturedAt } }
+            .flatMap { parse(it.scrapedCategoriesJson) }
+            .toSet()
+
     /** KL(current || baseline) over the CategoryPool support, Laplace-smoothed so it stays finite. */
     fun kl(current: Set<CategoryPool>, baseline: Set<CategoryPool>): Double {
         val cats = CategoryPool.values()

--- a/app/src/main/java/com/fauxx/targeting/layer2/ProfileSnapshot.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/ProfileSnapshot.kt
@@ -1,5 +1,6 @@
 package com.fauxx.targeting.layer2
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -11,6 +12,18 @@ import androidx.room.PrimaryKey
  * not possible from an embedded WebView (issues #51 / #52), so it is intentionally absent.
  */
 enum class SnapshotSource { IMPORT, PHANTOM }
+
+/**
+ * Which experimental arm a [ProfileSnapshot] belongs to (E3 #172). [POISONED] is the user's
+ * real, Fauxx-poisoned account — the default, and what every pre-#172 row is. [CONTROL] is a
+ * separate clean account the user imports but never poisons, so the dashboard can show how far
+ * the poisoned profile has diverged from an untouched baseline.
+ *
+ * The CONTROL series is measurement-only: a control import never updates [PlatformProfileCache]
+ * and is filtered out of every Layer 2 / profile-drift consumer, so it can never influence
+ * targeting — it exists purely to be compared against the poisoned series.
+ */
+enum class SnapshotSeries { POISONED, CONTROL }
 
 /**
  * An append-only, point-in-time snapshot of the ad-interest categories attributed to the
@@ -30,4 +43,7 @@ data class ProfileSnapshot(
     val source: SnapshotSource,
     val scrapedCategoriesJson: String,
     val capturedAt: Long,
+    // E3 #172: experimental arm. defaultValue keeps Room's expected schema in sync with the
+    // v6->v7 ALTER TABLE that backfills existing rows to POISONED.
+    @ColumnInfo(defaultValue = "POISONED") val series: SnapshotSeries = SnapshotSeries.POISONED,
 )

--- a/app/src/main/java/com/fauxx/targeting/layer2/importers/AdProfileImporter.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/importers/AdProfileImporter.kt
@@ -1,6 +1,7 @@
 package com.fauxx.targeting.layer2.importers
 
 import android.net.Uri
+import com.fauxx.targeting.layer2.SnapshotSeries
 
 /**
  * Source of a user-driven Layer 2 ad-profile import.
@@ -71,9 +72,16 @@ interface AdProfileImporter {
     val source: ImportSource
 
     /**
-     * Parse the archive at [uri] and write any extracted categories to
-     * `PlatformProfileCache` under [source].platformId. Idempotent — repeated imports
-     * overwrite the cache entry (the export is the source of truth at import time).
+     * Parse the archive at [uri] and persist any extracted categories.
+     *
+     * For [SnapshotSeries.POISONED] (the default) this overwrites the `PlatformProfileCache` entry
+     * under [source].platformId and appends a poisoned snapshot — idempotent, the export is the
+     * source of truth at import time. For [SnapshotSeries.CONTROL] (issue #172) it appends a
+     * control-series snapshot ONLY and never touches the cache, so the control account can never
+     * influence targeting.
      */
-    suspend fun import(uri: Uri): ImportResult
+    suspend fun import(
+        uri: Uri,
+        series: SnapshotSeries = SnapshotSeries.POISONED,
+    ): ImportResult
 }

--- a/app/src/main/java/com/fauxx/targeting/layer2/importers/FacebookDyiImporter.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/importers/FacebookDyiImporter.kt
@@ -60,7 +60,10 @@ class FacebookDyiImporter @Inject constructor(
 
     private val gson = Gson()
 
-    override suspend fun import(uri: Uri): ImportResult = withContext(Dispatchers.IO) {
+    override suspend fun import(
+        uri: Uri,
+        series: com.fauxx.targeting.layer2.SnapshotSeries,
+    ): ImportResult = withContext(Dispatchers.IO) {
         val rawStrings = try {
             extractRawCategories(uri)
         } catch (e: java.io.IOException) {
@@ -85,12 +88,12 @@ class FacebookDyiImporter @Inject constructor(
             )
         }
         if (rawStrings.isEmpty()) {
-            persistCategories(emptySet())
+            persistCategories(emptySet(), series)
             return@withContext ImportResult.Success(source, 0)
         }
 
         val mapped = categoryMapper.mapAll(rawStrings)
-        persistCategories(mapped)
+        persistCategories(mapped, series)
         ImportResult.Success(source, mapped.size)
     }
 
@@ -203,23 +206,32 @@ class FacebookDyiImporter @Inject constructor(
         return null
     }
 
-    private suspend fun persistCategories(mapped: Set<CategoryPool>) {
+    private suspend fun persistCategories(
+        mapped: Set<CategoryPool>,
+        series: com.fauxx.targeting.layer2.SnapshotSeries,
+    ) {
         val json = gson.toJson(mapped.map { it.name })
         val now = clock.currentTimeMillis()
-        platformProfileDao.upsert(
-            PlatformProfileCache(
-                platformName = source.platformId,
-                scrapedCategoriesJson = json,
-                lastScraped = now
+        // The control series is measurement-only (#172): never touch the cache Layer 2 reads, so
+        // a control import can't influence targeting. Only the poisoned import updates the cache.
+        if (series == com.fauxx.targeting.layer2.SnapshotSeries.POISONED) {
+            platformProfileDao.upsert(
+                PlatformProfileCache(
+                    platformName = source.platformId,
+                    scrapedCategoriesJson = json,
+                    lastScraped = now
+                )
             )
-        )
-        // Append an immutable IMPORT snapshot so Layer 2 can compute drift over time (#170 E1).
+        }
+        // Append an immutable IMPORT snapshot so Layer 2 can compute drift over time (#170 E1),
+        // tagged with its experimental arm (#172 E3).
         profileSnapshotDao.insert(
             com.fauxx.targeting.layer2.ProfileSnapshot(
                 platformName = source.platformId,
                 source = com.fauxx.targeting.layer2.SnapshotSource.IMPORT,
                 scrapedCategoriesJson = json,
                 capturedAt = now,
+                series = series,
             )
         )
     }

--- a/app/src/main/java/com/fauxx/targeting/layer2/importers/GoogleTakeoutImporter.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/importers/GoogleTakeoutImporter.kt
@@ -55,7 +55,10 @@ class GoogleTakeoutImporter @Inject constructor(
 
     private val gson = Gson()
 
-    override suspend fun import(uri: Uri): ImportResult = withContext(Dispatchers.IO) {
+    override suspend fun import(
+        uri: Uri,
+        series: com.fauxx.targeting.layer2.SnapshotSeries,
+    ): ImportResult = withContext(Dispatchers.IO) {
         val rawStrings = try {
             extractRawCategories(uri)
         } catch (e: java.io.IOException) {
@@ -83,12 +86,12 @@ class GoogleTakeoutImporter @Inject constructor(
             // Found the file but it has no categories. Treat as a Success with 0 so the
             // user gets explicit feedback that the import worked but their ad profile
             // is empty (signed-in but Google has no targeting topics for them).
-            persistCategories(emptySet())
+            persistCategories(emptySet(), series)
             return@withContext ImportResult.Success(source, 0)
         }
 
         val mapped = categoryMapper.mapAll(rawStrings)
-        persistCategories(mapped)
+        persistCategories(mapped, series)
         ImportResult.Success(source, mapped.size)
     }
 
@@ -230,23 +233,32 @@ class GoogleTakeoutImporter @Inject constructor(
         return null
     }
 
-    private suspend fun persistCategories(mapped: Set<com.fauxx.data.querybank.CategoryPool>) {
+    private suspend fun persistCategories(
+        mapped: Set<com.fauxx.data.querybank.CategoryPool>,
+        series: com.fauxx.targeting.layer2.SnapshotSeries,
+    ) {
         val json = gson.toJson(mapped.map { it.name })
         val now = clock.currentTimeMillis()
-        platformProfileDao.upsert(
-            PlatformProfileCache(
-                platformName = source.platformId,
-                scrapedCategoriesJson = json,
-                lastScraped = now
+        // The control series is measurement-only (#172): never touch the cache Layer 2 reads, so
+        // a control import can't influence targeting. Only the poisoned import updates the cache.
+        if (series == com.fauxx.targeting.layer2.SnapshotSeries.POISONED) {
+            platformProfileDao.upsert(
+                PlatformProfileCache(
+                    platformName = source.platformId,
+                    scrapedCategoriesJson = json,
+                    lastScraped = now
+                )
             )
-        )
-        // Append an immutable IMPORT snapshot so Layer 2 can compute drift over time (#170 E1).
+        }
+        // Append an immutable IMPORT snapshot so Layer 2 can compute drift over time (#170 E1),
+        // tagged with its experimental arm (#172 E3).
         profileSnapshotDao.insert(
             com.fauxx.targeting.layer2.ProfileSnapshot(
                 platformName = source.platformId,
                 source = com.fauxx.targeting.layer2.SnapshotSource.IMPORT,
                 scrapedCategoriesJson = json,
                 capturedAt = now,
+                series = series,
             )
         )
     }

--- a/app/src/main/java/com/fauxx/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/com/fauxx/ui/screens/DashboardScreen.kt
@@ -259,6 +259,16 @@ fun DashboardScreen(
 
         // Profile-drift indicator (issue #171 E2)
         DriftCard(driftState = uiState.driftState, kl = uiState.driftKlDivergence)
+
+        // Poisoned-vs-control divergence (issue #172 E3) — shown once a control profile is imported.
+        if (uiState.hasControlSeries) {
+            DriftCard(
+                driftState = uiState.controlDivergenceState,
+                kl = uiState.controlDivergenceKl,
+                title = stringResource(R.string.dashboard_control_divergence_title),
+                help = stringResource(R.string.dashboard_control_divergence_help),
+            )
+        }
     }
 }
 
@@ -585,7 +595,12 @@ private fun SyntheticActivityCard(actionsPerHour: Float) {
 }
 
 @Composable
-private fun DriftCard(driftState: com.fauxx.targeting.layer2.DriftState, kl: Double?) {
+private fun DriftCard(
+    driftState: com.fauxx.targeting.layer2.DriftState,
+    kl: Double?,
+    title: String = stringResource(R.string.dashboard_drift_title),
+    help: String = stringResource(R.string.dashboard_drift_help),
+) {
     Card(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
     ) {
@@ -595,8 +610,8 @@ private fun DriftCard(driftState: com.fauxx.targeting.layer2.DriftState, kl: Dou
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 SectionHeaderWithHelp(
-                    title = stringResource(R.string.dashboard_drift_title),
-                    help = stringResource(R.string.dashboard_drift_help)
+                    title = title,
+                    help = help
                 )
                 Text(
                     text = if (driftState == com.fauxx.targeting.layer2.DriftState.AVAILABLE && kl != null) {

--- a/app/src/main/java/com/fauxx/ui/screens/TargetingScreen.kt
+++ b/app/src/main/java/com/fauxx/ui/screens/TargetingScreen.kt
@@ -139,6 +139,34 @@ fun TargetingScreen(
                 onImportFacebook = { viewModel.importFacebookDyi(it) },
                 onDismissResult = { viewModel.dismissImportResult() }
             )
+
+            // #172 E3: route the next import to a clean "control" account for poisoned-vs-control A/B.
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.targeting_import_as_control_label),
+                            style = MaterialTheme.typography.titleSmall,
+                            fontFamily = FontFamily.Monospace
+                        )
+                        Text(
+                            text = stringResource(R.string.targeting_import_as_control_description),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = uiState.importAsControl,
+                        onCheckedChange = { viewModel.setImportAsControl(it) }
+                    )
+                }
+            }
         }
 
         // Layer 3 toggle

--- a/app/src/main/java/com/fauxx/ui/viewmodels/DashboardViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/viewmodels/DashboardViewModel.kt
@@ -21,6 +21,7 @@ import com.fauxx.targeting.layer2.DriftResult
 import com.fauxx.targeting.layer2.DriftState
 import com.fauxx.targeting.layer2.ProfileDriftMetric
 import com.fauxx.targeting.layer2.ProfileSnapshotDao
+import com.fauxx.targeting.layer2.SnapshotSeries
 import com.fauxx.targeting.layer3.PersonaRotationLayer
 import com.fauxx.util.Clock
 import com.fauxx.util.SystemClockImpl
@@ -54,9 +55,22 @@ data class DashboardUiState(
     /** Profile-drift (issue #171 E2): KL divergence of the latest import from the baseline. */
     val driftState: DriftState = DriftState.COLLECTING,
     val driftKlDivergence: Double? = null,
+    /** Poisoned-vs-control divergence (issue #172 E3): KL of the latest poisoned profile vs the
+     *  latest control profile. [hasControlSeries] gates the dashboard card so it appears only once
+     *  a control profile has been imported. */
+    val controlDivergenceState: DriftState = DriftState.COLLECTING,
+    val controlDivergenceKl: Double? = null,
+    val hasControlSeries: Boolean = false,
     /** Mobile-data tier (issue #62); gates the "use mobile data" one-tap action — the
      *  button only helps when this is null (mobile off), not when there's no network. */
     val mobileIntensity: IntensityLevel? = null
+)
+
+/** Bundles the two snapshot-derived dashboard metrics so combine() keeps a single snapshot flow. */
+private data class DriftBundle(
+    val drift: DriftResult,
+    val control: DriftResult,
+    val hasControl: Boolean,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -101,7 +115,14 @@ class DashboardViewModel @Inject constructor(
         poisonEngine.healthWarnings,
         poisonEngine.engineState,
         profileRepo.profiles,
-        profileSnapshotDao.observeAll().map { profileDriftMetric.compute(it) }
+        profileSnapshotDao.observeAll().map { snaps ->
+            DriftBundle(
+                // E2 profile-drift is the poisoned series only; control snapshots must not skew it.
+                drift = profileDriftMetric.compute(snaps.filter { it.series == SnapshotSeries.POISONED }),
+                control = profileDriftMetric.computeControlDivergence(snaps),
+                hasControl = snaps.any { it.series == SnapshotSeries.CONTROL },
+            )
+        }
     ) { flows ->
         @Suppress("UNCHECKED_CAST")
         val enabled = flows[0] as Boolean
@@ -114,7 +135,7 @@ class DashboardViewModel @Inject constructor(
         val warnings = flows[5] as List<String>
         val state = flows[6] as EngineState
         val profile = flows[7] as PoisonProfile
-        val drift = flows[8] as DriftResult
+        val drift = flows[8] as DriftBundle
         DashboardUiState(
             engineEnabled = enabled,
             engineState = state,
@@ -124,8 +145,11 @@ class DashboardViewModel @Inject constructor(
             currentPersona = persona,
             syntheticActionsPerHour = computeSyntheticActionRate(today),
             healthWarnings = warnings,
-            driftState = drift.state,
-            driftKlDivergence = drift.klDivergence,
+            driftState = drift.drift.state,
+            driftKlDivergence = drift.drift.klDivergence,
+            controlDivergenceState = drift.control.state,
+            controlDivergenceKl = drift.control.klDivergence,
+            hasControlSeries = drift.hasControl,
             mobileIntensity = profile.mobileIntensity
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DashboardUiState())

--- a/app/src/main/java/com/fauxx/ui/viewmodels/TargetingViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/viewmodels/TargetingViewModel.kt
@@ -23,6 +23,7 @@ import com.fauxx.targeting.layer1.Profession
 import com.fauxx.targeting.layer1.Region
 import com.fauxx.targeting.layer1.UserDemographicProfile
 import com.fauxx.targeting.layer2.PlatformProfileDao
+import com.fauxx.targeting.layer2.SnapshotSeries
 import com.fauxx.targeting.layer2.importers.AdProfileImporter
 import com.fauxx.targeting.layer2.importers.FacebookDyiImporter
 import com.fauxx.targeting.layer2.importers.GoogleTakeoutImporter
@@ -65,6 +66,9 @@ data class TargetingUiState(
     // most recent outcome shown to the user — auto-clears after a short display window.
     val importInProgress: ImportSource? = null,
     val lastImportResult: ImportResult? = null,
+    // #172 E3: when on, the next import is stored as the CONTROL series (a clean account the user
+    // never poisons) instead of the poisoned profile — it never touches the cache or targeting.
+    val importAsControl: Boolean = false,
     // [showImportReminder] fires if the most recent import is > 90 days old and the
     // user hasn't snoozed/muted it. Derived in the combine() block from cache state +
     // the mute-until pref mirrored via [importReminderMutedUntil].
@@ -168,12 +172,13 @@ class TargetingViewModel @Inject constructor(
 
     private fun runImport(uri: Uri, importer: AdProfileImporter) {
         if (_state.value.importInProgress != null) return
+        val series = if (_state.value.importAsControl) SnapshotSeries.CONTROL else SnapshotSeries.POISONED
         _state.value = _state.value.copy(
             importInProgress = importer.source,
             lastImportResult = null
         )
         viewModelScope.launch {
-            val result = importer.import(uri)
+            val result = importer.import(uri, series)
             _state.value = _state.value.copy(
                 importInProgress = null,
                 lastImportResult = result
@@ -198,6 +203,11 @@ class TargetingViewModel @Inject constructor(
     /** Tap on the result banner — clears it without waiting for the auto-dismiss timer. */
     fun dismissImportResult() {
         _state.value = _state.value.copy(lastImportResult = null)
+    }
+
+    /** Toggle whether the next import is stored as the control series (#172 E3). */
+    fun setImportAsControl(enabled: Boolean) {
+        _state.value = _state.value.copy(importAsControl = enabled)
     }
 
     /** Hide the 90-day-old-import reminder for 30 days. */

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -375,6 +375,8 @@
     <string name="targeting_adversarial_name">Asignación adversaria (experimental)</string>
     <string name="targeting_adversarial_description">Dirige el ruido donde más altera el perfil que inferiría un broker, dentro de un margen de realismo</string>
     <string name="targeting_adversarial_status">Requiere la Capa 1 o la Capa 2 activada</string>
+    <string name="targeting_import_as_control_label">Importar como perfil de control (A/B)</string>
+    <string name="targeting_import_as_control_description">Guarda la próxima importación como una cuenta de control limpia que nunca envenenas, para que el panel pueda mostrar cuánto se ha alejado tu perfil envenenado de ella.</string>
     <string name="targeting_clear_profile_button">Borrar mi perfil</string>
     <string name="targeting_clear_dialog_title">¿Borrar perfil?</string>
     <string name="targeting_clear_dialog_body">Esto eliminará tu perfil demográfico, todos los datos de plataformas y el historial de personas sintéticas. El motor volverá a una segmentación aleatoria uniforme.</string>
@@ -444,6 +446,8 @@
     <string name="dashboard_drift_title">DERIVA DEL PERFIL</string>
     <string name="dashboard_drift_help">Cuánto se ha alejado tu perfil de intereses publicitarios importado desde la primera importación (de referencia), expresado como divergencia KL. Un valor más alto indica más movimiento. La deriva también puede reflejar que la plataforma reentrena su propio modelo, no solo Fauxx, así que considérala un indicador, no una prueba.</string>
     <string name="dashboard_drift_collecting">recopilando…</string>
+    <string name="dashboard_control_divergence_title">ENVENENADO FRENTE A CONTROL</string>
+    <string name="dashboard_control_divergence_help">Divergencia KL entre tu perfil envenenado y un perfil de control importado (una cuenta limpia que nunca envenenas). Un valor más alto significa que Fauxx ha separado más ambos perfiles. Se muestra solo tras importar un perfil de control.</string>
     <string name="dashboard_synthetic_activity_title">ACTIVIDAD SINTÉTICA</string>
     <string name="dashboard_synthetic_activity_help">El número medio de acciones sintéticas que Fauxx generó por hora durante las últimas 24 horas. Muestra cuánto tráfico de cobertura añade Fauxx. No es una proporción frente a tu actividad real, algo que Android no permite medir a una aplicación.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -375,6 +375,8 @@
     <string name="targeting_adversarial_name">Allocation antagoniste (expérimental)</string>
     <string name="targeting_adversarial_description">Cible le bruit là où il modifie le plus le profil déduit par un courtier, dans une limite de réalisme</string>
     <string name="targeting_adversarial_status">Nécessite la Couche 1 ou la Couche 2 activée</string>
+    <string name="targeting_import_as_control_label">Importer comme profil de contrôle (A/B)</string>
+    <string name="targeting_import_as_control_description">Enregistre le prochain import comme un compte de contrôle propre que vous n\'empoisonnez jamais, pour que le tableau de bord montre à quel point votre profil empoisonné s\'en est éloigné.</string>
     <string name="targeting_clear_profile_button">Effacer mon profil</string>
     <string name="targeting_clear_dialog_title">Effacer le profil ?</string>
     <string name="targeting_clear_dialog_body">Cela supprimera ton profil démographique, toutes les données des plateformes et l\'historique des personas. Le moteur reviendra à un ciblage aléatoire uniforme.</string>
@@ -444,6 +446,8 @@
     <string name="dashboard_drift_title">DÉRIVE DU PROFIL</string>
     <string name="dashboard_drift_help">À quel point votre profil d\'intérêts publicitaires importé s\'est éloigné de votre premier import (de référence), exprimé en divergence KL. Plus la valeur est élevée, plus le mouvement est important. La dérive peut aussi refléter le réentraînement du modèle par la plateforme, pas seulement Fauxx, considérez-la donc comme un indicateur, pas une preuve.</string>
     <string name="dashboard_drift_collecting">collecte…</string>
+    <string name="dashboard_control_divergence_title">EMPOISONNÉ VS CONTRÔLE</string>
+    <string name="dashboard_control_divergence_help">Divergence KL entre votre profil empoisonné et un profil de contrôle importé (un compte propre que vous n\'empoisonnez jamais). Plus la valeur est élevée, plus Fauxx a éloigné les deux profils. Affiché uniquement après avoir importé un profil de contrôle.</string>
     <string name="dashboard_synthetic_activity_title">ACTIVITÉ SYNTHÉTIQUE</string>
     <string name="dashboard_synthetic_activity_help">Le nombre moyen d\'actions synthétiques générées par Fauxx par heure au cours des dernières 24 heures. Cela indique la quantité de trafic de couverture ajoutée par Fauxx. Ce n\'est pas un ratio par rapport à votre activité réelle, qu\'Android ne permet pas à une application de mesurer.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -404,6 +404,8 @@
     <string name="targeting_adversarial_name">Состязательное распределение (эксперимент)</string>
     <string name="targeting_adversarial_description">Направляет шум туда, где он сильнее всего меняет профиль, выводимый брокером, в пределах бюджета правдоподобия</string>
     <string name="targeting_adversarial_status">Требуется включённый Layer 1 или Layer 2</string>
+    <string name="targeting_import_as_control_label">Импортировать как контрольный профиль (A/B)</string>
+    <string name="targeting_import_as_control_description">Сохранить следующий импорт как чистую контрольную учётную запись, которую вы никогда не отравляете, чтобы на панели было видно, насколько ваш отравленный профиль отдалился от неё.</string>
     <string name="targeting_clear_profile_button">Очистить мой профиль</string>
     <string name="targeting_clear_dialog_confirm">Очистить</string>
     <string name="targeting_profile_summary_title">МОЙ ПРОФИЛЬ</string>
@@ -464,6 +466,8 @@
     <string name="dashboard_drift_title">ДРЕЙФ ПРОФИЛЯ</string>
     <string name="dashboard_drift_help">Насколько ваш импортированный профиль рекламных интересов отдалился от первого (базового) импорта, в виде KL-дивергенции. Большее значение означает большее движение. Дрейф также может отражать переобучение модели самой платформой, а не только работу Fauxx, поэтому воспринимайте его как индикатор, а не доказательство.</string>
     <string name="dashboard_drift_collecting">сбор данных…</string>
+    <string name="dashboard_control_divergence_title">ОТРАВЛЕННЫЙ ПРОТИВ КОНТРОЛЯ</string>
+    <string name="dashboard_control_divergence_help">KL-дивергенция между вашим отравленным профилем и импортированным контрольным профилем (чистая учётная запись, которую вы никогда не отравляете). Большее значение означает, что Fauxx сильнее развёл их. Показывается только после импорта контрольного профиля.</string>
     <string name="dashboard_synthetic_activity_title">СИНТЕТИЧЕСКАЯ АКТИВНОСТЬ</string>
     <string name="dashboard_synthetic_activity_help">Среднее число синтетических действий, которые Fauxx генерировал в час за последние 24 часа. Показывает, сколько маскирующего трафика добавляет Fauxx. Это не соотношение с вашей реальной активностью, которую приложение в Android измерить не может.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -373,6 +373,8 @@
     <string name="targeting_adversarial_name">Adversarial Allocation (experimental)</string>
     <string name="targeting_adversarial_description">Targets noise where it most shifts the profile a broker would infer, within a realism budget</string>
     <string name="targeting_adversarial_status">Needs Layer 1 or Layer 2 enabled</string>
+    <string name="targeting_import_as_control_label">Import as control profile (A/B)</string>
+    <string name="targeting_import_as_control_description">Store the next import as a clean control account you never poison, so the dashboard can show how far your poisoned profile has diverged from it.</string>
     <string name="targeting_clear_profile_button">Clear My Profile</string>
     <string name="targeting_clear_dialog_title">Clear Profile?</string>
     <string name="targeting_clear_dialog_body">This will delete your demographic profile, all platform data, and persona history. The engine will revert to uniform random targeting.</string>
@@ -443,6 +445,8 @@
     <string name="dashboard_drift_help">How far your imported ad-interest profile has moved from its first (baseline) import, shown as a KL divergence. Higher means more movement. Drift can also reflect the platform retraining its own model, not only Fauxx, so treat it as an indicator, not proof.</string>
     <string name="dashboard_drift_value" translatable="false">%.2f</string>
     <string name="dashboard_drift_collecting">collecting…</string>
+    <string name="dashboard_control_divergence_title">POISONED VS CONTROL</string>
+    <string name="dashboard_control_divergence_help">KL divergence between your poisoned profile and an imported control profile (a clean account you never poison). Higher means Fauxx has pushed the two further apart. Shown only after you import a control profile.</string>
     <string name="dashboard_synthetic_activity_title">SYNTHETIC ACTIVITY</string>
     <string name="dashboard_synthetic_activity_help">The average number of synthetic actions Fauxx generated per hour over the last 24 hours. It shows how much cover traffic Fauxx is adding. It is not a ratio against your real activity, which Android does not let an app measure.</string>
     <string name="dashboard_synthetic_activity_value" translatable="false">%.1f/h</string>

--- a/app/src/test/java/com/fauxx/targeting/layer2/ProfileDriftMetricTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer2/ProfileDriftMetricTest.kt
@@ -12,10 +12,15 @@ class ProfileDriftMetricTest {
     private val gson = Gson()
     private val metric = ProfileDriftMetric()
 
-    private fun snap(platform: String, cats: List<String>, at: Long) =
+    private fun snap(
+        platform: String,
+        cats: List<String>,
+        at: Long,
+        series: SnapshotSeries = SnapshotSeries.POISONED,
+    ) =
         ProfileSnapshot(
             platformName = platform, source = SnapshotSource.IMPORT,
-            scrapedCategoriesJson = gson.toJson(cats), capturedAt = at,
+            scrapedCategoriesJson = gson.toJson(cats), capturedAt = at, series = series,
         )
 
     @Test
@@ -46,6 +51,62 @@ class ProfileDriftMetricTest {
         val r = metric.compute(snaps)
         assertEquals(DriftState.AVAILABLE, r.state)
         assertTrue("drift should be positive when the profile changes", r.klDivergence!! > 0.0)
+    }
+
+    // --- Poisoned-vs-control divergence (E3 #172) ---
+
+    @Test
+    fun `control divergence is COLLECTING when there is no control series`() {
+        val r = metric.computeControlDivergence(
+            listOf(snap("google", listOf("GAMING"), 1), snap("google", listOf("COOKING"), 2)),
+        )
+        assertEquals(DriftState.COLLECTING, r.state)
+    }
+
+    @Test
+    fun `control divergence is COLLECTING with a control but no poisoned series`() {
+        val r = metric.computeControlDivergence(
+            listOf(snap("google", listOf("GAMING"), 1, SnapshotSeries.CONTROL)),
+        )
+        assertEquals(DriftState.COLLECTING, r.state)
+    }
+
+    @Test
+    fun `identical latest poisoned and control yields zero divergence`() {
+        val r = metric.computeControlDivergence(
+            listOf(
+                snap("google", listOf("GAMING", "MEDICAL"), 2, SnapshotSeries.POISONED),
+                snap("google", listOf("GAMING", "MEDICAL"), 2, SnapshotSeries.CONTROL),
+            ),
+        )
+        assertEquals(DriftState.AVAILABLE, r.state)
+        assertEquals(0.0, r.klDivergence!!, 1e-9)
+    }
+
+    @Test
+    fun `divergent poisoned and control yields positive divergence`() {
+        val r = metric.computeControlDivergence(
+            listOf(
+                snap("google", listOf("GAMING"), 2, SnapshotSeries.POISONED),
+                snap("google", listOf("COOKING", "TRAVEL"), 2, SnapshotSeries.CONTROL),
+            ),
+        )
+        assertEquals(DriftState.AVAILABLE, r.state)
+        assertTrue(r.klDivergence!! > 0.0)
+    }
+
+    @Test
+    fun `control divergence uses the latest snapshot of each series`() {
+        // Poisoned drifted to COOKING (latest), control stayed at GAMING — latest-of-each diverges.
+        val r = metric.computeControlDivergence(
+            listOf(
+                snap("google", listOf("GAMING"), 1, SnapshotSeries.POISONED),
+                snap("google", listOf("COOKING"), 3, SnapshotSeries.POISONED),
+                snap("google", listOf("GAMING"), 2, SnapshotSeries.CONTROL),
+            ),
+        )
+        assertEquals(DriftState.AVAILABLE, r.state)
+        assertTrue(r.klDivergence!! > 0.0)
     }
 
     @Test

--- a/app/src/test/java/com/fauxx/targeting/layer2/importers/GoogleTakeoutImporterTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer2/importers/GoogleTakeoutImporterTest.kt
@@ -8,6 +8,9 @@ import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.targeting.layer2.CategoryMapper
 import com.fauxx.targeting.layer2.PlatformProfileCache
 import com.fauxx.targeting.layer2.PlatformProfileDao
+import com.fauxx.targeting.layer2.ProfileSnapshot
+import com.fauxx.targeting.layer2.ProfileSnapshotDao
+import com.fauxx.targeting.layer2.SnapshotSeries
 import com.fauxx.util.Clock
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -35,6 +38,7 @@ class GoogleTakeoutImporterTest {
     private lateinit var contentResolver: ContentResolver
     private lateinit var assetManager: AssetManager
     private lateinit var dao: PlatformProfileDao
+    private lateinit var snapshotDao: ProfileSnapshotDao
     private lateinit var clock: Clock
     private lateinit var importer: GoogleTakeoutImporter
 
@@ -47,6 +51,7 @@ class GoogleTakeoutImporterTest {
         contentResolver = mockk()
         assetManager = mockk()
         dao = mockk(relaxed = true)
+        snapshotDao = mockk(relaxed = true)
         clock = mockk { every { currentTimeMillis() } returns nowMs }
         every { context.contentResolver } returns contentResolver
         every { context.assets } returns assetManager
@@ -62,7 +67,36 @@ class GoogleTakeoutImporterTest {
             """.trimIndent().toByteArray()
         )
         val mapper = CategoryMapper(context)
-        importer = GoogleTakeoutImporter(context, mapper, dao, mockk(relaxed = true), clock)
+        importer = GoogleTakeoutImporter(context, mapper, dao, snapshotDao, clock)
+    }
+
+    @Test
+    fun `control import persists a CONTROL snapshot and never touches the targeting cache`() = runBlocking {
+        val json = """{"interests": [{"category": "Video Games"}]}"""
+        stubStream(json.toByteArray())
+        val snapSlot = slot<ProfileSnapshot>()
+        coEvery { snapshotDao.insert(capture(snapSlot)) } returns 1L
+
+        val result = importer.import(fakeUri, SnapshotSeries.CONTROL)
+
+        assertTrue("expected Success, got $result", result is ImportResult.Success)
+        assertEquals(SnapshotSeries.CONTROL, snapSlot.captured.series)
+        // The control series is measurement-only (#172): the cache Layer 2 reads must NOT be written.
+        coVerify(exactly = 0) { dao.upsert(any()) }
+    }
+
+    @Test
+    fun `poisoned import writes the cache and a POISONED snapshot`() = runBlocking {
+        val json = """{"interests": [{"category": "Video Games"}]}"""
+        stubStream(json.toByteArray())
+        val snapSlot = slot<ProfileSnapshot>()
+        coEvery { snapshotDao.insert(capture(snapSlot)) } returns 1L
+        coEvery { dao.upsert(any()) } returns Unit
+
+        importer.import(fakeUri, SnapshotSeries.POISONED)
+
+        assertEquals(SnapshotSeries.POISONED, snapSlot.captured.series)
+        coVerify(exactly = 1) { dao.upsert(any()) }
     }
 
     @Test


### PR DESCRIPTION
Closes #172. M4 epic E3, reframed.

## Reframe

The original design (a second isolated, unpoisoned in-app WebView context, periodically scraped) is not buildable: there is no automated scraping path (Layer 2 is import-only since v0.3.0, #52; `SnapshotSource.PHANTOM` is never written), and a truly isolated in-app context needs a separate `:control` process the M2 and M3 spikes both deferred (and even then it is a weak A/B). See the reframe comment on #172.

This ships a real **control profile by import** instead: the user keeps one clean account they never poison, exports its Takeout/DYI, and imports it tagged as a control series. The dashboard then shows poisoned-vs-control divergence. No second process, no scraping, and a more honest control (a real account exposed to real brokers, not Fauxx measuring its own phantom). The cost is a real user workflow.

## What

- **Schema**: `ProfileSnapshot` gains a `series` discriminator (POISONED / CONTROL) via Room migration 6 -> 7. Existing rows backfill to POISONED; `@ColumnInfo(defaultValue = "POISONED")` keeps the entity schema in sync with the `ALTER TABLE` (the generated `7.json` confirms the match).
- **Isolation invariant**: a control import writes only a CONTROL snapshot and never updates `PlatformProfileCache`, and `AdversarialScraperLayer` plus the E2 profile-drift card both filter to POISONED. The control series can never influence targeting.
- **Measurement**: `ProfileDriftMetric.computeControlDivergence` returns the KL of the latest poisoned vs latest control distribution (COLLECTING until both exist). A gated `POISONED VS CONTROL` dashboard card surfaces it, reusing the E2 `DriftCard`.
- **UI**: an "import as control" toggle on the Targeting screen routes the next import to the control series. Strings in EN/ES/FR/RU.

## Invariants

- On-device only, blocklist and decoy-only invariants unchanged (this only adds a second import target and a measurement card).
- The control series is measurement-only and provably excluded from every targeting consumer.

## Verification

- Unit suite green: `ProfileDriftMetric` control-divergence cases (COLLECTING / zero / positive / latest-of-each-series) and the importer invariant (CONTROL writes a snapshot but never the cache; POISONED writes both). No regressions.
- `:app:lintFullDebug` green, zero new warnings; `MissingTranslation` satisfied across all four locales.
- A 6 -> 7 instrumented migration test is added (runs in the instrumented CI job).

## Dependencies

Builds on the M2 measurement loop (E2 KL metric / DriftCard) already on `main`.

## Deferred (follow-up)

On-device adaptation of the prior is unrelated; the natural follow-up here is a clearer dual-import UX (separate control card with its own buttons) if the toggle proves confusing in use.
