### PR TITLE
fix(audit): pre-0.4.0 bug + regression fixes

### DIFF
--- a/app/src/androidTest/java/com/fauxx/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/java/com/fauxx/di/TestDatabaseModule.kt
@@ -7,8 +7,10 @@ import androidx.datastore.preferences.preferencesDataStore
 import androidx.room.Room
 import com.fauxx.data.db.ActionLogDao
 import com.fauxx.data.db.PhantomDatabase
+import com.fauxx.engine.scheduling.CircadianUsageDao
 import com.fauxx.targeting.layer1.DemographicProfileDao
 import com.fauxx.targeting.layer2.PlatformProfileDao
+import com.fauxx.targeting.layer2.ProfileSnapshotDao
 import com.fauxx.targeting.layer3.PersonaHistoryDao
 import dagger.Module
 import dagger.Provides
@@ -57,6 +59,16 @@ object TestDatabaseModule {
 
     @Provides
     @Singleton
+    fun provideProfileSnapshotDao(db: PhantomDatabase): ProfileSnapshotDao =
+        db.profileSnapshotDao()
+
+    @Provides
+    @Singleton
+    fun provideCircadianUsageDao(db: PhantomDatabase): CircadianUsageDao =
+        db.circadianUsageDao()
+
+    @Provides
+    @Singleton
     fun provideTinkKeyManager(@ApplicationContext context: Context): TinkKeyManager =
         TinkKeyManager(context)
 
@@ -64,6 +76,16 @@ object TestDatabaseModule {
     @Singleton
     fun provideTestDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
         context.testDataStore
+
+    /**
+     * This module replaces [DataStoreModule], so it must also re-provide everything that module
+     * supplies — including the #179 query-grammar seed. A fixed deterministic seed (no DataStore
+     * IO) keeps instrumented tests reproducible. Without this the androidTest Hilt graph fails to
+     * build (QueryGrammarSeed has no binding).
+     */
+    @Provides
+    @Singleton
+    fun provideQueryGrammarSeed(): QueryGrammarSeed = QueryGrammarSeed { 0L }
 }
 
 // Process-level singleton. @HiltAndroidTest recreates the SingletonComponent per test class, so a

--- a/app/src/main/java/com/fauxx/data/querybank/GrammarQueryGenerator.kt
+++ b/app/src/main/java/com/fauxx/data/querybank/GrammarQueryGenerator.kt
@@ -2,6 +2,7 @@ package com.fauxx.data.querybank
 
 import com.fauxx.di.QueryGrammarSeed
 import com.fauxx.locale.LocaleManager
+import com.fauxx.targeting.layer3.PersonaChannel
 import com.fauxx.targeting.layer3.PersonaRotationLayer
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -35,8 +36,12 @@ class GrammarQueryGenerator @Inject constructor(
     seed: QueryGrammarSeed,
     private val random: Random = Random.Default,
 ) {
-    /** This install's grammar style, derived deterministically from the persisted device seed. */
-    private val style = InstallStyle.fromSeed(seed.value)
+    /**
+     * This install's grammar style, derived deterministically from the persisted device seed.
+     * Lazy so the seed loader (a blocking DataStore read) resolves on first generate() — which runs
+     * on the engine's background dispatcher — not at construction time on the main thread.
+     */
+    private val style by lazy { InstallStyle.fromSeed(seed.load()) }
 
     /**
      * Generate a compound search query for [category]. Guaranteed never to return a query that
@@ -75,9 +80,14 @@ class GrammarQueryGenerator @Inject constructor(
             .firstOrNull() ?: head
     }
 
-    /** 0f (informational persona) .. 1f (commercial persona); 0.5 when no persona/interests. */
+    /**
+     * 0f (informational persona) .. 1f (commercial persona); 0.5 when no persona/interests.
+     * Reads through the staggered [PersonaChannel.QUERY] accessor (like every other persona-bound
+     * channel) so the query lean phases in over its own adoption lag and inherits the Layer-3
+     * kill-switch, instead of stepping at the rotation instant (audit fix, E8 coherence).
+     */
     private fun personaCommercialLean(): Float {
-        val interests = personaLayer.activePersona()?.interests ?: return NEUTRAL_LEAN
+        val interests = personaLayer.personaForChannel(PersonaChannel.QUERY)?.interests ?: return NEUTRAL_LEAN
         if (interests.isEmpty()) return NEUTRAL_LEAN
         return interests.count { it in COMMERCIAL_CATEGORIES }.toFloat() / interests.size
     }

--- a/app/src/main/java/com/fauxx/di/DataStoreModule.kt
+++ b/app/src/main/java/com/fauxx/di/DataStoreModule.kt
@@ -114,23 +114,32 @@ object DataStoreModule {
         context.fauxxDataStore
 
     /**
-     * Per-install seed for the generative-grammar query model (E5 #179): read once, or generated
-     * and persisted on first launch. A one-time blocking read at injection time, mirroring the DB
-     * passphrase provider in AppModule. The seed is an anonymous random Long, never user data.
+     * Per-install seed for the generative-grammar query model (E5 #179), provided as a DEFERRED
+     * loader so no DataStore IO runs during Hilt graph construction — which can happen on the main
+     * thread in a service / ViewModel onCreate (audit fix). The blocking read-or-create resolves
+     * lazily on first query generation, which runs on the engine's background dispatcher. The seed
+     * is an anonymous random Long, never user data.
      */
     @Provides
     @Singleton
-    fun provideQueryGrammarSeed(dataStore: DataStore<Preferences>): QueryGrammarSeed = runBlocking {
-        val existing = dataStore.data.first()[PreferenceKeys.QUERY_GRAMMAR_SEED]
-        if (existing != null) {
-            QueryGrammarSeed(existing)
-        } else {
-            val seed = Random.Default.nextLong()
-            dataStore.edit { it[PreferenceKeys.QUERY_GRAMMAR_SEED] = seed }
-            QueryGrammarSeed(seed)
+    fun provideQueryGrammarSeed(dataStore: DataStore<Preferences>): QueryGrammarSeed =
+        QueryGrammarSeed {
+            runBlocking {
+                val existing = dataStore.data.first()[PreferenceKeys.QUERY_GRAMMAR_SEED]
+                if (existing != null) {
+                    existing
+                } else {
+                    val seed = Random.Default.nextLong()
+                    dataStore.edit { it[PreferenceKeys.QUERY_GRAMMAR_SEED] = seed }
+                    seed
+                }
+            }
         }
-    }
 }
 
-/** Wrapper so Hilt can inject the per-install query-grammar seed without a qualifier (#179). */
-data class QueryGrammarSeed(val value: Long)
+/**
+ * Deferred per-install query-grammar seed (#179). Holds a loader rather than the value so the
+ * blocking DataStore read happens lazily off the main thread (on first query generation), not at
+ * Hilt injection time. Hilt-injectable without a qualifier.
+ */
+class QueryGrammarSeed(val load: () -> Long)

--- a/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
+++ b/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
@@ -95,8 +95,6 @@ private const val CONSTRAINT_CHECK_MIN_MS = 3_000L
 /** Delay after a single module failure before retrying. */
 private const val FAILURE_RETRY_DELAY_MS = 5_000L
 
-/** Milliseconds in 24 hours. */
-private const val MS_PER_DAY = 24 * 60 * 60 * 1000L
 
 /** Sliding window duration for per-hour rate limiting. */
 private const val RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000L
@@ -248,7 +246,7 @@ class PoisonEngine @Inject constructor(
     /** Today's successful action count, incremented on each action. Reset on day rollover. */
     private val todayActionCount = AtomicInteger(0)
     @Volatile
-    private var actionCountDayStart = clock.currentTimeMillis().let { it - (it % MS_PER_DAY) }
+    private var actionCountDayStart = localDayStartMs(clock.currentTimeMillis())
 
     /**
      * Sliding window of action timestamps (epoch ms) for per-hour rate limiting.
@@ -303,15 +301,45 @@ class PoisonEngine @Inject constructor(
         cm?.allNetworks?.mapNotNull { cm.getNetworkCapabilities(it) }.orEmpty()
     }
 
-    /** Returns today's successful action count (thread-safe, cached). */
+    /**
+     * Local-midnight start of the day containing [nowMs] (mirrors nextAllowedHoursStartMs's
+     * Calendar field-zeroing). Local rather than UTC (epoch-ms modulo) so "actions today" rolls
+     * over at the user's wall-clock midnight, not UTC midnight — audit fix for non-UTC zones.
+     */
+    private fun localDayStartMs(nowMs: Long): Long =
+        java.util.Calendar.getInstance().apply {
+            timeInMillis = nowMs
+            set(java.util.Calendar.HOUR_OF_DAY, 0)
+            set(java.util.Calendar.MINUTE, 0)
+            set(java.util.Calendar.SECOND, 0)
+            set(java.util.Calendar.MILLISECOND, 0)
+        }.timeInMillis
+
+    /** Roll the action counter to a fresh day if [nowMs] has crossed local midnight. */
     @Synchronized
-    fun getTodayActionCount(): Int {
-        val now = clock.currentTimeMillis()
-        val dayStart = now - (now % MS_PER_DAY)
+    private fun rollIfNewDay(nowMs: Long) {
+        val dayStart = localDayStartMs(nowMs)
         if (dayStart != actionCountDayStart) {
             actionCountDayStart = dayStart
             todayActionCount.set(0)
         }
+    }
+
+    /**
+     * Record one successful action under the same monitor as the rollover, so a concurrent
+     * day-rollover can never zero a just-incremented new-day count — audit fix for the race
+     * between the engine's first post-midnight action and the FGS poll's reset.
+     */
+    @Synchronized
+    private fun recordTodayAction(nowMs: Long) {
+        rollIfNewDay(nowMs)
+        todayActionCount.incrementAndGet()
+    }
+
+    /** Returns today's successful action count (thread-safe, cached). */
+    @Synchronized
+    fun getTodayActionCount(): Int {
+        rollIfNewDay(clock.currentTimeMillis())
         return todayActionCount.get()
     }
 
@@ -363,7 +391,7 @@ class PoisonEngine @Inject constructor(
             targetingEngine.setAdversarialAllocationEnabled(savedProfile.adversarialAllocationEnabled)
 
             // Seed today's action count from DB once on start
-            val dayStart = clock.currentTimeMillis().let { it - (it % MS_PER_DAY) }
+            val dayStart = localDayStartMs(clock.currentTimeMillis())
             actionCountDayStart = dayStart
             todayActionCount.set(
                 try { actionLogDao.countSince(dayStart).first() } catch (_: Exception) { 0 }
@@ -623,7 +651,7 @@ class PoisonEngine @Inject constructor(
                 Timber.e(e, "Failed to insert action log entry")
             }
             if (logEntry.success) {
-                todayActionCount.incrementAndGet()
+                recordTodayAction(clock.currentTimeMillis())
                 recentActionTimestamps.add(clock.currentTimeMillis())
             }
 

--- a/app/src/main/java/com/fauxx/targeting/layer2/ProfileSnapshotDao.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/ProfileSnapshotDao.kt
@@ -25,13 +25,17 @@ interface ProfileSnapshotDao {
     suspend fun earliestForPlatform(platform: String): ProfileSnapshot?
 
     /**
-     * Retention: delete snapshots older than [cutoff], but always keep the earliest snapshot per
-     * platform so E2's baseline survives. (MIN(id) per platform is the earliest, since id
-     * auto-increments in capture order.)
+     * Retention: delete snapshots older than [cutoff], but always keep the earliest AND latest
+     * snapshot of each (platform, series). Per-(platform, series) so the control series (#172)
+     * survives independently of the poisoned series: E2 drift needs >=2 rows (earliest + latest)
+     * per platform-series, and E3 control-divergence needs a surviving latest row in each series.
+     * Series-blind pruning would silently revert both dashboard cards to "collecting" (audit fix).
+     * (MIN/MAX(id) per group is the earliest/latest, since id auto-increments in capture order.)
      */
     @Query(
         "DELETE FROM profile_snapshot WHERE capturedAt < :cutoff " +
-            "AND id NOT IN (SELECT MIN(id) FROM profile_snapshot GROUP BY platformName)"
+            "AND id NOT IN (SELECT MIN(id) FROM profile_snapshot GROUP BY platformName, series) " +
+            "AND id NOT IN (SELECT MAX(id) FROM profile_snapshot GROUP BY platformName, series)"
     )
     suspend fun deleteOlderThanKeepingBaseline(cutoff: Long)
 

--- a/app/src/main/java/com/fauxx/targeting/layer3/PersonaRotationLayer.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer3/PersonaRotationLayer.kt
@@ -77,10 +77,6 @@ class PersonaRotationLayer @Inject constructor(
 
     val currentPersona: Flow<SyntheticPersona?> = _currentPersona.asStateFlow()
 
-    /** Synchronous snapshot of the active persona for hot-path readers (e.g. query generation,
-     *  E4 #179); null until the first persona is generated/restored. */
-    fun activePersona(): SyntheticPersona? = _currentPersona.value
-
     /** Persona that was current before the last rotation; in-memory only (see below). */
     private val _previousPersona = MutableStateFlow<SyntheticPersona?>(null)
 
@@ -293,4 +289,4 @@ class PersonaRotationLayer @Inject constructor(
  * distribution itself (added by E9 #176: the peakier blend made an unstaggered
  * weights flip the sharpest remaining rotation change-point).
  */
-enum class PersonaChannel { LOCATION, APP_SIGNAL, RHYTHM, WEIGHTS }
+enum class PersonaChannel { LOCATION, APP_SIGNAL, RHYTHM, WEIGHTS, QUERY }

--- a/app/src/main/java/com/fauxx/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/viewmodels/SettingsViewModel.kt
@@ -61,6 +61,7 @@ class SettingsViewModel @Inject constructor(
     private val demographicDao: DemographicProfileDao,
     private val platformDao: PlatformProfileDao,
     private val personaHistoryDao: PersonaHistoryDao,
+    private val profileSnapshotDao: com.fauxx.targeting.layer2.ProfileSnapshotDao,
     private val targetingEngine: TargetingEngine,
     private val encryptedFileTree: EncryptedFileTree,
     private val localeManager: LocaleManager,
@@ -120,6 +121,9 @@ class SettingsViewModel @Inject constructor(
             actionLogDao.deleteOlderThan(Long.MAX_VALUE)
             demographicDao.delete()
             platformDao.deleteAll()
+            // Imported broker ad-interest history, including any clean "control" account (#172),
+            // must not survive an explicit "delete all data" (privacy contract — audit fix).
+            profileSnapshotDao.deleteAll()
             personaHistoryDao.deleteAll()
             // Wipe the learned daily-rhythm histogram, in memory and on disk, so the
             // behavioral profile doesn't survive a "delete all data" (E10 #177).

--- a/app/src/main/java/com/fauxx/ui/viewmodels/TargetingViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/viewmodels/TargetingViewModel.kt
@@ -94,6 +94,7 @@ class TargetingViewModel @Inject constructor(
     private val demographicDao: DemographicProfileDao,
     private val customInterestMapper: CustomInterestMapper,
     private val platformDao: PlatformProfileDao,
+    private val profileSnapshotDao: com.fauxx.targeting.layer2.ProfileSnapshotDao,
     private val personaHistoryDao: PersonaHistoryDao,
     private val personaLayer: PersonaRotationLayer,
     private val googleTakeoutImporter: GoogleTakeoutImporter,
@@ -293,6 +294,9 @@ class TargetingViewModel @Inject constructor(
         viewModelScope.launch {
             demographicDao.delete()
             platformDao.deleteAll()
+            // Imported broker ad-interest history, including any clean "control" account (#172),
+            // must not survive a profile wipe (privacy contract — audit fix).
+            profileSnapshotDao.deleteAll()
             personaHistoryDao.deleteAll()
             // Wipe the learned daily-rhythm histogram (memory + disk) so the behavioral
             // profile doesn't survive a profile wipe (E10 #177).

--- a/app/src/test/java/com/fauxx/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/fauxx/SettingsViewModelTest.kt
@@ -11,6 +11,7 @@ import com.fauxx.support.MainDispatcherRule
 import com.fauxx.targeting.TargetingEngine
 import com.fauxx.targeting.layer1.DemographicProfileDao
 import com.fauxx.targeting.layer2.PlatformProfileDao
+import com.fauxx.targeting.layer2.ProfileSnapshotDao
 import com.fauxx.targeting.layer3.PersonaHistoryDao
 import com.fauxx.ui.viewmodels.SettingsViewModel
 import io.mockk.coVerify
@@ -47,6 +48,7 @@ class SettingsViewModelTest {
     private val demographicDao: DemographicProfileDao = mockk(relaxed = true)
     private val platformDao: PlatformProfileDao = mockk(relaxed = true)
     private val personaHistoryDao: PersonaHistoryDao = mockk(relaxed = true)
+    private val profileSnapshotDao: ProfileSnapshotDao = mockk(relaxed = true)
     private val targetingEngine: TargetingEngine = mockk(relaxed = true)
     private val encryptedFileTree: EncryptedFileTree = mockk(relaxed = true)
     private val localeManager: LocaleManager = mockk(relaxed = true) {
@@ -57,7 +59,8 @@ class SettingsViewModelTest {
 
     private fun viewModel() = SettingsViewModel(
         profileRepo, actionLogDao, demographicDao, platformDao, personaHistoryDao,
-        targetingEngine, encryptedFileTree, localeManager, markovGenerator, circadianObserver
+        profileSnapshotDao, targetingEngine, encryptedFileTree, localeManager,
+        markovGenerator, circadianObserver
     )
 
     @Test
@@ -72,6 +75,9 @@ class SettingsViewModelTest {
         coVerify { demographicDao.delete() }
         coVerify { platformDao.deleteAll() }
         coVerify { personaHistoryDao.deleteAll() }
+        // Audit fix: imported broker-profile history (incl. the clean control account #172) must
+        // also be wiped, or it survives "delete all data" and resurfaces in the dashboard cards.
+        coVerify { profileSnapshotDao.deleteAll() }
         // E10 (#177): the learned daily-rhythm histogram is part of the trail wipe.
         coVerify { circadianObserver.clear() }
     }

--- a/app/src/test/java/com/fauxx/data/querybank/GrammarQueryGeneratorTest.kt
+++ b/app/src/test/java/com/fauxx/data/querybank/GrammarQueryGeneratorTest.kt
@@ -28,7 +28,7 @@ class GrammarQueryGeneratorTest {
         every { currentLocale } returns SupportedLocale.EN
     }
     private val personaLayer: PersonaRotationLayer = mockk(relaxed = true) {
-        every { activePersona() } returns null
+        every { personaForChannel(any()) } returns null
     }
 
     private fun gen(
@@ -37,8 +37,8 @@ class GrammarQueryGeneratorTest {
         blocklist: QueryBlocklist = mockk(relaxed = true) { every { isBlocked(any()) } returns false },
         persona: SyntheticPersona? = null,
     ): GrammarQueryGenerator {
-        every { personaLayer.activePersona() } returns persona
-        return GrammarQueryGenerator(queryBankManager, blocklist, localeManager, markov, personaLayer, QueryGrammarSeed(seed), random)
+        every { personaLayer.personaForChannel(any()) } returns persona
+        return GrammarQueryGenerator(queryBankManager, blocklist, localeManager, markov, personaLayer, QueryGrammarSeed { seed }, random)
     }
 
     private fun persona(vararg interests: CategoryPool) = SyntheticPersona(

--- a/app/src/test/java/com/fauxx/targeting/layer2/ProfileSnapshotRetentionTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer2/ProfileSnapshotRetentionTest.kt
@@ -1,0 +1,69 @@
+package com.fauxx.targeting.layer2
+
+import android.app.Application
+import androidx.room.Room
+import com.fauxx.data.db.PhantomDatabase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Retention (#172 audit fix): the keep-baseline prune must preserve the earliest AND latest of
+ * EACH (platform, series), so the control series survives independently of the poisoned series and
+ * the E2 drift / E3 control-divergence cards don't silently revert to "collecting" after the daily
+ * RetentionWorker runs. Exercises the real SQL on an in-memory Room DB — the existing
+ * RetentionWorkerTest mocks the DAO and never runs the query.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class ProfileSnapshotRetentionTest {
+
+    private lateinit var db: PhantomDatabase
+    private lateinit var dao: ProfileSnapshotDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            RuntimeEnvironment.getApplication(), PhantomDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.profileSnapshotDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun snap(series: SnapshotSeries, at: Long) = ProfileSnapshot(
+        platformName = "google", source = SnapshotSource.IMPORT,
+        scrapedCategoriesJson = "[]", capturedAt = at, series = series,
+    )
+
+    @Test
+    fun `retention keeps earliest and latest of each platform-series past the cutoff`() = runBlocking {
+        dao.insert(snap(SnapshotSeries.POISONED, 1000L))
+        dao.insert(snap(SnapshotSeries.POISONED, 2000L))
+        dao.insert(snap(SnapshotSeries.POISONED, 3000L))
+        dao.insert(snap(SnapshotSeries.CONTROL, 1500L))
+        dao.insert(snap(SnapshotSeries.CONTROL, 3500L))
+
+        // Cutoff is past every row. A series-blind prune (keep MIN(id) per platform only) would
+        // leave ONE row total for "google"; the fixed per-(platform, series) prune must not.
+        dao.deleteOlderThanKeepingBaseline(cutoff = 10_000L)
+
+        val all = dao.observeAll().first()
+        val poisoned = all.filter { it.series == SnapshotSeries.POISONED }.map { it.capturedAt }.toSet()
+        val control = all.filter { it.series == SnapshotSeries.CONTROL }.map { it.capturedAt }.toSet()
+
+        // POISONED keeps earliest(1000) + latest(3000) — so E2 drift still has its >= 2 rows;
+        // the middle(2000) is pruned.
+        assertEquals(setOf(1000L, 3000L), poisoned)
+        // CONTROL survives INDEPENDENTLY (earliest 1500 + latest 3500) — the bug deleted it.
+        assertEquals(setOf(1500L, 3500L), control)
+    }
+}


### PR DESCRIPTION
Pre-0.4.0 hardening. Fixes 6 bugs surfaced by a multi-agent bug/regression audit over the `v0.3.2..main` diff (M1-M4), each adversarially verified against `main` before fixing. Three were in the freshly-merged M4 work; unit tests + lint had passed them clean because they are integration / lifecycle / threading issues.

## Fixes

### HIGH - privacy-deletion: a full wipe left imported broker history behind
`SettingsViewModel.resetToDefaults()` ("Delete all data") and `TargetingViewModel.clearProfile()` never cleared the `profile_snapshot` table, so the imported ad-interest categories AND the clean "control" account (#172) survived an explicit wipe, and the dashboard drift / control-divergence cards kept showing values derived from the "deleted" data. Both ViewModels now inject `ProfileSnapshotDao` and call `deleteAll()` in the wipe path; `SettingsViewModelTest` guards it.

### MED - retention pruned the rows the measurement cards need
`RetentionWorker`'s keep-baseline query kept only `MIN(id)` per `platformName` - series-blind - so the daily prune deleted the POISONED / CONTROL snapshots that E2 drift (needs >= 2 per platform) and E3 control-divergence (needs a latest row per series) depend on, silently reverting both cards to "collecting". The query now keeps earliest AND latest per `(platformName, series)`. New Room in-memory regression test (`ProfileSnapshotRetentionTest`) proves the control series survives.

### MED - query-grammar seed did blocking IO on the main thread
`provideQueryGrammarSeed` ran `runBlocking { dataStore... }` at Hilt injection time, reachable from a service / ViewModel `onCreate` (main thread) -> jank/ANR risk. `QueryGrammarSeed` is now a deferred loader, and `GrammarQueryGenerator.style` is `by lazy`, so the read resolves on first `generate()` (engine background dispatcher), never during graph construction.

### LOW - query channel re-synced to the persona rotation instant
`GrammarQueryGenerator` read the raw active persona instead of the staggered `personaForChannel()` that every other persona-bound channel uses. Added `PersonaChannel.QUERY` and routed through it, so the query lean phases in over its own adoption lag and inherits the Layer-3 kill-switch.

### LOW - action-count race + UTC rollover
`PoisonEngine`'s today-action-count increment wasn't synchronized with the `@Synchronized` day-rollover reset (a concurrent reset could drop a count), and the day boundary was computed in UTC (`epoch-ms % 24h`) while all other time logic is local. The increment now goes through a `@Synchronized recordTodayAction()` that rolls first, and the boundary is computed at local midnight via a `Calendar` helper.

## Verification

Full unit suite and `lintFullDebug` green; new/updated regression tests: `ProfileSnapshotRetentionTest` (retention keeps both series), `SettingsViewModelTest` (wipe clears `profile_snapshot`), `GrammarQueryGeneratorTest` (seed-loader + channel changes). No new lint warnings.

## Note

This is the static half of pre-0.4.0 testing. Device / manual / instrumented / upgrade-path (v0.3.2 -> 0.4.0, the 6->7 migration) testing is still outstanding before the release is cut.
