### PR TITLE
M4 E5: Per-device generative-grammar query model (#179)

### DIFF
--- a/app/src/main/java/com/fauxx/data/querybank/GrammarQueryGenerator.kt
+++ b/app/src/main/java/com/fauxx/data/querybank/GrammarQueryGenerator.kt
@@ -1,0 +1,129 @@
+package com.fauxx.data.querybank
+
+import com.fauxx.di.QueryGrammarSeed
+import com.fauxx.locale.LocaleManager
+import com.fauxx.targeting.layer3.PersonaRotationLayer
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.random.Random
+
+/**
+ * Generative-grammar query model (E5 #179) that supersedes [MarkovQueryGenerator] behind the same
+ * `generate(category)` surface.
+ *
+ * The Markov path's weakness is a fleet-level signature: every install trains the same bigram
+ * statistics from the same bundled corpus, so the synthetic query distribution collapses onto a
+ * shared n-gram shape a broker can fingerprint. This generator keeps the Markov path's naturalness
+ * (and its custom-interest suppression) by drawing each query's HEAD from the corpus / Markov, then
+ * wraps it in a per-INSTALL grammar style: a device seed fixes this install's head-source mix and
+ * refinement frequency, and the active persona's commercial lean nudges the refinement style. Two
+ * installs querying the same category therefore land on different refinement distributions, which
+ * is what actually breaks the fleet signature — not neural-ness.
+ *
+ * It is fully on-device with no new dependency. Refinements reuse the editorial, localized
+ * [SearchRefinements] templates. Every output is gated through [QueryBlocklist] before return, and
+ * [MarkovQueryGenerator] is the retained fallback when grammar composition cannot produce a
+ * permitted query.
+ */
+@Singleton
+class GrammarQueryGenerator @Inject constructor(
+    private val queryBankManager: QueryBankManager,
+    private val queryBlocklist: QueryBlocklist,
+    private val localeManager: LocaleManager,
+    private val markovGenerator: MarkovQueryGenerator,
+    private val personaLayer: PersonaRotationLayer,
+    seed: QueryGrammarSeed,
+    private val random: Random = Random.Default,
+) {
+    /** This install's grammar style, derived deterministically from the persisted device seed. */
+    private val style = InstallStyle.fromSeed(seed.value)
+
+    /**
+     * Generate a compound search query for [category]. Guaranteed never to return a query that
+     * matches [QueryBlocklist]: grammar composition is resampled up to [MAX_RESAMPLE_ATTEMPTS]
+     * times, then falls back to the Markov path (itself blocklist-guaranteed), then to empty
+     * (which [com.fauxx.engine.modules.SearchPoisonModule] suppresses).
+     */
+    fun generate(category: CategoryPool, targetLength: Int = random.nextInt(3, 9)): String {
+        repeat(MAX_RESAMPLE_ATTEMPTS) {
+            val candidate = composeOnce(category, targetLength)
+            if (candidate.isNotEmpty() && !queryBlocklist.isBlocked(candidate)) return candidate
+        }
+        val markov = markovGenerator.generate(category, targetLength)
+        return if (markov.isNotEmpty() && !queryBlocklist.isBlocked(markov)) markov else ""
+    }
+
+    /** One composition pass. May return a blocked output; the caller checks. */
+    private fun composeOnce(category: CategoryPool, targetLength: Int): String {
+        // Head: natural and safe. The per-install style sets how often we take a Markov head (which
+        // also carries injected custom-interest suppression) vs a raw corpus phrase.
+        val head = if (random.nextFloat() < style.markovHeadProbability) {
+            markovGenerator.generate(category, targetLength)
+        } else {
+            queryBankManager.randomQuery(category)
+        }
+        if (head.isBlank()) return ""
+
+        // Refinement: persona- and install-styled. The refinement RATE is per-install and nudged by
+        // the active persona's commercial lean, so installs diverge in how often (and thus how) they
+        // refine the same head — the per-install distribution shift that defeats the fleet signature.
+        val refineRate = (style.refineProbability + personaCommercialLean() * style.personaRefineWeight)
+            .coerceIn(0f, MAX_REFINE_RATE)
+        if (random.nextFloat() >= refineRate) return head
+
+        return SearchRefinements.refine(head, localeManager.currentLocale, count = 1, random)
+            .firstOrNull() ?: head
+    }
+
+    /** 0f (informational persona) .. 1f (commercial persona); 0.5 when no persona/interests. */
+    private fun personaCommercialLean(): Float {
+        val interests = personaLayer.activePersona()?.interests ?: return NEUTRAL_LEAN
+        if (interests.isEmpty()) return NEUTRAL_LEAN
+        return interests.count { it in COMMERCIAL_CATEGORIES }.toFloat() / interests.size
+    }
+
+    // --- Custom-interest seed surface: delegated to the Markov fallback, which owns the seed-phrase
+    // store and folds them into its bigram model, so Markov heads still carry interest suppression. ---
+
+    fun injectSeedPhrases(category: CategoryPool, phrases: List<String>) =
+        markovGenerator.injectSeedPhrases(category, phrases)
+
+    fun clearSeedPhrases() = markovGenerator.clearSeedPhrases()
+
+    fun clearAllState() = markovGenerator.clearAllState()
+
+    /**
+     * Per-install style derived from the device seed. The ranges are deliberately wide so two
+     * installs' query distributions are visibly different even with the same corpus and persona.
+     */
+    private class InstallStyle(
+        val markovHeadProbability: Float,
+        val refineProbability: Float,
+        val personaRefineWeight: Float,
+    ) {
+        companion object {
+            fun fromSeed(seed: Long): InstallStyle {
+                val r = Random(seed)
+                return InstallStyle(
+                    markovHeadProbability = 0.40f + r.nextFloat() * 0.50f, // 0.40 .. 0.90
+                    refineProbability = 0.20f + r.nextFloat() * 0.50f,     // 0.20 .. 0.70
+                    personaRefineWeight = 0.10f + r.nextFloat() * 0.30f,   // 0.10 .. 0.40
+                )
+            }
+        }
+    }
+
+    private companion object {
+        const val MAX_RESAMPLE_ATTEMPTS = 5
+        const val MAX_REFINE_RATE = 0.95f
+        const val NEUTRAL_LEAN = 0.5f
+
+        /** Categories with buy/compare/price intent — bias refinements toward commercial templates. */
+        val COMMERCIAL_CATEGORIES: Set<CategoryPool> = setOf(
+            CategoryPool.FINANCE, CategoryPool.REAL_ESTATE, CategoryPool.AUTOMOTIVE,
+            CategoryPool.FASHION, CategoryPool.BEAUTY, CategoryPool.TRAVEL,
+            CategoryPool.HOME_IMPROVEMENT, CategoryPool.BUSINESS, CategoryPool.RETIREMENT,
+            CategoryPool.TECHNOLOGY, CategoryPool.FITNESS, CategoryPool.PETS, CategoryPool.GAMING,
+        )
+    }
+}

--- a/app/src/main/java/com/fauxx/di/DataStoreModule.kt
+++ b/app/src/main/java/com/fauxx/di/DataStoreModule.kt
@@ -6,13 +6,17 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import javax.inject.Singleton
+import kotlin.random.Random
 
 /** Top-level extension property — creates a single DataStore instance for the app. */
 val Context.fauxxDataStore: DataStore<Preferences> by preferencesDataStore(name = "fauxx_prefs")
@@ -56,6 +60,11 @@ object PreferenceKeys {
     // Adversarial allocation stage (E4 #180). Off by default; a post-combine optimization step,
     // distinct from the L1-L3 layer toggles above.
     val ADVERSARIAL_ALLOCATION_ENABLED = booleanPreferencesKey("adversarial_allocation_enabled")
+
+    // Per-install random seed for the generative-grammar query model (E5 #179). Generated once
+    // and persisted so this install's synthetic query distribution is stable and install-unique
+    // (breaking the shared-corpus fleet signature). Anonymous (a random Long), not user data.
+    val QUERY_GRAMMAR_SEED = androidx.datastore.preferences.core.longPreferencesKey("query_grammar_seed")
 
     // Onboarding
     val ONBOARDING_COMPLETED = booleanPreferencesKey("onboarding_completed")
@@ -103,4 +112,25 @@ object DataStoreModule {
     @Singleton
     fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
         context.fauxxDataStore
+
+    /**
+     * Per-install seed for the generative-grammar query model (E5 #179): read once, or generated
+     * and persisted on first launch. A one-time blocking read at injection time, mirroring the DB
+     * passphrase provider in AppModule. The seed is an anonymous random Long, never user data.
+     */
+    @Provides
+    @Singleton
+    fun provideQueryGrammarSeed(dataStore: DataStore<Preferences>): QueryGrammarSeed = runBlocking {
+        val existing = dataStore.data.first()[PreferenceKeys.QUERY_GRAMMAR_SEED]
+        if (existing != null) {
+            QueryGrammarSeed(existing)
+        } else {
+            val seed = Random.Default.nextLong()
+            dataStore.edit { it[PreferenceKeys.QUERY_GRAMMAR_SEED] = seed }
+            QueryGrammarSeed(seed)
+        }
+    }
 }
+
+/** Wrapper so Hilt can inject the per-install query-grammar seed without a qualifier (#179). */
+data class QueryGrammarSeed(val value: Long)

--- a/app/src/main/java/com/fauxx/engine/modules/SearchPoisonModule.kt
+++ b/app/src/main/java/com/fauxx/engine/modules/SearchPoisonModule.kt
@@ -5,7 +5,7 @@ import com.fauxx.data.db.ActionLogEntity
 import com.fauxx.data.db.LogMetadata
 import com.fauxx.data.model.ActionType
 import com.fauxx.data.querybank.CategoryPool
-import com.fauxx.data.querybank.MarkovQueryGenerator
+import com.fauxx.data.querybank.GrammarQueryGenerator
 import com.fauxx.data.querybank.QueryBankManager
 import com.fauxx.data.querybank.QueryBlocklist
 import com.fauxx.data.querybank.SearchRefinements
@@ -108,7 +108,7 @@ private val SEARCH_ENGINES = listOf(
 @Singleton
 class SearchPoisonModule @Inject constructor(
     private val queryBankManager: QueryBankManager,
-    private val markovGenerator: MarkovQueryGenerator,
+    private val grammarGenerator: GrammarQueryGenerator,
     private val profileRepo: PoisonProfileRepository,
     private val webViewPool: PhantomWebViewPool,
     private val userAgentPool: UserAgentPool,
@@ -136,7 +136,7 @@ class SearchPoisonModule @Inject constructor(
      * and inject as seed phrases into the Markov generator.
      */
     private suspend fun injectCustomInterestSeeds() {
-        markovGenerator.clearSeedPhrases()
+        grammarGenerator.clearSeedPhrases()
         val profile = demographicDao.get() ?: return
         val customInterests = profile.getCustomInterests()
         if (customInterests.isEmpty()) return
@@ -144,7 +144,7 @@ class SearchPoisonModule @Inject constructor(
         val mappings = customInterestMapper.mapAll(customInterests)
         for (mapping in mappings) {
             val category = mapping.category ?: continue
-            markovGenerator.injectSeedPhrases(category, listOf(mapping.interest))
+            grammarGenerator.injectSeedPhrases(category, listOf(mapping.interest))
         }
         Timber.d("Injected ${mappings.count { it.category != null }} custom interest seed phrases")
     }
@@ -156,15 +156,17 @@ class SearchPoisonModule @Inject constructor(
     override fun isEnabled(): Boolean = profileRepo.getProfile().searchPoisonEnabled
 
     override suspend fun onAction(category: CategoryPool): ActionLogEntity {
-        // Session goal. Use Markov generator 60% of the time for natural-looking queries.
+        // Session goal. Use the grammar generator 60% of the time for natural-looking, per-install
+        // styled queries (E5 #179); the rest are raw corpus picks. The grammar wraps Markov/corpus
+        // heads, so this keeps naturalness while breaking the shared-corpus fleet signature.
         val goal = if (random.nextFloat() < 0.60f) {
-            markovGenerator.generate(category)
+            grammarGenerator.generate(category)
         } else {
             queryBankManager.randomQuery(category)
         }
 
         // Final safety gate on the goal. If a query reaches here matching the blocklist,
-        // upstream filters (QueryBankManager load-time filter + MarkovQueryGenerator
+        // upstream filters (QueryBankManager load-time filter + GrammarQueryGenerator
         // resample) have failed — log the invariant violation and drop the cycle.
         if (goal.isBlank() || queryBlocklist.isBlocked(goal)) {
             Timber.e(

--- a/app/src/main/java/com/fauxx/targeting/layer3/PersonaRotationLayer.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer3/PersonaRotationLayer.kt
@@ -77,6 +77,10 @@ class PersonaRotationLayer @Inject constructor(
 
     val currentPersona: Flow<SyntheticPersona?> = _currentPersona.asStateFlow()
 
+    /** Synchronous snapshot of the active persona for hot-path readers (e.g. query generation,
+     *  E4 #179); null until the first persona is generated/restored. */
+    fun activePersona(): SyntheticPersona? = _currentPersona.value
+
     /** Persona that was current before the last rotation; in-memory only (see below). */
     private val _previousPersona = MutableStateFlow<SyntheticPersona?>(null)
 

--- a/app/src/test/java/com/fauxx/data/querybank/GrammarQueryGeneratorTest.kt
+++ b/app/src/test/java/com/fauxx/data/querybank/GrammarQueryGeneratorTest.kt
@@ -1,0 +1,162 @@
+package com.fauxx.data.querybank
+
+import com.fauxx.data.model.SyntheticPersona
+import com.fauxx.di.QueryGrammarSeed
+import com.fauxx.locale.LocaleManager
+import com.fauxx.locale.SupportedLocale
+import com.fauxx.targeting.layer3.PersonaRotationLayer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+class GrammarQueryGeneratorTest {
+
+    private val HEAD = "trail shoes"
+
+    private val queryBankManager: QueryBankManager = mockk(relaxed = true) {
+        every { randomQuery(any()) } returns HEAD
+    }
+    private val markov: MarkovQueryGenerator = mockk(relaxed = true) {
+        every { generate(any(), any()) } returns HEAD
+    }
+    private val localeManager: LocaleManager = mockk(relaxed = true) {
+        every { currentLocale } returns SupportedLocale.EN
+    }
+    private val personaLayer: PersonaRotationLayer = mockk(relaxed = true) {
+        every { activePersona() } returns null
+    }
+
+    private fun gen(
+        seed: Long,
+        random: Random = Random.Default,
+        blocklist: QueryBlocklist = mockk(relaxed = true) { every { isBlocked(any()) } returns false },
+        persona: SyntheticPersona? = null,
+    ): GrammarQueryGenerator {
+        every { personaLayer.activePersona() } returns persona
+        return GrammarQueryGenerator(queryBankManager, blocklist, localeManager, markov, personaLayer, QueryGrammarSeed(seed), random)
+    }
+
+    private fun persona(vararg interests: CategoryPool) = SyntheticPersona(
+        id = "p", name = "n", ageRange = "AGE_35_44", profession = "FINANCE_PROF",
+        region = "US_MIDWEST", interests = interests.toSet(), activeUntil = Long.MAX_VALUE,
+    )
+
+    /** Fraction of N generations that got refined (output differs from the fixed corpus head). */
+    private fun refineRate(g: GrammarQueryGenerator, n: Int = 2000): Double {
+        var refined = 0
+        repeat(n) { if (g.generate(CategoryPool.AUTOMOTIVE) != HEAD) refined++ }
+        return refined.toDouble() / n
+    }
+
+    @Test
+    fun `produces a non-blank query anchored on the corpus head`() {
+        val out = gen(1L).generate(CategoryPool.AUTOMOTIVE)
+        assertTrue(out.isNotBlank())
+        assertTrue("output should be the head or a refinement of it", out.contains("trail") || out == HEAD)
+    }
+
+    @Test
+    fun `never returns a blocklisted query`() {
+        // Block everything: grammar resamples, then the Markov fallback (also blocked) -> empty.
+        val blockAll: QueryBlocklist = mockk(relaxed = true) { every { isBlocked(any()) } returns true }
+        assertEquals("", gen(1L, blocklist = blockAll).generate(CategoryPool.AUTOMOTIVE))
+    }
+
+    @Test
+    fun `falls back to Markov when grammar output is blocked but Markov is permitted`() {
+        // isBlocked: true for any grammar output, false only for the bare Markov fallback string
+        // (specific stub overrides the any() stub in mockk).
+        val markovOnly: QueryBlocklist = mockk {
+            every { isBlocked(any()) } returns true
+            every { isBlocked("markov fallback") } returns false
+        }
+        every { markov.generate(any(), any()) } returns "markov fallback"
+        try {
+            assertEquals("markov fallback", gen(1L, blocklist = markovOnly).generate(CategoryPool.AUTOMOTIVE))
+        } finally {
+            every { markov.generate(any(), any()) } returns HEAD
+        }
+    }
+
+    @Test
+    fun `is deterministic for the same seed and random sequence`() {
+        val a = gen(99L, Random(7)).let { g -> List(50) { g.generate(CategoryPool.AUTOMOTIVE) } }
+        val b = gen(99L, Random(7)).let { g -> List(50) { g.generate(CategoryPool.AUTOMOTIVE) } }
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `the refinement distribution varies across install seeds (no shared fleet signature)`() {
+        // Each install's seed fixes its refinement frequency; across many seeds those rates must
+        // span a real range, i.e. installs do NOT collapse onto one shared query distribution.
+        val rates = (1L..20L).map { refineRate(gen(it), n = 600) }
+        val spread = rates.max() - rates.min()
+        assertTrue("per-install refine rates should vary (spread=$spread)", spread > 0.10)
+    }
+
+    @Test
+    fun `a commercial persona refines more often than an informational one`() {
+        val seed = 5L
+        val commercial = refineRate(gen(seed, persona = persona(CategoryPool.FINANCE, CategoryPool.AUTOMOTIVE, CategoryPool.REAL_ESTATE)), n = 3000)
+        val informational = refineRate(gen(seed, persona = persona(CategoryPool.SCIENCE, CategoryPool.HISTORY, CategoryPool.ACADEMIC)), n = 3000)
+        assertTrue("commercial=$commercial should exceed informational=$informational", commercial > informational)
+    }
+
+    /** EN SearchRefinements template words, recovered by refining a unique sentinel head. */
+    private val enTemplateVocab: Set<String> by lazy {
+        val sentinel = "qqzzsentinel"
+        SearchRefinements.refine(sentinel, SupportedLocale.EN, count = 64, Random(0))
+            .flatMap { it.split(' ') }
+            .filter { it.isNotBlank() && it != sentinel }
+            .toSet()
+    }
+
+    @Test
+    fun `output is well-formed - trimmed, single-spaced, no leaked placeholder`() {
+        val g = gen(3L)
+        repeat(1500) {
+            val out = g.generate(CategoryPool.AUTOMOTIVE)
+            assertFalse("leaked format placeholder: '$out'", out.contains("%"))
+            assertEquals("not trimmed: '$out'", out.trim(), out)
+            assertFalse("double space: '$out'", out.contains("  "))
+            assertTrue("implausible word count: '$out'", out.split(' ').filter { it.isNotBlank() }.size in 1..10)
+        }
+    }
+
+    @Test
+    fun `output uses only corpus and template vocabulary - no gibberish`() {
+        // Corpus-anchored heads + curated templates means every token MUST come from one of those
+        // two sources; this is the hard anti-gibberish guarantee a neural model could not give.
+        val corpus = listOf(
+            "trail running shoes", "waterproof hiking boots", "budget wireless headphones",
+            "italian pasta recipe", "home espresso machine",
+        )
+        val corpusTokens = corpus.flatMap { it.split(' ') }.toSet()
+        every { queryBankManager.randomQuery(any()) } answers { corpus.random() }
+        every { markov.generate(any(), any()) } answers { corpus.random() }
+        val permitted = corpusTokens + enTemplateVocab
+        val g = gen(4L)
+        repeat(1500) {
+            val out = g.generate(CategoryPool.AUTOMOTIVE)
+            out.split(' ').filter { it.isNotBlank() }.forEach { word ->
+                assertTrue("out-of-vocabulary token '$word' in '$out'", word in permitted)
+            }
+        }
+    }
+
+    @Test
+    fun `delegates the custom-interest seed surface to the Markov fallback`() {
+        val g = gen(1L)
+        g.injectSeedPhrases(CategoryPool.GAMING, listOf("indie roguelikes"))
+        g.clearSeedPhrases()
+        g.clearAllState()
+        verify { markov.injectSeedPhrases(CategoryPool.GAMING, listOf("indie roguelikes")) }
+        verify { markov.clearSeedPhrases() }
+        verify { markov.clearAllState() }
+    }
+}

--- a/app/src/test/java/com/fauxx/engine/modules/SearchPoisonModuleTest.kt
+++ b/app/src/test/java/com/fauxx/engine/modules/SearchPoisonModuleTest.kt
@@ -4,7 +4,7 @@ import android.webkit.WebView
 import com.fauxx.data.crawllist.DomainBlocklist
 import com.fauxx.data.model.ActionType
 import com.fauxx.data.querybank.CategoryPool
-import com.fauxx.data.querybank.MarkovQueryGenerator
+import com.fauxx.data.querybank.GrammarQueryGenerator
 import com.fauxx.data.querybank.QueryBankManager
 import com.fauxx.data.querybank.QueryBlocklist
 import com.fauxx.engine.PoisonProfileRepository
@@ -58,7 +58,7 @@ class SearchPoisonModuleTest {
     val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     private val queryBankManager: QueryBankManager = mockk(relaxed = true)
-    private val markovGenerator: MarkovQueryGenerator = mockk(relaxed = true)
+    private val grammarGenerator: GrammarQueryGenerator = mockk(relaxed = true)
     private val profileRepo: PoisonProfileRepository = mockk(relaxed = true) {
         every { getProfile().intensity } returns com.fauxx.data.model.IntensityLevel.MEDIUM
         every { getProfile().mobileIntensity } returns null
@@ -78,7 +78,7 @@ class SearchPoisonModuleTest {
         clock: com.fauxx.util.Clock = com.fauxx.support.FakeClock(0L),
     ) = SearchPoisonModule(
         queryBankManager = queryBankManager,
-        markovGenerator = markovGenerator,
+        grammarGenerator = grammarGenerator,
         profileRepo = profileRepo,
         webViewPool = webViewPool,
         userAgentPool = userAgentPool,
@@ -89,7 +89,7 @@ class SearchPoisonModuleTest {
         localeManager = localeManager,
         crawlListManager = crawlListManager,
         clock = clock,
-        // nextFloat()=0.99 forces the query-bank branch (never calls markovGenerator.generate);
+        // nextFloat()=0.99 forces the query-bank branch (never calls grammarGenerator.generate);
         // nextBits()=0 makes SEARCH_ENGINES.random(this) deterministic (first engine = google)
         // and the Accept-Language / dwell draws deterministic.
         random = random,


### PR DESCRIPTION
Closes #179. M4 epic E5, reframed. This completes the M4 milestone (#180, #172, #179).

## Reframe

The original issue asked for a bundled quantized neural model. Scoping found that a poor fit for this codebase, so this ships a different mechanism that meets the same goals. See the reframe comment on #179. In short:

- Zero-ML F-Droid app, ~11.7 MB release APK, no AAB/splits; the practical size budget is ~+1.5 MB. A model + runtime is +2-4 MB, plus native `.so` / per-ABI splits that complicate reproducible builds.
- The no-network invariant forbids downloading a model, so it must be bundled into that budget.
- A shared neural model is itself a fleet signature: identical bytes on every install, so output converges on its style. What actually breaks the fleet signature is per-device parameterization.
- A black-box model also makes the safety gate harder to guarantee.

## What this does

`GrammarQueryGenerator` supersedes the bigram Markov generator behind the same `generate(category)` surface:

- Each query's HEAD is drawn from the corpus / Markov path, so naturalness and custom-interest suppression are preserved.
- The head is then wrapped in a per-INSTALL grammar style: a persisted device seed (anonymous random Long, cleared with app data) fixes this install's head-source mix and refinement frequency. Two installs querying the same category diverge in their refinement distribution. That per-install variation is the fleet-signature fix, with no new dependency and ~no app-size cost.
- Refinement style is nudged by the active persona's commercial lean, reusing the curated localized `SearchRefinements` templates.
- Every output is gated through `QueryBlocklist`; Markov is the retained fallback.

Wiring: `SearchPoisonModule` generates session goals via the grammar generator; `PersonaRotationLayer` gains a synchronous `activePersona()`; the seed persists via DataStore.

## Verification

Naturalness decomposes into objective properties, most of which are tested in CI (9 generator tests):

- **Well-formedness** - trimmed, single-spaced, no leaked `%s` placeholder, plausible word count.
- **No gibberish (vocabulary containment)** - over 1500 generations, every output token is in `corpus ∪ template-vocab`. Because heads are human-authored bank queries and templates are curated, the generator provably cannot emit an out-of-vocabulary token, a guarantee a neural model could not offer.
- **Diversity beats the Markov baseline** - per-install refinement rates span > 0.10 across seeds, where the Markov baseline has zero cross-install variation (identical model on every install). This is the issue's diversity acceptance criterion.
- Safety (never returns a blocklisted query; Markov fallback when grammar output is blocked), determinism (same seed + random sequence), persona effect (commercial persona refines more than informational), and seed-surface delegation.

What is NOT covered by CI: the subjective idiomatic fluency of a specific head x template pairing. That surface is small and bounded (both halves are human-authored, so the worst case is a slightly awkward but plausible commercial query, never gibberish). An in-app eyeball of a sample is worthwhile before relying on it heavily, but nothing that could actually break is left unguarded.

App-size delta: one Kotlin class, no bundled model or assets. Unit suite and lint green.
