### PR TITLE
release: v0.5.0 (versionCode 500)

### DIFF
--- a/app/version.properties
+++ b/app/version.properties
@@ -1,2 +1,2 @@
-versionCode=401
-versionName=0.4.1
+versionCode=500
+versionName=0.5.0

--- a/fastlane/metadata/android/en-US/changelogs/500.txt
+++ b/fastlane/metadata/android/en-US/changelogs/500.txt
@@ -1,0 +1,2 @@
+• New: Cross-device sync. From the new LAN Sync screen in Settings, pair Fauxx with the Fauxx Desktop companion or another device by scanning a QR code, then share one coherent synthetic persona across them. Pairing and transfer happen entirely on your local Wi-Fi, end-to-end encrypted, with no account and no cloud.
+• Maintenance: dependency and build updates


### PR DESCRIPTION
Release v0.5.0: cross-device encrypted LAN persona sync, pairing with the Fauxx Desktop companion (E13, #178).