### PR TITLE
fix: v0.5.1 bug-fix payload + LAN-sync repair

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -183,6 +183,7 @@ ksp {
 dependencies {
     implementation(libs.core.ktx)
     implementation(libs.lifecycle.runtime.ktx)
+    implementation(libs.lifecycle.runtime.compose)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.activity.compose)
 

--- a/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
+++ b/app/src/main/java/com/fauxx/engine/PoisonEngine.kt
@@ -14,7 +14,9 @@ import androidx.work.NetworkType
 import com.fauxx.di.IoDispatcher
 import com.fauxx.service.ResumeSpec
 import com.fauxx.util.Clock
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import timber.log.Timber
 import com.fauxx.data.crawllist.CrawlListManager
 import com.fauxx.data.crawllist.DomainBlocklist
@@ -122,6 +124,14 @@ private const val SLEEP_CONSTRAINT_RECHECK_MS = 60_000L
 private const val LONG_PAUSE_THRESHOLD_MS = 30L * 60 * 1000
 
 /**
+ * Delay before auto-resuming after the engine loop terminates by an uncaught exception (issue
+ * #197). Long enough that a deterministic fault doesn't hot-loop, short enough that a transient
+ * one self-heals without waiting on the 6h reconcile watchdog. The full flavor's exact-alarm
+ * resume path auto-restarts the FGS at this time with no user interaction (#126).
+ */
+private const val LOOP_FAILURE_RESUME_DELAY_MS = 60_000L
+
+/**
  * Decision returned by [PoisonEngine.decidePauseAction]: either keep the current
  * delay-loop ([Continue]) or [Resign] from the foreground service and schedule a
  * resume notification when the constraint clears.
@@ -173,7 +183,16 @@ class PoisonEngine @Inject constructor(
      */
     private val usageObserver: UsageObserver = UsageObserver.NONE,
 ) {
-    private var scope = CoroutineScope(SupervisorJob() + loopDispatcher)
+    /**
+     * Backstop for an uncaught exception in a direct child of [scope] (issue #197). A
+     * [SupervisorJob] does NOT absorb a child failure, so without this the exception would reach
+     * the app's default uncaught-exception handler ([com.fauxx.FauxxApp]) and crash the whole
+     * process. The primary guard is the try/catch around the engineJob body in [start]; this
+     * additionally catches anything launched separately on [scope].
+     */
+    private val loopExceptionHandler = CoroutineExceptionHandler { _, t -> handleLoopFailure(t) }
+
+    private var scope = CoroutineScope(SupervisorJob() + loopDispatcher + loopExceptionHandler)
     private var engineJob: Job? = null
 
     /**
@@ -374,7 +393,7 @@ class PoisonEngine @Inject constructor(
         if (engineJob?.isActive == true) return
         // Recreate the scope if it was previously cancelled by destroy()
         if (!scope.isActive) {
-            scope = CoroutineScope(SupervisorJob() + loopDispatcher)
+            scope = CoroutineScope(SupervisorJob() + loopDispatcher + loopExceptionHandler)
         }
         engineStartElapsedMs = clock.elapsedRealtime()
         pauseEnteredAtElapsedMs = 0L
@@ -383,47 +402,68 @@ class PoisonEngine @Inject constructor(
         hasSignaledActive = false
         registerConstraintReceivers()
         engineJob = scope.launch {
-            // Sync targeting layer enable flags from persisted profile
-            val savedProfile = profile.getProfile()
-            targetingEngine.setLayer1Enabled(savedProfile.layer1Enabled)
-            targetingEngine.setLayer2Enabled(savedProfile.layer2Enabled)
-            targetingEngine.setLayer3Enabled(savedProfile.layer3Enabled)
-            targetingEngine.setAdversarialAllocationEnabled(savedProfile.adversarialAllocationEnabled)
-
-            // Seed today's action count from DB once on start
-            val dayStart = localDayStartMs(clock.currentTimeMillis())
-            actionCountDayStart = dayStart
-            todayActionCount.set(
-                try { actionLogDao.countSince(dayStart).first() } catch (_: Exception) { 0 }
-            )
-            _engineState.value = EngineState.ACTIVE
-            Timber.i("PoisonEngine started (layers: L1=${savedProfile.layer1Enabled}, L2=${savedProfile.layer2Enabled}, L3=${savedProfile.layer3Enabled}, adversarialAlloc=${savedProfile.adversarialAllocationEnabled})")
-            // Fail-closed: if blocklist couldn't load, permanently circuit-break all
-            // URL-loading modules. These modules load arbitrary URLs and MUST have a
-            // working blocklist to prevent navigation to harmful domains.
-            if (blocklist.loadFailed) {
-                val urlModules = listOf(searchModule, cookieModule, adModule, appSignalModule)
-                for (m in urlModules) {
-                    val name = m::class.simpleName ?: "Unknown"
-                    circuitBreakerUntil[name] = Long.MAX_VALUE
-                    Timber.e("Blocklist failed to load — permanently disabling $name")
-                }
+            try {
+                runEngineSession()
+            } catch (ce: CancellationException) {
+                throw ce // normal stop()/destroy() cancellation — must propagate
+            } catch (t: Throwable) {
+                // #197: an uncaught exception from the loop machinery (profile.getProfile,
+                // checkConstraints, dispatcher.selectCategory, scheduler.nextDelayMs, the
+                // rate-limit block, sleepRespectingConstraints) would otherwise escape this
+                // SupervisorJob child, reach the app's default uncaught handler (FauxxApp), and
+                // crash the whole process — leaving isRunning=true so EngineReconcileWorker could
+                // not recover. Catch it, mark STOPPED, and resign so recovery is scheduled.
+                handleLoopFailure(t)
             }
-
-            // Startup asset health check — verify critical data loaded successfully.
-            _healthWarnings.value = checkAssetHealth()
-
-            allModules.filter { it.isEnabled() }.forEach { module ->
-                try {
-                    module.start()
-                } catch (e: Exception) {
-                    val name = module::class.simpleName ?: "Unknown"
-                    Timber.e(e, "Module $name failed to start, circuit-breaking")
-                    circuitBreakerUntil[name] = clock.currentTimeMillis() + MAX_BACKOFF_MS
-                }
-            }
-            runLoop()
         }
+    }
+
+    /**
+     * The engine session body: sync targeting flags, seed counters, start modules, then enter the
+     * run loop. Extracted from [start] so the launch can wrap it in the #197 crash guard. Runs on
+     * the engine [scope] / [loopDispatcher].
+     */
+    private suspend fun runEngineSession() {
+        // Sync targeting layer enable flags from persisted profile
+        val savedProfile = profile.getProfile()
+        targetingEngine.setLayer1Enabled(savedProfile.layer1Enabled)
+        targetingEngine.setLayer2Enabled(savedProfile.layer2Enabled)
+        targetingEngine.setLayer3Enabled(savedProfile.layer3Enabled)
+        targetingEngine.setAdversarialAllocationEnabled(savedProfile.adversarialAllocationEnabled)
+
+        // Seed today's action count from DB once on start
+        val dayStart = localDayStartMs(clock.currentTimeMillis())
+        actionCountDayStart = dayStart
+        todayActionCount.set(
+            try { actionLogDao.countSince(dayStart).first() } catch (_: Exception) { 0 }
+        )
+        _engineState.value = EngineState.ACTIVE
+        Timber.i("PoisonEngine started (layers: L1=${savedProfile.layer1Enabled}, L2=${savedProfile.layer2Enabled}, L3=${savedProfile.layer3Enabled}, adversarialAlloc=${savedProfile.adversarialAllocationEnabled})")
+        // Fail-closed: if blocklist couldn't load, permanently circuit-break all
+        // URL-loading modules. These modules load arbitrary URLs and MUST have a
+        // working blocklist to prevent navigation to harmful domains.
+        if (blocklist.loadFailed) {
+            val urlModules = listOf(searchModule, cookieModule, adModule, appSignalModule)
+            for (m in urlModules) {
+                val name = m::class.simpleName ?: "Unknown"
+                circuitBreakerUntil[name] = Long.MAX_VALUE
+                Timber.e("Blocklist failed to load — permanently disabling $name")
+            }
+        }
+
+        // Startup asset health check — verify critical data loaded successfully.
+        _healthWarnings.value = checkAssetHealth()
+
+        allModules.filter { it.isEnabled() }.forEach { module ->
+            try {
+                module.start()
+            } catch (e: Exception) {
+                val name = module::class.simpleName ?: "Unknown"
+                Timber.e(e, "Module $name failed to start, circuit-breaking")
+                circuitBreakerUntil[name] = clock.currentTimeMillis() + MAX_BACKOFF_MS
+            }
+        }
+        runLoop()
     }
 
     /**
@@ -796,6 +836,30 @@ class PoisonEngine @Inject constructor(
         val ctx = reason ?: state?.toString() ?: "unknown"
         Timber.i("Engine resigning ($ctx) after ${sessionDurationMs}ms; resume spec: $spec")
         onLongPause?.invoke(spec)
+    }
+
+    /**
+     * Recover from an uncaught exception thrown by the engine loop machinery (issue #197).
+     * Without this, the exception escapes [engineJob] (a [SupervisorJob] child has no parent to
+     * absorb it), reaches the app's default uncaught-exception handler ([com.fauxx.FauxxApp]),
+     * and crashes the whole process — and because [com.fauxx.service.PhantomForegroundService]
+     * `isRunning` stays true, [com.fauxx.service.EngineReconcileWorker] could not recover it.
+     *
+     * Instead: mark the engine [EngineState.STOPPED] and route through the existing resign path so
+     * the FGS schedules a resume and tears itself down cleanly (clearing isRunning). The full
+     * flavor's exact-alarm resume auto-restarts shortly so a transient fault self-heals; the delay
+     * keeps a deterministic fault from hot-looping. Idempotent: a no-op if already resigned.
+     */
+    private fun handleLoopFailure(t: Throwable) {
+        if (t is CancellationException) return
+        Timber.e(t, "Engine loop terminated by an uncaught exception (#197); tearing down for recovery")
+        _engineState.value = EngineState.STOPPED
+        if (hasResigned) return
+        resignAndRecord(
+            state = EngineState.STOPPED,
+            spec = ResumeSpec.AtTime(clock.currentTimeMillis() + LOOP_FAILURE_RESUME_DELAY_MS),
+            reason = "loop failure: ${t.javaClass.simpleName}",
+        )
     }
 
     /**

--- a/app/src/main/java/com/fauxx/engine/scheduling/PoissonScheduler.kt
+++ b/app/src/main/java/com/fauxx/engine/scheduling/PoissonScheduler.kt
@@ -113,10 +113,15 @@ class PoissonScheduler @Inject constructor(
             if (sameTopic) {
                 baseDelay
             } else {
-                // Cross-niche: scale up by a lognormal dwell multiplier and enforce a
-                // tier-derived floor (lower for the aggressive tiers — see crossNicheFloorMs).
+                // Cross-niche: scale the Poisson base up by a lognormal dwell multiplier so
+                // unrelated topics tend to sit further apart, then bound the result to BOTH a
+                // tier-derived floor (lower for the aggressive tiers — see crossNicheFloorMs)
+                // AND the same 3× mean-inter-arrival ceiling poissonDelay already enforces.
+                // Without the ceiling the unbounded lognormal tail (p95 ≈ 4.5×, worst ≈ 15×)
+                // applied on top of an already-clamped baseDelay let a single LOW/MEDIUM gap
+                // run past an hour, starving the displayed actions/hour (issue #209).
                 val dwell = (baseDelay * lognormalMultiplier()).toLong()
-                maxOf(crossNicheFloorMs(actionsPerHour), dwell)
+                dwell.coerceIn(crossNicheFloorMs(actionsPerHour), maxPoissonDelayMs(effectiveRate))
             }
         }
     }
@@ -164,11 +169,22 @@ class PoissonScheduler @Inject constructor(
     fun poissonDelay(actionsPerHour: Float): Long {
         if (actionsPerHour <= 0f) return 60_000L
         val ratePerMs = actionsPerHour / (60f * 60f * 1000f)
-        val meanDelayMs = (3_600_000f / actionsPerHour).toLong()
-        val maxDelayMs = maxOf(60_000L, meanDelayMs * 3)
         val u = random.nextDouble()
         val delayMs = (-ln(1.0 - u) / ratePerMs).toLong()
-        return delayMs.coerceIn(1_000L, maxDelayMs)
+        return delayMs.coerceIn(1_000L, maxPoissonDelayMs(actionsPerHour))
+    }
+
+    /**
+     * The upper clamp on any single inter-action delay: 3× the mean inter-arrival time
+     * (minimum 60 s). Shared by [poissonDelay] and the cross-niche dwell branch of
+     * [nextDelayMs] so a cross-niche pause can never exceed the same ceiling a same-topic
+     * gap does (issue #209). For LOW (12/hr, mean 300 s) this is ~15 min; HIGH (200/hr,
+     * mean 18 s) caps at ~54 s.
+     */
+    private fun maxPoissonDelayMs(actionsPerHour: Float): Long {
+        if (actionsPerHour <= 0f) return 60_000L
+        val meanDelayMs = (3_600_000f / actionsPerHour).toLong()
+        return maxOf(60_000L, meanDelayMs * 3)
     }
 
     private fun msUntilHour(now: Calendar, targetHour: Int): Long {

--- a/app/src/main/java/com/fauxx/engine/webview/PhantomWebViewClient.kt
+++ b/app/src/main/java/com/fauxx/engine/webview/PhantomWebViewClient.kt
@@ -5,6 +5,7 @@ import android.net.http.SslError
 import android.os.Build
 import androidx.annotation.RequiresApi
 import timber.log.Timber
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.SafeBrowsingResponse
 import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
@@ -34,7 +35,11 @@ class PhantomWebViewClient(
     // Issue #73: incremented for each allowed (non-blocked) resource request so the pool can
     // report a "resources loaded" count in the action-log metadata. Null = don't count.
     private val resourceCounter: AtomicInteger? = null,
-    private val onPageFinished: ((String) -> Unit)? = null
+    private val onPageFinished: ((String) -> Unit)? = null,
+    // Issue #210: invoked with the affected WebView when its renderer process dies, so the pool
+    // can destroy the broken instance and swap in a fresh one. onRenderProcessGone ALWAYS returns
+    // true regardless, so Android never terminates the whole app process on a renderer death.
+    private val onRenderGone: ((WebView) -> Unit)? = null
 ) : WebViewClient() {
 
     override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
@@ -93,6 +98,18 @@ class PhantomWebViewClient(
         val description = error?.description ?: "unknown error"
         val code = error?.errorCode ?: 0
         Timber.w("WebView load error on ${request.url} (code=$code): $description")
+    }
+
+    override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
+        // A renderer-process death (Chromium renderer OOM, or the OS evicting a backgrounded
+        // renderer — common on memory-constrained/foldable devices and hardened OSes like
+        // GrapheneOS) takes down the ENTIRE app process unless this returns true. Issue #210:
+        // the SIGTRAP abort "Render process crash wasn't handled by all associated webviews,
+        // triggering application crash". Handle it: log, hand the dead instance to the pool for
+        // replacement, and tell Android we recovered so the app keeps running.
+        Timber.w("WebView renderer gone (didCrash=${detail.didCrash()}); recovering pool slot instead of crashing")
+        onRenderGone?.invoke(view)
+        return true
     }
 
     override fun onReceivedSslError(view: WebView, handler: SslErrorHandler, error: SslError) {

--- a/app/src/main/java/com/fauxx/engine/webview/PhantomWebViewPool.kt
+++ b/app/src/main/java/com/fauxx/engine/webview/PhantomWebViewPool.kt
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import javax.inject.Singleton
+import timber.log.Timber
 
 /** Maximum number of WebView instances in the pool. */
 private const val POOL_SIZE = 2
@@ -74,6 +75,9 @@ class PhantomWebViewPool @Inject constructor(
 
     /** Per-WebView allowed-resource-request counter, reset on [acquire] (issue #73 metadata). */
     private val resourceCounters = ConcurrentHashMap<String, AtomicInteger>()
+
+    /** Total renderer-process deaths recovered from (issue #210), for diagnostics. */
+    private val rendererDeaths = AtomicInteger(0)
 
     /**
      * Current User-Agent string to apply to WebViews on acquire.
@@ -185,11 +189,16 @@ class PhantomWebViewPool @Inject constructor(
         try {
             withTimeoutOrNull(MAIN_OP_TIMEOUT_MS) {
                 withContext(Dispatchers.Main) {
-                    webView.stopLoading()
-                    webView.clearHistory()
-                    webView.clearCache(false)
-                    webView.evaluateJavascript("document.open();document.close();", null)
-                    webView.loadUrl("about:blank")
+                    // Guard the cleanup: after a renderer death (issue #210) this instance may be
+                    // broken or already destroyed + replaced in the pool, so these ops can throw.
+                    // The bookkeeping in the finally must still run so the permit is returned.
+                    runCatching {
+                        webView.stopLoading()
+                        webView.clearHistory()
+                        webView.clearCache(false)
+                        webView.evaluateJavascript("document.open();document.close();", null)
+                        webView.loadUrl("about:blank")
+                    }
                     // Note: WebStorage.getInstance().deleteAllData() is intentionally NOT called
                     // here because it's a global singleton that wipes storage for ALL WebView
                     // instances. Per-WebView cleanup (stopLoading + clearHistory + clearCache +
@@ -219,6 +228,34 @@ class PhantomWebViewPool @Inject constructor(
         pool.forEach { it.destroy() }
         pool.clear()
         initialized = false
+    }
+
+    /**
+     * Recover from a system-WebView renderer-process death (issue #210). [PhantomWebViewClient]
+     * returns true from onRenderProcessGone (so Android never terminates the whole app process)
+     * and routes the dead instance here. We destroy it and swap a freshly-created WebView into the
+     * same pool slot (same tag), so the engine can keep running on the next acquire.
+     *
+     * Always invoked on the main thread — WebView callbacks are delivered on the creating thread,
+     * which is also where [pool] is mutated in [initialize]/[acquire]/[destroy] — so the list swap
+     * here cannot race those. A WebView whose renderer died but that is still acquired and in-flight
+     * is destroyed here; the engine's current action on it fails and is caught by the engine's
+     * per-action try/catch, and the subsequent [release] is defended with runCatching.
+     */
+    private fun handleRendererGone(dead: WebView) {
+        val total = rendererDeaths.incrementAndGet()
+        val tag = dead.tag as? String
+        val index = pool.indexOfFirst { it === dead }
+        if (index < 0) {
+            // Already swapped out (e.g. a duplicate callback for the same instance). Just destroy.
+            Timber.w("Renderer death for an already-replaced WebView (tag=$tag, total=$total)")
+            runCatching { dead.destroy() }
+            return
+        }
+        Timber.w("Rebuilding phantom WebView pool slot after renderer death (tag=$tag, total=$total)")
+        val replacement = createWebView(tag = tag ?: "pool_$index")
+        pool[index] = replacement
+        runCatching { dead.destroy() }
     }
 
     private fun createWebView(tag: String): WebView {
@@ -256,7 +293,11 @@ class PhantomWebViewPool @Inject constructor(
 
         val resourceCounter = AtomicInteger(0)
         resourceCounters[tag] = resourceCounter
-        webView.webViewClient = PhantomWebViewClient(blocklist, resourceCounter = resourceCounter)
+        webView.webViewClient = PhantomWebViewClient(
+            blocklist,
+            resourceCounter = resourceCounter,
+            onRenderGone = ::handleRendererGone,
+        )
         webView.isClickable = false
         webView.isFocusable = false
 

--- a/app/src/main/java/com/fauxx/network/UserAgentPool.kt
+++ b/app/src/main/java/com/fauxx/network/UserAgentPool.kt
@@ -56,13 +56,7 @@ class UserAgentPool @Inject constructor(
         return if (chromiumAndroidAgents.isNotEmpty()) chromiumAndroidAgents.random(random) else DEFAULT_UA
     }
 
-    /** Android + Chrome/Samsung only; excludes Firefox, Opera, Edge, and iOS browsers. */
-    private fun isChromiumAndroid(ua: String): Boolean =
-        ua.contains("Android") && ua.contains("Chrome/") &&
-            !ua.contains("Firefox") && !ua.contains("OPR/") &&
-            !ua.contains("EdgA") && !ua.contains("CriOS") && !ua.contains("FxiOS")
-
-    private val chromiumAndroidAgents: List<String> by lazy { agents.filter(::isChromiumAndroid) }
+    private val chromiumAndroidAgents: List<String> by lazy { agents.filter { isChromiumAndroid(it) } }
 
     private fun loadAgents(): List<String> {
         return try {
@@ -80,5 +74,16 @@ class UserAgentPool @Inject constructor(
         private const val DEFAULT_UA =
             "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 " +
             "(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+
+        /**
+         * Android + Chrome/Samsung only; excludes Firefox, Opera, Edge, and iOS browsers. A custom
+         * UA is honored on the WebView path only when this holds (the System WebView always does an
+         * Android-Chromium TLS handshake, so a non-Chromium UA there recreates the #168 tell). The
+         * Settings screen uses this to warn that a non-Chromium custom UA will be ignored (#201).
+         */
+        internal fun isChromiumAndroid(ua: String): Boolean =
+            ua.contains("Android") && ua.contains("Chrome/") &&
+                !ua.contains("Firefox") && !ua.contains("OPR/") &&
+                !ua.contains("EdgA") && !ua.contains("CriOS") && !ua.contains("FxiOS")
     }
 }

--- a/app/src/main/java/com/fauxx/service/SyncForegroundService.kt
+++ b/app/src/main/java/com/fauxx/service/SyncForegroundService.kt
@@ -77,6 +77,7 @@ class SyncForegroundService : Service() {
             return START_NOT_STICKY
         }
         startInForeground()
+        isRunning = true
         if (!started) {
             started = true
             startSession()
@@ -146,6 +147,7 @@ class SyncForegroundService : Service() {
     }
 
     override fun onDestroy() {
+        isRunning = false
         stopSession()
         scope.cancel()
         started = false
@@ -207,6 +209,21 @@ class SyncForegroundService : Service() {
         const val CHANNEL_ID = "fauxx_sync"
         const val NOTIFICATION_ID = 2
         const val ACTION_STOP = "com.fauxx.sync.action.STOP"
+
+        /**
+         * True while the sync session is foregrounded (#213). The Sync screen's toggle defaults to
+         * false and was only ever mutated by the toggle itself, so re-entering the screen showed a
+         * stale OFF even with a session running. [SyncViewModel] seeds its state from this flag.
+         * Process-scoped: a fresh process correctly reads false.
+         */
+        @Volatile
+        var isRunning: Boolean = false
+            private set
+
+        @androidx.annotation.VisibleForTesting
+        internal fun setRunningForTest(value: Boolean) {
+            isRunning = value
+        }
 
         fun start(context: Context) {
             val intent = Intent(context, SyncForegroundService::class.java)

--- a/app/src/main/java/com/fauxx/sync/transport/TcpClient.kt
+++ b/app/src/main/java/com/fauxx/sync/transport/TcpClient.kt
@@ -1,5 +1,6 @@
 package com.fauxx.sync.transport
 
+import androidx.annotation.VisibleForTesting
 import com.fauxx.data.model.SyntheticPersona
 import com.fauxx.sync.SealedChannel
 import com.fauxx.sync.data.PairedPeer
@@ -30,6 +31,15 @@ class TcpClient @Inject constructor(
 ) {
     private val routes = ConcurrentHashMap<String, InetSocketAddress>()
 
+    /**
+     * User-supplied manual peer address (#213). Used as a last-resort route for ANY paired peer
+     * that mDNS could not resolve — the path to recovery when discovery is blocked by a VPN/proxy
+     * app or Wi-Fi AP client-isolation. Safe because the sealed channel authenticates by paired
+     * public key regardless of the IP: a frame sent to the wrong host simply fails to authenticate.
+     */
+    @Volatile
+    private var manualFallback: InetSocketAddress? = null
+
     /** Insert or update the resolved address for a recipient (keyed on base64url public key). */
     fun setRoute(peerPublicKey: String, addr: InetSocketAddress) {
         routes[peerPublicKey] = addr
@@ -38,7 +48,19 @@ class TcpClient @Inject constructor(
     /** The current route for a peer, if any. */
     fun routeFor(peerPublicKey: String): InetSocketAddress? = routes[peerPublicKey]
 
-    /** Drop all routes (e.g. on a network change; identity is the key, the IP is a re-resolvable hint). */
+    /** Set (or clear, with null) the manual last-resort address for mDNS-blocked networks (#213). */
+    fun setManualFallback(addr: InetSocketAddress?) {
+        manualFallback = addr
+    }
+
+    /** The current manual fallback address, if the user set one (#213). */
+    fun manualFallback(): InetSocketAddress? = manualFallback
+
+    /**
+     * Drop all mDNS-resolved routes (e.g. on a network change; identity is the key, the IP is a
+     * re-resolvable hint). The user's [manualFallback] is intentionally NOT cleared here — it is a
+     * deliberate override the user re-sets when their address changes.
+     */
     fun clearRoutes() = routes.clear()
 
     /** Open a connection, write one frame, close. Runs on [Dispatchers.IO] with timeouts. */
@@ -78,21 +100,54 @@ class TcpClient @Inject constructor(
         return PushResult(sent, failed)
     }
 
-    private fun resolveAddr(peer: PairedPeer): InetSocketAddress? {
+    @VisibleForTesting
+    internal fun resolveAddr(peer: PairedPeer): InetSocketAddress? {
         routes[peer.publicKey]?.let { return it }
         // Fall back to the QR/stored host hint only when it is a numeric address: mDNS `.local.`
         // names do not resolve through InetAddress, so those rely on the NSD-fed route instead.
-        val host = peer.host ?: return null
-        if (host.isBlank() || host.endsWith(".local.") || host.endsWith(".local")) return null
-        return try {
-            InetSocketAddress(host, peer.port).takeUnless { it.isUnresolved }
-        } catch (e: Exception) {
-            null
+        val host = peer.host
+        if (host != null && host.isNotBlank() &&
+            !host.endsWith(".local.") && !host.endsWith(".local")
+        ) {
+            runCatching { InetSocketAddress(host, peer.port).takeUnless { it.isUnresolved } }
+                .getOrNull()
+                ?.let { return it }
         }
+        // #213: last resort — the user-supplied manual address (mDNS blocked by VPN/proxy/isolation).
+        return manualFallback
     }
 
-    private companion object {
-        const val CONNECT_TIMEOUT_MS = 5_000
-        const val IO_TIMEOUT_MS = 10_000
+    companion object {
+        private const val CONNECT_TIMEOUT_MS = 5_000
+        private const val IO_TIMEOUT_MS = 10_000
+
+        /**
+         * Parse a user-entered "host" or "host:port" (or "[ipv6]:port") into an [InetSocketAddress]
+         * for the manual fallback (#213), defaulting the port to [defaultPort]. Returns null on
+         * blank input, a bad port, or an address that does not resolve to a literal. Intended for
+         * literal IPs; call off the main thread since a hostname would trigger DNS resolution.
+         */
+        fun parseHostPort(input: String, defaultPort: Int): InetSocketAddress? {
+            val trimmed = input.trim()
+            if (trimmed.isEmpty()) return null
+            val (host, port) = when {
+                trimmed.startsWith("[") -> { // [IPv6] or [IPv6]:port
+                    val close = trimmed.indexOf(']')
+                    if (close < 1) return null
+                    val p = trimmed.substring(close + 1).removePrefix(":")
+                        .let { if (it.isEmpty()) defaultPort else it.toIntOrNull() ?: return null }
+                    trimmed.substring(1, close) to p
+                }
+                trimmed.count { it == ':' } == 1 -> { // host:port (IPv4 or hostname)
+                    val idx = trimmed.lastIndexOf(':')
+                    val p = trimmed.substring(idx + 1).toIntOrNull() ?: return null
+                    trimmed.substring(0, idx) to p
+                }
+                else -> trimmed to defaultPort // bare IPv4 / hostname / bare IPv6
+            }
+            if (host.isBlank() || port !in 1..65535) return null
+            return runCatching { InetSocketAddress(host, port).takeUnless { it.isUnresolved } }
+                .getOrNull()
+        }
     }
 }

--- a/app/src/main/java/com/fauxx/targeting/layer2/ProfileDriftMetric.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer2/ProfileDriftMetric.kt
@@ -7,10 +7,17 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.ln
 
-/** Whether enough snapshots exist to show a drift number yet (issue #171 E2). */
-enum class DriftState { COLLECTING, AVAILABLE }
+/**
+ * Whether a drift number can be shown yet (issue #171 E2).
+ *  - [COLLECTING]: a profile exists but not enough snapshots to compute drift (needs a second).
+ *  - [AVAILABLE]: a drift value is computed.
+ *  - [NO_PROFILE]: the user has imported a profile but it is empty — e.g. personalized ads are
+ *    turned off, so there is no ad profile to track. Distinguished from COLLECTING so the
+ *    dashboard can say so instead of showing "collecting…" forever (#220).
+ */
+enum class DriftState { COLLECTING, AVAILABLE, NO_PROFILE }
 
-/** Result of the profile-drift computation; [klDivergence] is null while [state] is COLLECTING. */
+/** Result of the profile-drift computation; [klDivergence] is null unless [state] is AVAILABLE. */
 data class DriftResult(val state: DriftState, val klDivergence: Double?)
 
 /**
@@ -28,6 +35,13 @@ class ProfileDriftMetric @Inject constructor() {
     private val gson = Gson()
 
     fun compute(snapshots: List<ProfileSnapshot>): DriftResult {
+        // If the user has imported at least one profile but the latest snapshot for every platform
+        // is empty, there is simply no ad profile to track (e.g. Google personalized ads turned
+        // off). Report NO_PROFILE so the dashboard can explain that, rather than sitting on
+        // "collecting…" indefinitely while a value can never accrue (#220).
+        if (snapshots.isNotEmpty() && latestUnion(snapshots).isEmpty()) {
+            return DriftResult(DriftState.NO_PROFILE, null)
+        }
         val baselineSets = mutableListOf<Set<CategoryPool>>()
         val currentSets = mutableListOf<Set<CategoryPool>>()
         for ((_, snaps) in snapshots.groupBy { it.platformName }) {
@@ -54,6 +68,15 @@ class ProfileDriftMetric @Inject constructor() {
         if (poisoned.isEmpty() || control.isEmpty()) return DriftResult(DriftState.COLLECTING, null)
         return DriftResult(DriftState.AVAILABLE, kl(poisoned, control))
     }
+
+    /** Union of the latest snapshot's categories per platform, across all series (#220). */
+    private fun latestUnion(snapshots: List<ProfileSnapshot>): Set<CategoryPool> =
+        snapshots.asSequence()
+            .groupBy { it.platformName }
+            .values
+            .mapNotNull { perPlatform -> perPlatform.maxByOrNull { it.capturedAt } }
+            .flatMap { parse(it.scrapedCategoriesJson) }
+            .toSet()
 
     /** Union of the latest snapshot's categories per platform, within one series. */
     private fun latestCategories(

--- a/app/src/main/java/com/fauxx/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/com/fauxx/ui/screens/DashboardScreen.kt
@@ -614,10 +614,14 @@ private fun DriftCard(
                     help = help
                 )
                 Text(
-                    text = if (driftState == com.fauxx.targeting.layer2.DriftState.AVAILABLE && kl != null) {
-                        stringResource(R.string.dashboard_drift_value, kl)
-                    } else {
-                        stringResource(R.string.dashboard_drift_collecting)
+                    text = when {
+                        driftState == com.fauxx.targeting.layer2.DriftState.AVAILABLE && kl != null ->
+                            stringResource(R.string.dashboard_drift_value, kl)
+                        // #220: an empty imported profile (e.g. personalized ads off) can never
+                        // produce a value, so say so instead of "collecting…" forever.
+                        driftState == com.fauxx.targeting.layer2.DriftState.NO_PROFILE ->
+                            stringResource(R.string.dashboard_drift_no_profile)
+                        else -> stringResource(R.string.dashboard_drift_collecting)
                     },
                     style = MaterialTheme.typography.labelMedium,
                     fontFamily = FontFamily.Monospace,

--- a/app/src/main/java/com/fauxx/ui/screens/ModulesScreen.kt
+++ b/app/src/main/java/com/fauxx/ui/screens/ModulesScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import android.content.Context
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import com.fauxx.R
 import com.fauxx.engine.modules.LocationDiagnostics
 import com.fauxx.ui.viewmodels.ModulesViewModel
@@ -54,6 +56,14 @@ fun ModulesScreen(
     val uiState by viewModel.uiState.collectAsState()
     val locationFailure by viewModel.locationStartFailure.collectAsState()
     var showLocationSetupHint by remember { mutableStateOf(false) }
+
+    // #202: the mock-location AppOp is only checked when the location module (re)starts, so setting
+    // Fauxx as the "Select mock location app" in Developer Options while Location is already ON is
+    // not picked up live. Re-check on every return to this screen (e.g. back from the Developer
+    // Options deep-link) so the green/red banner refreshes without an engine restart.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.refreshLocationStatus()
+    }
 
     if (showLocationSetupHint) {
         LocationSetupHintDialog(onDismiss = { showLocationSetupHint = false })

--- a/app/src/main/java/com/fauxx/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/fauxx/ui/screens/SettingsScreen.kt
@@ -453,6 +453,16 @@ fun SettingsScreen(
                 },
                 singleLine = true
             )
+            // #201: a non-Android-Chromium custom UA is silently dropped on the WebView path, so
+            // warn rather than let the user believe a Firefox/Edge/iOS string is in effect.
+            if (uiState.customUserAgentIsNonChromium) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    stringResource(R.string.settings_custom_ua_non_chromium_warning),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
             if (uiState.customUserAgent.isNotBlank()) {
                 Spacer(Modifier.height(4.dp))
                 TextButton(

--- a/app/src/main/java/com/fauxx/ui/sync/SyncScreen.kt
+++ b/app/src/main/java/com/fauxx/ui/sync/SyncScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import com.fauxx.R
 import com.fauxx.sync.discovery.DiscoveredPeer
 import com.fauxx.sync.data.PairedPeer
@@ -56,6 +58,12 @@ fun SyncScreen(viewModel: SyncViewModel = hiltViewModel()) {
 
     var showPasteDialog by remember { mutableStateOf(false) }
     val scanPrompt = stringResource(R.string.sync_scan_prompt)
+
+    // #213: reflect an externally-stopped session (e.g. the notification Stop action) when the
+    // user returns to the screen, instead of leaving a stale ON toggle.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.refreshSyncEnabledState()
+    }
 
     val scanLauncher = rememberLauncherForActivityResult(ScanContract()) { result ->
         result.contents?.let { viewModel.completePairing(it) }
@@ -86,6 +94,25 @@ fun SyncScreen(viewModel: SyncViewModel = hiltViewModel()) {
             ) {
                 Text(stringResource(R.string.sync_enable_title), style = MaterialTheme.typography.titleMedium)
                 Switch(checked = state.syncEnabled, onCheckedChange = { viewModel.setSyncEnabled(it) })
+            }
+        }
+
+        // #213: most sync failures are silent setup gaps (one-way pairing, sync left off, mDNS
+        // blocked). Spell out the steps and the common blockers up front.
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(stringResource(R.string.sync_onboarding_title), style = MaterialTheme.typography.titleSmall)
+                    Text(stringResource(R.string.sync_onboarding_steps), style = MaterialTheme.typography.bodySmall)
+                    Text(
+                        stringResource(R.string.sync_onboarding_blockers),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
 
@@ -136,8 +163,19 @@ fun SyncScreen(viewModel: SyncViewModel = hiltViewModel()) {
             Button(
                 onClick = { viewModel.pushCurrentPersonaToAll() },
                 modifier = Modifier.fillMaxWidth(),
-                enabled = paired.isNotEmpty()
+                // #213: a push needs both a paired peer AND a running session (routes only exist
+                // while sync is enabled), so don't offer the action until both hold.
+                enabled = paired.isNotEmpty() && state.syncEnabled
             ) { Text(stringResource(R.string.sync_push_button)) }
+        }
+        if (paired.isNotEmpty() && !state.syncEnabled) {
+            item {
+                Text(
+                    stringResource(R.string.sync_push_disabled_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
 
         state.statusMessage?.let { msg ->
@@ -158,9 +196,28 @@ fun SyncScreen(viewModel: SyncViewModel = hiltViewModel()) {
         item { HorizontalDivider() }
         item { Text(stringResource(R.string.sync_discovered_header), style = MaterialTheme.typography.titleSmall) }
         if (discovered.isEmpty()) {
-            item { Text(stringResource(R.string.sync_none_yet), style = MaterialTheme.typography.bodySmall) }
+            // #213: distinguish "sync off" from "on but nothing found" instead of a bare "none yet".
+            item {
+                Text(
+                    stringResource(
+                        if (state.syncEnabled) R.string.sync_discovered_empty_searching
+                        else R.string.sync_discovered_disabled
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         } else {
             items(discovered, key = { it.name }) { peer -> DiscoveredPeerRow(peer) }
+        }
+
+        // #213: manual IP fallback for networks where mDNS is blocked (VPN/proxy app, AP isolation).
+        item { HorizontalDivider() }
+        item {
+            ManualPeerAddressSection(
+                onSet = { viewModel.setManualPeerAddress(it) },
+                onClear = { viewModel.setManualPeerAddress("") }
+            )
         }
     }
 
@@ -172,6 +229,39 @@ fun SyncScreen(viewModel: SyncViewModel = hiltViewModel()) {
                 viewModel.completePairing(payload)
             }
         )
+    }
+}
+
+@Composable
+private fun ManualPeerAddressSection(onSet: (String) -> Unit, onClear: () -> Unit) {
+    var manualIp by remember { mutableStateOf("") }
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(stringResource(R.string.sync_manual_ip_title), style = MaterialTheme.typography.titleSmall)
+        Text(
+            stringResource(R.string.sync_manual_ip_help),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        OutlinedTextField(
+            value = manualIp,
+            onValueChange = { manualIp = it },
+            label = { Text(stringResource(R.string.sync_manual_ip_label)) },
+            placeholder = { Text(stringResource(R.string.sync_manual_ip_placeholder)) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = { onSet(manualIp) }, enabled = manualIp.isNotBlank()) {
+                Text(stringResource(R.string.sync_manual_ip_set_button))
+            }
+            OutlinedButton(onClick = {
+                manualIp = ""
+                onClear()
+            }) { Text(stringResource(R.string.sync_manual_ip_clear_button)) }
+        }
     }
 }
 

--- a/app/src/main/java/com/fauxx/ui/sync/SyncViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/sync/SyncViewModel.kt
@@ -15,6 +15,7 @@ import com.fauxx.sync.discovery.NsdDiscovery
 import com.fauxx.sync.pairing.PairingManager
 import com.fauxx.sync.pairing.QrRenderer
 import com.fauxx.sync.transport.TcpClient
+import com.fauxx.sync.wire.SyncConstants
 import com.fauxx.targeting.layer3.PersonaHistoryDao
 import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -69,6 +70,9 @@ class SyncViewModel @Inject constructor(
     val discoveredPeers: StateFlow<List<DiscoveredPeer>> = nsdDiscovery.discoveredPeers
 
     init {
+        // #213: seed the toggle from the REAL service state so re-entering the screen (or a fresh
+        // process) reflects whether a session is actually running, not the stale OFF default.
+        _uiState.value = _uiState.value.copy(syncEnabled = SyncForegroundService.isRunning)
         // Load this device's identity-derived display values off the main thread.
         viewModelScope.launch {
             val payload = pairingManager.myPairingPayload()
@@ -90,6 +94,50 @@ class SyncViewModel @Inject constructor(
                 }
             }
             .launchIn(viewModelScope)
+    }
+
+    /**
+     * Re-sync the toggle with the real service state (#213). Called on screen resume so the toggle
+     * reflects an externally-stopped session (e.g. the notification's Stop action) instead of a
+     * stale ON.
+     */
+    fun refreshSyncEnabledState() {
+        val running = SyncForegroundService.isRunning
+        if (_uiState.value.syncEnabled != running) {
+            _uiState.value = _uiState.value.copy(syncEnabled = running)
+        }
+    }
+
+    /**
+     * Set (or clear, on blank input) a manual peer IP[:port] used as a last-resort route when mDNS
+     * discovery is blocked by a VPN/proxy app or Wi-Fi AP client-isolation (#213). The sealed
+     * channel still authenticates by paired key, so a wrong address simply fails to deliver.
+     */
+    fun setManualPeerAddress(input: String) {
+        viewModelScope.launch {
+            if (input.isBlank()) {
+                tcpClient.setManualFallback(null)
+                _uiState.value = _uiState.value.copy(
+                    statusMessage = appContext.getString(R.string.sync_status_manual_ip_cleared)
+                )
+                return@launch
+            }
+            val addr = withContext(Dispatchers.IO) {
+                TcpClient.parseHostPort(input, SyncConstants.DEFAULT_SYNC_PORT)
+            }
+            if (addr == null) {
+                _uiState.value = _uiState.value.copy(
+                    statusMessage = appContext.getString(R.string.sync_status_manual_ip_invalid)
+                )
+                return@launch
+            }
+            tcpClient.setManualFallback(addr)
+            _uiState.value = _uiState.value.copy(
+                statusMessage = appContext.getString(
+                    R.string.sync_status_manual_ip_set, "${addr.hostString}:${addr.port}"
+                )
+            )
+        }
     }
 
     /** Enable or disable the LAN sync session (starts/stops the foreground service). */
@@ -129,6 +177,14 @@ class SyncViewModel @Inject constructor(
     /** Push the most recent locally-generated persona to every paired peer. */
     fun pushCurrentPersonaToAll() {
         viewModelScope.launch {
+            // #213: routes only populate while the session runs, so pushing with sync disabled
+            // deterministically failed with a confusing "no route" error. Tell the user plainly.
+            if (!_uiState.value.syncEnabled) {
+                _uiState.value = _uiState.value.copy(
+                    statusMessage = appContext.getString(R.string.sync_status_push_requires_enabled)
+                )
+                return@launch
+            }
             val peers = pairedPeers.value
             if (peers.isEmpty()) {
                 _uiState.value = _uiState.value.copy(

--- a/app/src/main/java/com/fauxx/ui/viewmodels/ModulesViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/viewmodels/ModulesViewModel.kt
@@ -56,6 +56,24 @@ class ModulesViewModel @Inject constructor(
     }
     fun setAppSignalEnabled(v: Boolean) { update { it.copy(appSignalEnabled = v) } }
 
+    /**
+     * Re-evaluate the mock-location AppOp gate (issue #202). The capability is only checked inside
+     * [LocationDiagnostics.requestStart] (LocationSpoofModule.start), which runs at engine start
+     * and on toggle-ON. So designating Fauxx as the "Select mock location app" in Developer Options
+     * while Location is ALREADY enabled is not detected live — the red NOT_MOCK_APP banner stays
+     * stale until the engine is restarted. The screen calls this on ON_RESUME, so returning from
+     * the Developer Options deep-link refreshes the banner. Re-runs only when Location is enabled
+     * AND the last attempt is in a failure state, to avoid re-kicking start() (and any in-flight
+     * spoof route) on every routine return to the screen.
+     */
+    fun refreshLocationStatus() {
+        if (_uiState.value.locationEnabled &&
+            locationDiagnostics.lastStartFailure.value != LocationDiagnostics.StartFailure.OK
+        ) {
+            viewModelScope.launch { locationDiagnostics.requestStart() }
+        }
+    }
+
     private fun update(transform: (ModulesUiState) -> ModulesUiState) {
         val new = transform(_uiState.value)
         _uiState.value = new

--- a/app/src/main/java/com/fauxx/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/fauxx/ui/viewmodels/SettingsViewModel.kt
@@ -38,7 +38,16 @@ data class SettingsUiState(
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val resumeOnBoot: Boolean = true,
     val customUserAgent: String = ""
-)
+) {
+    /**
+     * #201: true when a non-blank custom UA is NOT an Android-Chromium string, so it is silently
+     * dropped on the WebView path (a Firefox/Edge/iOS UA would otherwise mislead the user). The
+     * Settings screen surfaces a warning when this holds.
+     */
+    val customUserAgentIsNonChromium: Boolean
+        get() = customUserAgent.isNotBlank() &&
+            !com.fauxx.network.UserAgentPool.isChromiumAndroid(customUserAgent)
+}
 
 /**
  * UI state for the app-language picker. `userOverride == null` means "follow system locale";
@@ -100,7 +109,14 @@ class SettingsViewModel @Inject constructor(
     fun setLogRetentionDays(v: Int) { update { it.copy(logRetentionDays = v) } }
     fun setThemeMode(mode: ThemeMode) { update { it.copy(themeMode = mode) } }
     fun setResumeOnBoot(v: Boolean) { update { it.copy(resumeOnBoot = v) } }
-    fun setCustomUserAgent(v: String) { update { it.copy(customUserAgent = v) } }
+    fun setCustomUserAgent(v: String) {
+        // #201: the system WebView's getDefaultUserAgent (the "use this device's browser" capture)
+        // always carries the Android WebView marker "; wv", which is itself a tell and which users
+        // were hand-editing out. Strip it here — the single funnel for both the capture and the
+        // text field — so the stored UA matches a real on-device Chrome. No-op for input without it.
+        val cleaned = if (v.contains("; wv")) v.replace("; wv", "").replace("  ", " ") else v
+        update { it.copy(customUserAgent = cleaned) }
+    }
 
     /**
      * Persist the user's app-language choice and trigger the activity recreate that

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -329,6 +329,7 @@
     <string name="settings_custom_ua_field_label">Identificador de navegador (avanzado — déjalo en blanco para rotar automáticamente)</string>
     <string name="settings_custom_ua_placeholder">Mozilla/5.0 (…)</string>
     <string name="settings_custom_ua_clear_button">Borrar y reanudar la rotación</string>
+    <string name="settings_custom_ua_non_chromium_warning">Este no es un user-agent de Chrome en Android, así que se ignorará para la navegación sintética (que usa el WebView del sistema). Usa un user-agent de Chrome en Android para que se aplique.</string>
     <string name="settings_clear_all_data_button">Borrar todos los datos</string>
     <string name="settings_export_debug_logs_button">Exportar registros de depuración</string>
     <string name="settings_about_privacy_button">Información y política de privacidad</string>
@@ -343,6 +344,23 @@
     <string name="sync_scan_button">Escanear para emparejar</string>
     <string name="sync_paste_button">Pegar carga útil</string>
     <string name="sync_push_button">Enviar persona actual a los dispositivos emparejados</string>
+    <!-- #213 -->
+    <string name="sync_onboarding_title">Cómo funciona la sincronización LAN</string>
+    <string name="sync_onboarding_steps">1. Activa \"Habilitar sincronización LAN\" en AMBOS dispositivos.\n2. En cada dispositivo, escanea (o pega) el QR del OTRO dispositivo: el emparejamiento debe hacerse en ambos sentidos.\n3. Mantén ambos dispositivos en la misma red Wi-Fi.\n4. Toca \"Enviar persona actual\".</string>
+    <string name="sync_onboarding_blockers">Si los dispositivos no aparecen: una app de VPN o proxy, o una red Wi-Fi de invitados o con \"aislamiento de clientes\", puede bloquear la detección. Usa una red sin proxy o configura una IP manual abajo.</string>
+    <string name="sync_push_disabled_hint">Habilita la sincronización LAN arriba para enviar a tus dispositivos emparejados.</string>
+    <string name="sync_status_push_requires_enabled">Primero habilita la sincronización LAN y luego envía.</string>
+    <string name="sync_discovered_empty_searching">Aún no se han encontrado dispositivos. Asegúrate de que el otro dispositivo también tenga la sincronización LAN habilitada y esté en la misma red Wi-Fi (no una red de invitados o aislada), y de que ninguna app de VPN o proxy bloquee la detección.</string>
+    <string name="sync_discovered_disabled">Habilita la sincronización LAN para empezar a detectar dispositivos.</string>
+    <string name="sync_manual_ip_title">Conectar por IP (avanzado)</string>
+    <string name="sync_manual_ip_help">Si la detección está bloqueada, introduce la dirección IP de un dispositivo emparejado para enviarle directamente. Solo funciona con un dispositivo que ya hayas emparejado.</string>
+    <string name="sync_manual_ip_label">Dirección IP del par</string>
+    <string name="sync_manual_ip_placeholder">192.168.1.42</string>
+    <string name="sync_manual_ip_set_button">Usar esta dirección</string>
+    <string name="sync_manual_ip_clear_button">Borrar</string>
+    <string name="sync_status_manual_ip_set">Dirección manual establecida: %1$s. Los envíos la usarán cuando un dispositivo no se detecte.</string>
+    <string name="sync_status_manual_ip_invalid">Eso no parece una dirección IP o IP:puerto válida.</string>
+    <string name="sync_status_manual_ip_cleared">Dirección manual borrada.</string>
     <string name="sync_paired_header">Dispositivos emparejados</string>
     <string name="sync_discovered_header">Detectados en esta red</string>
     <string name="sync_none_yet">Ninguno todavía.</string>
@@ -477,6 +495,7 @@
     <string name="dashboard_drift_title">DERIVA DEL PERFIL</string>
     <string name="dashboard_drift_help">Cuánto se ha alejado tu perfil de intereses publicitarios importado desde la primera importación (de referencia), expresado como divergencia KL. Un valor más alto indica más movimiento. La deriva también puede reflejar que la plataforma reentrena su propio modelo, no solo Fauxx, así que considérala un indicador, no una prueba.</string>
     <string name="dashboard_drift_collecting">recopilando…</string>
+    <string name="dashboard_drift_no_profile">sin perfil publicitario</string>
     <string name="dashboard_control_divergence_title">ENVENENADO FRENTE A CONTROL</string>
     <string name="dashboard_control_divergence_help">Divergencia KL entre tu perfil envenenado y un perfil de control importado (una cuenta limpia que nunca envenenas). Un valor más alto significa que Fauxx ha separado más ambos perfiles. Se muestra solo tras importar un perfil de control.</string>
     <string name="dashboard_synthetic_activity_title">ACTIVIDAD SINTÉTICA</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -329,6 +329,7 @@
     <string name="settings_custom_ua_field_label">Identifiant de navigateur (avancé — laisse vide pour la rotation automatique)</string>
     <string name="settings_custom_ua_placeholder">Mozilla/5.0 (…)</string>
     <string name="settings_custom_ua_clear_button">Effacer et reprendre la rotation</string>
+    <string name="settings_custom_ua_non_chromium_warning">Ce n\'est pas un user-agent Chrome sur Android, il sera donc ignoré pour la navigation synthétique (qui passe par le WebView du système). Utilisez un user-agent Chrome sur Android pour qu\'il soit appliqué.</string>
     <string name="settings_clear_all_data_button">Effacer toutes les données</string>
     <string name="settings_export_debug_logs_button">Exporter les journaux de débogage</string>
     <string name="settings_about_privacy_button">À propos et politique de confidentialité</string>
@@ -343,6 +344,23 @@
     <string name="sync_scan_button">Scanner pour appairer</string>
     <string name="sync_paste_button">Coller la charge utile</string>
     <string name="sync_push_button">Envoyer la persona actuelle aux appareils appairés</string>
+    <!-- #213 -->
+    <string name="sync_onboarding_title">Comment fonctionne la synchro LAN</string>
+    <string name="sync_onboarding_steps">1. Activez \"Activer la synchro LAN\" sur LES DEUX appareils.\n2. Sur chaque appareil, scannez (ou collez) le QR de l\'AUTRE appareil — l\'appairage doit se faire dans les deux sens.\n3. Gardez les deux appareils sur le même Wi-Fi.\n4. Touchez \"Envoyer la persona actuelle\".</string>
+    <string name="sync_onboarding_blockers">Si les appareils n\'apparaissent pas : une app VPN ou proxy, ou un réseau Wi-Fi invité/\"isolation des clients\", peut bloquer la découverte. Utilisez un réseau sans proxy, ou définissez une IP manuelle ci-dessous.</string>
+    <string name="sync_push_disabled_hint">Activez la synchro LAN ci-dessus pour envoyer à vos appareils appairés.</string>
+    <string name="sync_status_push_requires_enabled">Activez d\'abord la synchro LAN, puis envoyez.</string>
+    <string name="sync_discovered_empty_searching">Aucun appareil trouvé pour l\'instant. Vérifiez que l\'autre appareil a aussi la synchro LAN activée et se trouve sur le même Wi-Fi (pas un réseau invité ou isolé), et qu\'aucune app VPN ou proxy ne bloque la découverte.</string>
+    <string name="sync_discovered_disabled">Activez la synchro LAN pour commencer à découvrir des appareils.</string>
+    <string name="sync_manual_ip_title">Connexion par IP (avancé)</string>
+    <string name="sync_manual_ip_help">Si la découverte est bloquée, saisissez l\'adresse IP d\'un appareil appairé pour lui envoyer directement. Cela ne fonctionne qu\'avec un appareil déjà appairé.</string>
+    <string name="sync_manual_ip_label">Adresse IP du pair</string>
+    <string name="sync_manual_ip_placeholder">192.168.1.42</string>
+    <string name="sync_manual_ip_set_button">Utiliser cette adresse</string>
+    <string name="sync_manual_ip_clear_button">Effacer</string>
+    <string name="sync_status_manual_ip_set">Adresse manuelle définie : %1$s. Les envois l\'utiliseront quand un appareil n\'est pas découvert.</string>
+    <string name="sync_status_manual_ip_invalid">Cela ne ressemble pas à une adresse IP ou IP:port valide.</string>
+    <string name="sync_status_manual_ip_cleared">Adresse manuelle effacée.</string>
     <string name="sync_paired_header">Appareils appairés</string>
     <string name="sync_discovered_header">Découverts sur ce réseau</string>
     <string name="sync_none_yet">Aucun pour l\'instant.</string>
@@ -477,6 +495,7 @@
     <string name="dashboard_drift_title">DÉRIVE DU PROFIL</string>
     <string name="dashboard_drift_help">À quel point votre profil d\'intérêts publicitaires importé s\'est éloigné de votre premier import (de référence), exprimé en divergence KL. Plus la valeur est élevée, plus le mouvement est important. La dérive peut aussi refléter le réentraînement du modèle par la plateforme, pas seulement Fauxx, considérez-la donc comme un indicateur, pas une preuve.</string>
     <string name="dashboard_drift_collecting">collecte…</string>
+    <string name="dashboard_drift_no_profile">aucun profil publicitaire</string>
     <string name="dashboard_control_divergence_title">EMPOISONNÉ VS CONTRÔLE</string>
     <string name="dashboard_control_divergence_help">Divergence KL entre votre profil empoisonné et un profil de contrôle importé (un compte propre que vous n\'empoisonnez jamais). Plus la valeur est élevée, plus Fauxx a éloigné les deux profils. Affiché uniquement après avoir importé un profil de contrôle.</string>
     <string name="dashboard_synthetic_activity_title">ACTIVITÉ SYNTHÉTIQUE</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -390,6 +390,7 @@
     <string name="settings_custom_ua_field_label">Идентификатор браузера (для продвинутых — оставь пустым для автоматического чередования)</string>
     <string name="settings_custom_ua_placeholder">Mozilla/5.0 (…)</string>
     <string name="settings_custom_ua_clear_button">Очистить и возобновить чередование</string>
+    <string name="settings_custom_ua_non_chromium_warning">Это не user-agent Chrome для Android, поэтому он будет проигнорирован для синтетического просмотра (он идёт через системный WebView). Используйте user-agent Chrome для Android, чтобы он применялся.</string>
     <string name="settings_clear_all_data_button">Очистить все данные</string>
     <string name="settings_export_debug_logs_button">Экспортировать отладочные логи</string>
     <string name="settings_about_privacy_button">О приложении и приватность</string>
@@ -404,6 +405,23 @@
     <string name="sync_scan_button">Сканировать для сопряжения</string>
     <string name="sync_paste_button">Вставить данные</string>
     <string name="sync_push_button">Отправить текущую личность на сопряжённые устройства</string>
+    <!-- #213 -->
+    <string name="sync_onboarding_title">Как работает синхронизация по локальной сети</string>
+    <string name="sync_onboarding_steps">1. Включите \"Включить синхронизацию по локальной сети\" на ОБОИХ устройствах.\n2. На каждом устройстве отсканируйте (или вставьте) QR-код ДРУГОГО устройства — сопряжение должно быть выполнено в обе стороны.\n3. Держите оба устройства в одной сети Wi-Fi.\n4. Нажмите \"Отправить текущую личность\".</string>
+    <string name="sync_onboarding_blockers">Если устройства не появляются: приложение VPN или прокси либо гостевая сеть Wi-Fi с \"изоляцией клиентов\" может блокировать обнаружение. Используйте сеть без прокси или задайте IP вручную ниже.</string>
+    <string name="sync_push_disabled_hint">Включите синхронизацию по локальной сети выше, чтобы отправлять на сопряжённые устройства.</string>
+    <string name="sync_status_push_requires_enabled">Сначала включите синхронизацию по локальной сети, затем отправляйте.</string>
+    <string name="sync_discovered_empty_searching">Устройства пока не найдены. Убедитесь, что на другом устройстве также включена синхронизация по локальной сети и оно в той же сети Wi-Fi (не гостевой или изолированной), и что обнаружение не блокирует приложение VPN или прокси.</string>
+    <string name="sync_discovered_disabled">Включите синхронизацию по локальной сети, чтобы начать обнаружение устройств.</string>
+    <string name="sync_manual_ip_title">Подключение по IP (для опытных)</string>
+    <string name="sync_manual_ip_help">Если обнаружение заблокировано, введите IP-адрес сопряжённого устройства, чтобы отправить напрямую. Это работает только с уже сопряжённым устройством.</string>
+    <string name="sync_manual_ip_label">IP-адрес узла</string>
+    <string name="sync_manual_ip_placeholder">192.168.1.42</string>
+    <string name="sync_manual_ip_set_button">Использовать этот адрес</string>
+    <string name="sync_manual_ip_clear_button">Очистить</string>
+    <string name="sync_status_manual_ip_set">Адрес задан вручную: %1$s. Отправки будут использовать его, когда устройство не обнаружено.</string>
+    <string name="sync_status_manual_ip_invalid">Это не похоже на корректный IP-адрес или IP:порт.</string>
+    <string name="sync_status_manual_ip_cleared">Адрес, заданный вручную, очищен.</string>
     <string name="sync_paired_header">Сопряжённые устройства</string>
     <string name="sync_discovered_header">Обнаружены в этой сети</string>
     <string name="sync_none_yet">Пока нет.</string>
@@ -497,6 +515,7 @@
     <string name="dashboard_drift_title">ДРЕЙФ ПРОФИЛЯ</string>
     <string name="dashboard_drift_help">Насколько ваш импортированный профиль рекламных интересов отдалился от первого (базового) импорта, в виде KL-дивергенции. Большее значение означает большее движение. Дрейф также может отражать переобучение модели самой платформой, а не только работу Fauxx, поэтому воспринимайте его как индикатор, а не доказательство.</string>
     <string name="dashboard_drift_collecting">сбор данных…</string>
+    <string name="dashboard_drift_no_profile">нет рекламного профиля</string>
     <string name="dashboard_control_divergence_title">ОТРАВЛЕННЫЙ ПРОТИВ КОНТРОЛЯ</string>
     <string name="dashboard_control_divergence_help">KL-дивергенция между вашим отравленным профилем и импортированным контрольным профилем (чистая учётная запись, которую вы никогда не отравляете). Большее значение означает, что Fauxx сильнее развёл их. Показывается только после импорта контрольного профиля.</string>
     <string name="dashboard_synthetic_activity_title">СИНТЕТИЧЕСКАЯ АКТИВНОСТЬ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -327,6 +327,8 @@
     <string name="settings_custom_ua_field_label">Browser identifier (advanced — leave blank to auto-rotate)</string>
     <string name="settings_custom_ua_placeholder">Mozilla/5.0 (…)</string>
     <string name="settings_custom_ua_clear_button">Clear and resume rotation</string>
+    <!-- #201: shown when the custom UA is not an Android-Chromium string and so is ignored on the WebView path. -->
+    <string name="settings_custom_ua_non_chromium_warning">This isn\'t an Android Chrome user-agent, so it will be ignored for synthetic browsing (which runs through the system WebView). Use a Chrome-on-Android user-agent to have it applied.</string>
     <string name="settings_clear_all_data_button">Clear All Data</string>
     <string name="settings_export_debug_logs_button">Export Debug Logs</string>
     <string name="settings_about_privacy_button">About &amp; Privacy Policy</string>
@@ -342,6 +344,23 @@
     <string name="sync_scan_button">Scan to pair</string>
     <string name="sync_paste_button">Paste payload</string>
     <string name="sync_push_button">Push current persona to paired devices</string>
+    <!-- #213 LAN-sync onboarding, diagnostics, and manual-IP fallback -->
+    <string name="sync_onboarding_title">How LAN sync works</string>
+    <string name="sync_onboarding_steps">1. Turn on \"Enable LAN sync\" on BOTH devices.\n2. On each device, scan (or paste) the OTHER device\'s QR — pairing must be done both ways.\n3. Keep both devices on the same Wi-Fi.\n4. Tap \"Push current persona\".</string>
+    <string name="sync_onboarding_blockers">If devices don\'t appear: a VPN or proxy app, or a guest/\"client-isolation\" Wi-Fi network, can block discovery. Use an un-proxied network, or set a manual IP below.</string>
+    <string name="sync_push_disabled_hint">Enable LAN sync above to push to your paired devices.</string>
+    <string name="sync_status_push_requires_enabled">Enable LAN sync first, then push.</string>
+    <string name="sync_discovered_empty_searching">No devices found yet. Make sure the other device also has LAN sync enabled and is on the same Wi-Fi (not a guest/isolated network), and that no VPN or proxy app is blocking discovery.</string>
+    <string name="sync_discovered_disabled">Enable LAN sync to start discovering devices.</string>
+    <string name="sync_manual_ip_title">Connect by IP (advanced)</string>
+    <string name="sync_manual_ip_help">If discovery is blocked, enter a paired device\'s IP address to push to it directly. It still only works with a device you\'ve paired.</string>
+    <string name="sync_manual_ip_label">Peer IP address</string>
+    <string name="sync_manual_ip_placeholder">192.168.1.42</string>
+    <string name="sync_manual_ip_set_button">Use this address</string>
+    <string name="sync_manual_ip_clear_button">Clear</string>
+    <string name="sync_status_manual_ip_set">Manual address set: %1$s. Pushes will use it when a device isn\'t discovered.</string>
+    <string name="sync_status_manual_ip_invalid">That doesn\'t look like a valid IP address or IP:port.</string>
+    <string name="sync_status_manual_ip_cleared">Manual address cleared.</string>
     <string name="sync_paired_header">Paired devices</string>
     <string name="sync_discovered_header">Discovered on this network</string>
     <string name="sync_none_yet">None yet.</string>
@@ -476,6 +495,8 @@
     <string name="dashboard_drift_help">How far your imported ad-interest profile has moved from its first (baseline) import, shown as a KL divergence. Higher means more movement. Drift can also reflect the platform retraining its own model, not only Fauxx, so treat it as an indicator, not proof.</string>
     <string name="dashboard_drift_value" translatable="false">%.2f</string>
     <string name="dashboard_drift_collecting">collecting…</string>
+    <!-- #220: shown when the imported profile is empty (e.g. personalized ads off), so a drift value can never accrue. -->
+    <string name="dashboard_drift_no_profile">no ad profile</string>
     <string name="dashboard_control_divergence_title">POISONED VS CONTROL</string>
     <string name="dashboard_control_divergence_help">KL divergence between your poisoned profile and an imported control profile (a clean account you never poison). Higher means Fauxx has pushed the two further apart. Shown only after you import a control profile.</string>
     <string name="dashboard_synthetic_activity_title">SYNTHETIC ACTIVITY</string>

--- a/app/src/test/java/com/fauxx/ModulesViewModelTest.kt
+++ b/app/src/test/java/com/fauxx/ModulesViewModelTest.kt
@@ -1,0 +1,76 @@
+package com.fauxx
+
+import com.fauxx.data.model.PoisonProfile
+import com.fauxx.engine.PoisonProfileRepository
+import com.fauxx.engine.modules.LocationDiagnostics
+import com.fauxx.support.MainDispatcherRule
+import com.fauxx.ui.viewmodels.ModulesViewModel
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * #202: the mock-location AppOp is only re-evaluated when LocationSpoofModule (re)starts. The
+ * screen calls [ModulesViewModel.refreshLocationStatus] on ON_RESUME so designating Fauxx as the
+ * mock-location app in Developer Options is picked up live, but ONLY when Location is enabled and
+ * the last attempt failed — so a routine screen resume doesn't re-kick an in-flight spoof route.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ModulesViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val failureFlow = MutableStateFlow(LocationDiagnostics.StartFailure.NOT_MOCK_APP)
+    private val diagnostics: LocationDiagnostics = mockk(relaxed = true) {
+        every { lastStartFailure } returns failureFlow
+        coEvery { requestStart() } returns Unit
+    }
+
+    private fun viewModel(locationEnabled: Boolean): ModulesViewModel {
+        val profileRepo: PoisonProfileRepository = mockk(relaxed = true) {
+            every { getProfile() } returns PoisonProfile(locationSpoofEnabled = locationEnabled)
+        }
+        return ModulesViewModel(profileRepo, diagnostics)
+    }
+
+    @Test
+    fun `refreshLocationStatus re-checks when enabled and the last attempt failed`() = runTest {
+        failureFlow.value = LocationDiagnostics.StartFailure.NOT_MOCK_APP
+        val vm = viewModel(locationEnabled = true)
+
+        vm.refreshLocationStatus()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { diagnostics.requestStart() }
+    }
+
+    @Test
+    fun `refreshLocationStatus does nothing when the gate is already OK`() = runTest {
+        failureFlow.value = LocationDiagnostics.StartFailure.OK
+        val vm = viewModel(locationEnabled = true)
+
+        vm.refreshLocationStatus()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { diagnostics.requestStart() }
+    }
+
+    @Test
+    fun `refreshLocationStatus does nothing when location is disabled`() = runTest {
+        failureFlow.value = LocationDiagnostics.StartFailure.NOT_MOCK_APP
+        val vm = viewModel(locationEnabled = false)
+
+        vm.refreshLocationStatus()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { diagnostics.requestStart() }
+    }
+}

--- a/app/src/test/java/com/fauxx/PoisonEngineLoopTest.kt
+++ b/app/src/test/java/com/fauxx/PoisonEngineLoopTest.kt
@@ -11,6 +11,7 @@ import com.fauxx.data.model.IntensityLevel
 import com.fauxx.data.model.PoisonProfile
 import com.fauxx.data.querybank.CategoryPool
 import com.fauxx.data.querybank.QueryBankManager
+import com.fauxx.engine.EngineState
 import com.fauxx.engine.NetworkTransport
 import com.fauxx.engine.PoisonEngine
 import com.fauxx.engine.PoisonProfileRepository
@@ -112,6 +113,32 @@ class PoisonEngineLoopTest {
         assertNotNull("engine should have resigned during quiet hours", resignedWith)
         assertTrue(
             "quiet-hours resignation must use AtTime spec",
+            resignedWith is ResumeSpec.AtTime
+        )
+    }
+
+    @Test
+    fun `an uncaught loop exception tears down and resigns instead of crashing the process`() = runTest {
+        // #197: pre-fix, an exception from the loop machinery (here profile.getProfile()) escaped
+        // engineJob — a SupervisorJob child the supervisor does not absorb — reached the app's
+        // default uncaught handler (FauxxApp), and killed the whole process; isRunning stayed true
+        // so the watchdog couldn't recover. The engine must instead catch it, mark STOPPED, and
+        // resign so an (auto-)resume is scheduled. Under runTest, an uncaught child exception also
+        // fails the test, so this pins the no-propagation contract too.
+        val clock = FakeClock(noonEpochMs())
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        engine = buildEngine(clock, profile = baseProfile, loopDispatcher = dispatcher, profileThrows = true)
+
+        var resignedWith: ResumeSpec? = null
+        engine.setOnLongPause { spec -> resignedWith = spec }
+        engine.start()
+
+        advanceVirtualTime(clock, scheduler = testScheduler, by = 100)
+
+        assertEquals("a crashed loop must end STOPPED", EngineState.STOPPED, engine.engineState.value)
+        assertNotNull("a crashed loop must resign so recovery is scheduled", resignedWith)
+        assertTrue(
+            "loop-failure recovery must use an AtTime auto-resume",
             resignedWith is ResumeSpec.AtTime
         )
     }
@@ -371,10 +398,17 @@ class PoisonEngineLoopTest {
         scheduler: PoissonScheduler = mockk {
             every { nextDelayMs(any(), any(), any(), any(), any()) } returns 1000L
         },
-        searchModule: SearchPoisonModule? = null
+        searchModule: SearchPoisonModule? = null,
+        // #197: when true, profile.getProfile() throws so the loop machinery raises an uncaught
+        // exception, exercising the crash-guard teardown rather than a normal resign.
+        profileThrows: Boolean = false
     ): PoisonEngine {
         val profileRepo: PoisonProfileRepository = mockk {
-            every { getProfile() } returns profile
+            if (profileThrows) {
+                every { getProfile() } throws RuntimeException("boom: corrupt profile read")
+            } else {
+                every { getProfile() } returns profile
+            }
         }
         val dispatcher: ActionDispatcher = mockk {
             coEvery { selectCategory() } returns CategoryPool.GAMING

--- a/app/src/test/java/com/fauxx/PoissonSchedulerTest.kt
+++ b/app/src/test/java/com/fauxx/PoissonSchedulerTest.kt
@@ -190,6 +190,44 @@ class PoissonSchedulerTest {
         }
     }
 
+    // --- Cross-niche upper ceiling (issue #209) ---
+    //
+    // The lognormal dwell multiplier is unbounded, so before the fix a single cross-niche gap
+    // at LOW/MEDIUM could exceed an hour (an already-clamped baseDelay up to 15 min times the
+    // ~4.5x+ lognormal tail), starving the displayed actions/hour — users reported "a few
+    // actions then quiet for most of the hour". The dwell is now clamped to the SAME 3x-mean
+    // ceiling poissonDelay uses, so a cross-niche pause can never exceed a same-topic gap.
+
+    @Test
+    fun `cross-niche delay never exceeds the 3x-mean ceiling at LOW`() {
+        // LOW (12/hr): mean=300s, ceiling=3*300s=900s (15 min). Pre-fix this could blow past an hour.
+        repeat(5000) {
+            val delay = scheduler.nextDelayMs(
+                actionsPerHour = 12,
+                prev = CategoryPool.FINANCE,
+                next = CategoryPool.LEGAL,
+                allowedStart = ALL_HOURS_START,
+                allowedEnd = ALL_HOURS_END
+            )
+            assertTrue("LOW cross-niche must not exceed 900s (got ${delay}ms)", delay <= 900_000L)
+        }
+    }
+
+    @Test
+    fun `cross-niche delay never exceeds the 3x-mean ceiling at MEDIUM`() {
+        // MEDIUM (60/hr): mean=60s, ceiling=3*60s=180s.
+        repeat(5000) {
+            val delay = scheduler.nextDelayMs(
+                actionsPerHour = 60,
+                prev = CategoryPool.FINANCE,
+                next = CategoryPool.LEGAL,
+                allowedStart = ALL_HOURS_START,
+                allowedEnd = ALL_HOURS_END
+            )
+            assertTrue("MEDIUM cross-niche must not exceed 180s (got ${delay}ms)", delay <= 180_000L)
+        }
+    }
+
     // --- Degenerate (start == end) allowed-hours window (issue #124) ---
     //
     // The scheduler's old private predicate evaluated start==end as `hour in start until

--- a/app/src/test/java/com/fauxx/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/fauxx/SettingsViewModelTest.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -62,6 +64,38 @@ class SettingsViewModelTest {
         profileSnapshotDao, targetingEngine, encryptedFileTree, localeManager,
         markovGenerator, circadianObserver
     )
+
+    // --- #201 custom-UA quick wins ---
+
+    @Test
+    fun `setCustomUserAgent strips the WebView wv marker`() = runTest {
+        val vm = viewModel()
+        vm.setCustomUserAgent(
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/AP1A; wv) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36"
+        )
+        advanceUntilIdle()
+        val ua = vm.uiState.value.customUserAgent
+        assertFalse("the '; wv' WebView marker must be stripped", ua.contains("; wv"))
+        assertTrue("the rest of the UA is preserved", ua.contains("Chrome/120.0.0.0"))
+    }
+
+    @Test
+    fun `customUserAgentIsNonChromium flags a Firefox UA but not a Chrome one`() = runTest {
+        val vm = viewModel()
+        vm.setCustomUserAgent("Mozilla/5.0 (Android 14; Mobile; rv:130.0) Gecko/130.0 Firefox/130.0")
+        advanceUntilIdle()
+        assertTrue("a Firefox UA is non-Chromium and ignored on the WebView path",
+            vm.uiState.value.customUserAgentIsNonChromium)
+
+        vm.setCustomUserAgent(
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+        )
+        advanceUntilIdle()
+        assertFalse("a Chrome-on-Android UA must not be flagged",
+            vm.uiState.value.customUserAgentIsNonChromium)
+    }
 
     @Test
     fun `resetToDefaults clears the encrypted logs and the trained Markov model`() = runTest {

--- a/app/src/test/java/com/fauxx/engine/webview/PhantomWebViewClientTest.kt
+++ b/app/src/test/java/com/fauxx/engine/webview/PhantomWebViewClientTest.kt
@@ -2,6 +2,7 @@ package com.fauxx.engine.webview
 
 import android.net.Uri
 import android.net.http.SslError
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.SafeBrowsingResponse
 import android.webkit.SslErrorHandler
 import android.webkit.WebResourceRequest
@@ -194,6 +195,30 @@ class PhantomWebViewClientTest {
         client().onSafeBrowsingHit(view, req, /* threatType */ 1, callback)
 
         verify(exactly = 1) { callback.backToSafety(false) }
+    }
+
+    // --- onRenderProcessGone (issue #210) --------------------------------------
+
+    @Test
+    fun `onRenderProcessGone returns true so Android does not kill the app process`() {
+        var notified: WebView? = null
+        val client = PhantomWebViewClient(blocklist, onRenderGone = { notified = it })
+        val detail: RenderProcessGoneDetail = mockk(relaxed = true)
+        every { detail.didCrash() } returns true
+
+        val handled = client.onRenderProcessGone(view, detail)
+
+        assertTrue("must return true to prevent the app-process kill", handled)
+        assertEquals("the dead WebView must be handed to the pool for replacement", view, notified)
+    }
+
+    @Test
+    fun `onRenderProcessGone still returns true with no callback wired`() {
+        val client = PhantomWebViewClient(blocklist)
+        val detail: RenderProcessGoneDetail = mockk(relaxed = true)
+        every { detail.didCrash() } returns false
+
+        assertTrue(client.onRenderProcessGone(view, detail))
     }
 
     // --- onPageFinished --------------------------------------------------------

--- a/app/src/test/java/com/fauxx/sync/transport/TcpClientTest.kt
+++ b/app/src/test/java/com/fauxx/sync/transport/TcpClientTest.kt
@@ -1,0 +1,88 @@
+package com.fauxx.sync.transport
+
+import com.fauxx.sync.SealedChannel
+import com.fauxx.sync.data.PairedPeer
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.net.InetSocketAddress
+
+/**
+ * #213: route resolution and the manual-IP fallback. The sealed channel authenticates by paired
+ * key, so a manual address is a safe last resort when mDNS is blocked (VPN/proxy/AP isolation).
+ */
+class TcpClientTest {
+
+    private val client = TcpClient(mockk<SealedChannel>(relaxed = true))
+
+    private fun peer(host: String?, port: Int = 48173, pk: String = "PEER_PK") =
+        PairedPeer(name = "dev", publicKey = pk, fingerprint = "fp", host = host, port = port, pairedAt = 0L)
+
+    // --- parseHostPort ---
+
+    @Test
+    fun `parseHostPort accepts a bare IPv4 with the default port`() {
+        val addr = TcpClient.parseHostPort("192.168.1.42", 48173)!!
+        assertEquals("192.168.1.42", addr.hostString)
+        assertEquals(48173, addr.port)
+    }
+
+    @Test
+    fun `parseHostPort accepts an explicit IPv4 port`() {
+        assertEquals(5000, TcpClient.parseHostPort("192.168.1.42:5000", 48173)!!.port)
+    }
+
+    @Test
+    fun `parseHostPort accepts a bracketed IPv6 with port`() {
+        val addr = TcpClient.parseHostPort("[::1]:9000", 48173)
+        assertEquals(9000, addr!!.port)
+    }
+
+    @Test
+    fun `parseHostPort rejects blank, bad port, and out-of-range port`() {
+        assertNull(TcpClient.parseHostPort("   ", 48173))
+        assertNull(TcpClient.parseHostPort("192.168.1.42:notaport", 48173))
+        assertNull(TcpClient.parseHostPort("192.168.1.42:70000", 48173))
+    }
+
+    // --- resolveAddr precedence ---
+
+    @Test
+    fun `resolveAddr prefers an mDNS-fed route`() {
+        val routed = InetSocketAddress("10.0.0.9", 1234)
+        client.setRoute("PEER_PK", routed)
+        client.setManualFallback(InetSocketAddress("10.0.0.99", 5555))
+        assertEquals(routed, client.resolveAddr(peer(host = "10.0.0.5")))
+    }
+
+    @Test
+    fun `resolveAddr falls back to a numeric host hint when no route`() {
+        val addr = client.resolveAddr(peer(host = "10.0.0.5", port = 7000))
+        assertEquals("10.0.0.5", addr!!.hostString)
+        assertEquals(7000, addr.port)
+    }
+
+    @Test
+    fun `resolveAddr ignores a dot-local host and uses the manual fallback`() {
+        val manual = InetSocketAddress("10.0.0.42", 48173)
+        client.setManualFallback(manual)
+        assertEquals(manual, client.resolveAddr(peer(host = "mydevice.local.")))
+    }
+
+    @Test
+    fun `resolveAddr returns null when nothing resolves`() {
+        assertNull(client.resolveAddr(peer(host = "mydevice.local.")))
+        assertNull(client.resolveAddr(peer(host = null)))
+    }
+
+    @Test
+    fun `clearRoutes drops mDNS routes but keeps the manual fallback`() {
+        val manual = InetSocketAddress("10.0.0.42", 48173)
+        client.setRoute("PEER_PK", InetSocketAddress("10.0.0.9", 1234))
+        client.setManualFallback(manual)
+        client.clearRoutes()
+        // route gone -> .local host ignored -> manual fallback remains
+        assertEquals(manual, client.resolveAddr(peer(host = "mydevice.local.")))
+    }
+}

--- a/app/src/test/java/com/fauxx/targeting/layer2/ProfileDriftMetricTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer2/ProfileDriftMetricTest.kt
@@ -32,6 +32,33 @@ class ProfileDriftMetricTest {
     }
 
     @Test
+    fun `an empty imported profile reports NO_PROFILE not collecting`() {
+        // #220: personalized ads off -> the export parses to zero categories, so a drift value can
+        // never accrue. A single empty import must report NO_PROFILE (not "collecting…" forever)...
+        val one = metric.compute(listOf(snap("google", emptyList(), 1)))
+        assertEquals(DriftState.NO_PROFILE, one.state)
+        assertNull(one.klDivergence)
+
+        // ...and even two empty imports, which would otherwise compute a meaningless kl=0.00.
+        val two = metric.compute(
+            listOf(
+                snap("google", emptyList(), 1),
+                snap("google", emptyList(), 2),
+            )
+        )
+        assertEquals(DriftState.NO_PROFILE, two.state)
+        assertNull(two.klDivergence)
+    }
+
+    @Test
+    fun `a non-empty single import is still COLLECTING not NO_PROFILE`() {
+        // Guards the boundary: one real (non-empty) snapshot is genuinely collecting, awaiting a
+        // second to compute drift — it must NOT be misreported as NO_PROFILE.
+        val r = metric.compute(listOf(snap("google", listOf("GAMING"), 1)))
+        assertEquals(DriftState.COLLECTING, r.state)
+    }
+
+    @Test
     fun `identical baseline and latest yields zero drift`() {
         val snaps = listOf(
             snap("google", listOf("GAMING", "MEDICAL"), 1),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ zxingEmbedded = "4.3.0"
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }


### PR DESCRIPTION
See .devloop/drafts/v0.5.1-worklog.md for the task-by-task detail. Bug fixes (#210 WebView renderer crash, #197 engine-loop hardening, #209 dwell cap, #202 live mock-location, #220 NO_PROFILE drift state, #201 UA quick wins) plus the #213 LAN-sync UX repair. All local gates green: testFullDebugUnitTest, koverVerifyFullDebug, lintFullDebug, assembleFullDebug.