### PR TITLE
fix: v0.5.2 bug-fix payload (#239 log-export crash, #234 sync persona convergence)

### DIFF
--- a/app/src/main/java/com/fauxx/service/SyncForegroundService.kt
+++ b/app/src/main/java/com/fauxx/service/SyncForegroundService.kt
@@ -23,6 +23,7 @@ import com.fauxx.sync.pairing.PairingManager
 import com.fauxx.sync.transport.SyncListener
 import com.fauxx.sync.transport.TcpClient
 import com.fauxx.sync.wire.SyncConstants
+import com.fauxx.targeting.layer3.PersonaRotationLayer
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -54,6 +55,7 @@ class SyncForegroundService : Service() {
     @Inject lateinit var multicastLock: MulticastLockHolder
     @Inject lateinit var tcpClient: TcpClient
     @Inject lateinit var pairedPeerRepository: PairedPeerRepository
+    @Inject lateinit var personaRotationLayer: PersonaRotationLayer
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var started = false
@@ -108,7 +110,11 @@ class SyncForegroundService : Service() {
                 val fingerprint = sealedChannel.fingerprint()
                 val name = pairingManager.deviceName()
                 nsdDiscovery.advertise(name, SyncConstants.DEFAULT_SYNC_PORT, pkB64, fingerprint)
-                syncListener.start(scope, SyncConstants.DEFAULT_SYNC_PORT)
+                // Auto-adopt a received persona as the active one (#234) so paired devices converge
+                // to a single coherent persona, rather than the receiver silently keeping its own.
+                syncListener.start(scope, SyncConstants.DEFAULT_SYNC_PORT) { persona, _ ->
+                    personaRotationLayer.adoptSyncedPersona(persona)
+                }
                 // Feed resolved peers that match a paired key into the routing table.
                 nsdDiscovery.discoveredPeers.collectLatest { discovered ->
                     val paired = pairedPeerRepository.getAll().map { it.publicKey }.toHashSet()

--- a/app/src/main/java/com/fauxx/sync/transport/SyncListener.kt
+++ b/app/src/main/java/com/fauxx/sync/transport/SyncListener.kt
@@ -45,8 +45,9 @@ class SyncListener @Inject constructor(
 
     /**
      * Bind [port] (all interfaces) and run the accept loop on [scope]. Idempotent: a second call
-     * while already running is a no-op. [onPersona] is invoked after a synced persona is persisted
-     * (a transparency hook for the UI; persistence is the gate, not this callback).
+     * while already running is a no-op. [onPersona] is invoked after a synced persona is persisted;
+     * the sync session wires it to adopt the persona as the active one (#234) and to surface a
+     * transparency notice. Persistence happens unconditionally here regardless of the callback.
      */
     @Synchronized
     fun start(
@@ -124,8 +125,10 @@ class SyncListener @Inject constructor(
             val (peer, message) = opened
             when (val body = message.body) {
                 is SyncBody.PersonaUpsert -> {
+                    // Persist unconditionally (the transparency gate); onPersona then drives
+                    // adoption of the persona as active (#234). Adoption is logged separately.
                     syncPersonaStore.upsert(body.persona)
-                    Timber.i("LAN sync: applied synced persona %s from %s", body.persona.id, peer.fingerprint)
+                    Timber.i("LAN sync: persisted synced persona %s from %s", body.persona.id, peer.fingerprint)
                     onPersona(body.persona, peer)
                 }
             }

--- a/app/src/main/java/com/fauxx/targeting/layer3/PersonaHistoryDao.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer3/PersonaHistoryDao.kt
@@ -36,6 +36,16 @@ interface PersonaHistoryDao {
     @Query("SELECT * FROM persona_history WHERE createdAt > :sinceMillis ORDER BY createdAt DESC")
     suspend fun getRecentPersonas(sinceMillis: Long): List<PersonaHistoryEntity>
 
+    /**
+     * Personas within retention ordered by INSERT ORDER (autoincrement `id` DESC), so the most
+     * recently STORED persona is first. Used to restore the last-active persona (#234): a persona
+     * adopted from a paired device carries the sender's `createdAt`, which may be older than a local
+     * persona, so `createdAt` ordering would revert the adoption on restart. Insert order does not.
+     * For local-only history, insert order matches `createdAt` order, so restore is unchanged.
+     */
+    @Query("SELECT * FROM persona_history WHERE createdAt > :sinceMillis ORDER BY id DESC")
+    suspend fun getRecentByInsertOrder(sinceMillis: Long): List<PersonaHistoryEntity>
+
     /** Delete all persona history (e.g., "Clear My Profile" action). */
     @Query("DELETE FROM persona_history")
     suspend fun deleteAll()

--- a/app/src/main/java/com/fauxx/targeting/layer3/PersonaRotationLayer.kt
+++ b/app/src/main/java/com/fauxx/targeting/layer3/PersonaRotationLayer.kt
@@ -192,13 +192,60 @@ class PersonaRotationLayer @Inject constructor(
      */
     internal suspend fun restoreMostRecentActivePersona(): SyntheticPersona? {
         val cutoff = clock.currentTimeMillis() - HISTORY_RETENTION_MS
-        val entries = runCatching { historyDao.getRecentPersonas(cutoff) }.getOrNull() ?: return null
+        val entries = runCatching { historyDao.getRecentByInsertOrder(cutoff) }.getOrNull() ?: return null
         val now = clock.currentTimeMillis()
-        // `getRecentPersonas` already sorts DESC by createdAt — first deserializable
-        // entry whose activeUntil is in the future is the right pick.
+        // Ordered by insert order (id DESC): the most recently STORED persona — whether locally
+        // rotated or adopted from a paired device (#234) — is first. First deserializable entry
+        // whose activeUntil is in the future is the currently-active persona. For local-only
+        // history this equals createdAt order, so restore is unchanged for existing users.
         return entries.asSequence()
             .mapNotNull { runCatching { gson.fromJson(it.personaJson, SyntheticPersona::class.java) }.getOrNull() }
             .firstOrNull { it.activeUntil > now }
+    }
+
+    /**
+     * Adopt a persona received from a paired device as the active persona (#234), so paired
+     * devices converge to one coherent persona instead of the receiver silently keeping its own.
+     * Fire-and-forget wrapper over [adoptSyncedPersonaInternal], wired from the sync session (see
+     * [com.fauxx.sync.transport.SyncListener]'s `onPersona` hook).
+     */
+    fun adoptSyncedPersona(persona: SyntheticPersona) {
+        scope.launch { adoptSyncedPersonaInternal(persona) }
+    }
+
+    /**
+     * The adoption body (internal + suspend so tests can await it deterministically, mirroring
+     * [restoreMostRecentActivePersona]).
+     *
+     * A push is an explicit convergence event, not the weekly automatic change-point, so the new
+     * identity is adopted on ALL channels at once (previous persona cleared) rather than staggered.
+     * An already-expired incoming persona is ignored (adopting a dead identity would immediately
+     * rotate it out), and re-delivery of the persona already active is a no-op. The persona is
+     * written to history so the adoption survives a process restart: [restoreMostRecentActivePersona]
+     * reads history by insert order, so this last-stored active persona is the one restored.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun adoptSyncedPersonaInternal(persona: SyntheticPersona) {
+        try {
+            val now = clock.currentTimeMillis()
+            if (now > persona.activeUntil) {
+                Timber.i("LAN sync: ignoring already-expired synced persona ${persona.id}")
+                return
+            }
+            if (_currentPersona.value?.id == persona.id) return // idempotent: already active
+            _previousPersona.value = null
+            _currentPersona.value = persona
+            historyDao.insert(
+                PersonaHistoryEntity(
+                    personaJson = gson.toJson(persona),
+                    createdAt = persona.createdAt
+                )
+            )
+            historyDao.pruneOlderThan(now - HISTORY_RETENTION_MS)
+            Timber.i("LAN sync: adopted synced persona ${persona.name} (${persona.id}) as active")
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to adopt synced persona ${persona.id}")
+        }
     }
 
     /**

--- a/app/src/main/java/com/fauxx/ui/screens/LogExportSheet.kt
+++ b/app/src/main/java/com/fauxx/ui/screens/LogExportSheet.kt
@@ -38,11 +38,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import androidx.core.content.FileProvider
 import com.fauxx.BuildConfig
 import com.fauxx.R
 import com.fauxx.util.CrashReportUrlBuilder
-import java.io.File
+import com.fauxx.util.FileShare
 
 private const val GITHUB_ISSUES_URL = "https://github.com/digital-grease/fauxx/issues/new"
 
@@ -211,25 +210,17 @@ private fun openBugReportForm(context: Context) {
 }
 
 private fun shareViaIntent(context: Context, content: String, fileName: String, subject: String) {
-    val tempFile = File(context.cacheDir, fileName)
-    tempFile.writeText(content)
-
-    val uri = FileProvider.getUriForFile(
-        context,
-        "${context.packageName}.fileprovider",
-        tempFile
+    // Shares the export as a FileProvider stream (never an EXTRA_TEXT extra) so a large log cannot
+    // overflow the Binder transaction limit and crash on startActivity (issue #239).
+    val shared = FileShare.share(
+        context = context,
+        content = content,
+        mimeType = "text/plain",
+        fileName = fileName,
+        chooserTitle = subject,
+        caption = context.getString(R.string.log_export_share_text, subject),
     )
-
-    val intent = Intent(Intent.ACTION_SEND).apply {
-        type = "text/plain"
-        putExtra(Intent.EXTRA_STREAM, uri)
-        putExtra(Intent.EXTRA_SUBJECT, subject)
-        putExtra(Intent.EXTRA_TEXT, context.getString(R.string.log_export_share_text, subject))
-        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-    }
-    try {
-        context.startActivity(Intent.createChooser(intent, subject))
-    } catch (_: ActivityNotFoundException) {
+    if (!shared) {
         Toast.makeText(context, context.getString(R.string.log_export_toast_no_sharing_app), Toast.LENGTH_LONG).show()
     }
 }

--- a/app/src/main/java/com/fauxx/ui/screens/LogScreen.kt
+++ b/app/src/main/java/com/fauxx/ui/screens/LogScreen.kt
@@ -1,6 +1,7 @@
 package com.fauxx.ui.screens
 
 import android.content.Intent
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
@@ -55,6 +56,7 @@ import com.fauxx.data.model.ActionType
 import com.fauxx.ui.format.displayNameRes
 import com.fauxx.ui.viewmodels.LogListItem
 import com.fauxx.ui.viewmodels.LogViewModel
+import com.fauxx.util.FileShare
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -75,9 +77,33 @@ fun LogScreen(
     val context = LocalContext.current
     var showExportMenu by remember { mutableStateOf(false) }
     val chooserTitle = stringResource(R.string.log_export_chooser_title)
+    // Resolve resource values via stringResource (not context.getString on LocalContext.current) so
+    // Compose handles config changes and lint's LocalContextGetResourceValueCall stays satisfied.
+    val noSharingAppMessage = stringResource(R.string.log_export_toast_no_sharing_app)
+    val csvShareCaption = stringResource(R.string.log_export_share_text, "action_log.csv")
+    val jsonShareCaption = stringResource(R.string.log_export_share_text, "action_log.json")
+    val htmlShareCaption = stringResource(R.string.log_export_share_text, "action_log.html")
 
     val onShareEntry: (ActionLogEntity) -> Unit = { entry ->
         shareText(context, viewModel.formatEntry(entry), "text/plain", "action_log_entry.txt", chooserTitle)
+    }
+
+    // Full-log exports (CSV/JSON/HTML) can be several megabytes, so they are shared as a file via
+    // FileProvider, never an Intent EXTRA_TEXT extra. A megabyte in EXTRA_TEXT overflows the ~1MB
+    // Binder transaction limit and crashes on startActivity (issue #239). The per-entry share above
+    // stays inline text because a single entry is tiny.
+    val shareExport: (String, String, String, String) -> Unit = { content, mimeType, fileName, caption ->
+        val shared = FileShare.share(
+            context = context,
+            content = content,
+            mimeType = mimeType,
+            fileName = fileName,
+            chooserTitle = chooserTitle,
+            caption = caption,
+        )
+        if (!shared) {
+            Toast.makeText(context, noSharingAppMessage, Toast.LENGTH_LONG).show()
+        }
     }
 
     Column(
@@ -114,7 +140,7 @@ fun LogScreen(
                         onClick = {
                             showExportMenu = false
                             viewModel.exportCsv { csv ->
-                                shareText(context, csv, "text/csv", "action_log.csv", chooserTitle)
+                                shareExport(csv, "text/csv", "action_log.csv", csvShareCaption)
                             }
                         }
                     )
@@ -123,7 +149,7 @@ fun LogScreen(
                         onClick = {
                             showExportMenu = false
                             viewModel.exportJson { json ->
-                                shareText(context, json, "application/json", "action_log.json", chooserTitle)
+                                shareExport(json, "application/json", "action_log.json", jsonShareCaption)
                             }
                         }
                     )
@@ -132,7 +158,7 @@ fun LogScreen(
                         onClick = {
                             showExportMenu = false
                             viewModel.exportHtml { html ->
-                                shareText(context, html, "text/html", "action_log.html", chooserTitle)
+                                shareExport(html, "text/html", "action_log.html", htmlShareCaption)
                             }
                         }
                     )

--- a/app/src/main/java/com/fauxx/util/FileShare.kt
+++ b/app/src/main/java/com/fauxx/util/FileShare.kt
@@ -1,0 +1,66 @@
+package com.fauxx.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.FileProvider
+import java.io.File
+
+/**
+ * Shares text content through the system share sheet as a FILE, never an inline
+ * Intent extra.
+ *
+ * A full action-log export can be several megabytes. Passing it in
+ * [Intent.EXTRA_TEXT] serializes the whole string into the Binder transaction
+ * that backs `startActivity`, which is capped at ~1MB, so a large export crashes
+ * with `TransactionTooLargeException` (issue #239). Instead the content is
+ * written to the app cache dir and shared as a [FileProvider] content URI in
+ * [Intent.EXTRA_STREAM]; only a short caption rides in [Intent.EXTRA_TEXT], so
+ * the transaction stays tiny regardless of log size.
+ */
+object FileShare {
+
+    /** Write [content] to `<cacheDir>/[fileName]`, returning the file. */
+    fun writeToCache(cacheDir: File, fileName: String, content: String): File =
+        File(cacheDir, fileName).apply { writeText(content) }
+
+    /**
+     * Build the `ACTION_SEND` intent that shares [uri] as [mimeType]. The payload
+     * rides [Intent.EXTRA_STREAM]; [Intent.EXTRA_TEXT] carries only the short
+     * [caption], so no large string is ever placed in an Intent extra (issue #239).
+     */
+    fun buildSendIntent(uri: Uri, mimeType: String, subject: String, caption: String): Intent =
+        Intent(Intent.ACTION_SEND).apply {
+            type = mimeType
+            putExtra(Intent.EXTRA_STREAM, uri)
+            putExtra(Intent.EXTRA_SUBJECT, subject)
+            putExtra(Intent.EXTRA_TEXT, caption)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+
+    /**
+     * Share [content] as a file named [fileName] of [mimeType] via a chooser
+     * titled [chooserTitle]. [caption] is the short body text, never the content
+     * itself. Returns `false` if no app can handle the share, so the caller can
+     * surface a message.
+     */
+    fun share(
+        context: Context,
+        content: String,
+        mimeType: String,
+        fileName: String,
+        chooserTitle: String,
+        caption: String,
+    ): Boolean {
+        val file = writeToCache(context.cacheDir, fileName, content)
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+        val intent = buildSendIntent(uri, mimeType, fileName, caption)
+        return try {
+            context.startActivity(Intent.createChooser(intent, chooserTitle))
+            true
+        } catch (_: ActivityNotFoundException) {
+            false
+        }
+    }
+}

--- a/app/src/test/java/com/fauxx/targeting/layer3/PersonaRotationAdoptTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer3/PersonaRotationAdoptTest.kt
@@ -1,0 +1,123 @@
+package com.fauxx.targeting.layer3
+
+import com.fauxx.data.model.SyntheticPersona
+import com.fauxx.data.querybank.CategoryPool
+import com.google.gson.Gson
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks the auto-adopt contract for issue #234: a persona pushed from a paired device must become
+ * the receiver's ACTIVE persona (so "pushed to 1 peer(s)" actually makes the phones match), not
+ * just land in the synced-personas side table. Adoption is on all channels at once (a push is an
+ * explicit convergence event, not the staggered weekly change-point) and must survive a process
+ * restart even when the sender's persona is OLDER (by createdAt) than a local one.
+ */
+class PersonaRotationAdoptTest {
+
+    private val gson = Gson()
+    private val generator: PersonaGenerator = mockk(relaxed = true)
+    private val oneDay = 24L * 60 * 60 * 1000
+
+    /** In-memory [PersonaHistoryDao] that models autoincrement ids and both orderings. */
+    private class FakeHistoryDao : PersonaHistoryDao {
+        val rows = mutableListOf<PersonaHistoryEntity>()
+        private var nextId = 1L
+        override suspend fun insert(entry: PersonaHistoryEntity) {
+            rows += if (entry.id == 0L) {
+                entry.copy(id = nextId++)
+            } else {
+                nextId = maxOf(nextId, entry.id + 1)
+                entry
+            }
+        }
+        override suspend fun getRecentPersonas(sinceMillis: Long) =
+            rows.filter { it.createdAt > sinceMillis }.sortedByDescending { it.createdAt }
+        override suspend fun getRecentByInsertOrder(sinceMillis: Long) =
+            rows.filter { it.createdAt > sinceMillis }.sortedByDescending { it.id }
+        override suspend fun deleteAll() = rows.clear()
+        override suspend fun pruneOlderThan(beforeMillis: Long) {
+            rows.removeAll { it.createdAt < beforeMillis }
+        }
+    }
+
+    private fun persona(name: String, createdAtOffsetMs: Long, activeUntilOffsetMs: Long): SyntheticPersona {
+        val now = System.currentTimeMillis()
+        return SyntheticPersona(
+            id = name,
+            name = name,
+            ageRange = "35-44",
+            profession = "Engineer",
+            region = "US_MIDWEST",
+            interests = setOf(CategoryPool.TECHNOLOGY),
+            createdAt = now + createdAtOffsetMs,
+            activeUntil = now + activeUntilOffsetMs
+        )
+    }
+
+    private fun historyEntry(persona: SyntheticPersona) =
+        PersonaHistoryEntity(personaJson = gson.toJson(persona), createdAt = persona.createdAt)
+
+    @Test
+    fun `adopting a synced persona makes it the active persona on all channels`() = runTest {
+        val layer = PersonaRotationLayer(generator, FakeHistoryDao())
+        val synced = persona("Synced Sam", createdAtOffsetMs = -oneDay, activeUntilOffsetMs = 5 * oneDay)
+
+        layer.adoptSyncedPersonaInternal(synced)
+
+        assertEquals("Synced Sam", layer.currentPersona.first()?.id)
+        // No staggering for an explicit convergence event: bound channels serve it immediately.
+        layer.setEnabled(true)
+        assertEquals("Synced Sam", layer.personaForChannel(PersonaChannel.WEIGHTS)?.id)
+    }
+
+    @Test
+    fun `adopted synced persona survives restart over a local persona with a newer createdAt`() = runTest {
+        val dao = FakeHistoryDao()
+        val layer = PersonaRotationLayer(generator, dao)
+
+        // A local persona already in history, created MORE recently and still active. Under the old
+        // createdAt-DESC restore this would win on restart and silently revert the adoption (#234).
+        val local = persona("Local Lee", createdAtOffsetMs = -oneDay, activeUntilOffsetMs = 5 * oneDay)
+        dao.insert(historyEntry(local))
+
+        // Synced persona from a paired device: OLDER createdAt, adopted now (so stored later -> higher id).
+        val synced = persona("Synced Sam", createdAtOffsetMs = -3 * oneDay, activeUntilOffsetMs = 4 * oneDay)
+        layer.adoptSyncedPersonaInternal(synced)
+
+        assertEquals("Synced Sam", layer.currentPersona.first()?.id)
+        // The core regression: restore (insert order) returns the adopted persona, not the newer local one.
+        assertEquals("Synced Sam", layer.restoreMostRecentActivePersona()?.id)
+    }
+
+    @Test
+    fun `re-delivering the already-active persona is a no-op`() = runTest {
+        val dao = FakeHistoryDao()
+        val layer = PersonaRotationLayer(generator, dao)
+        val p = persona("Sam", createdAtOffsetMs = 0, activeUntilOffsetMs = 5 * oneDay)
+
+        layer.adoptSyncedPersonaInternal(p)
+        layer.adoptSyncedPersonaInternal(p)
+
+        assertEquals("Sam", layer.currentPersona.first()?.id)
+        val stored = dao.rows.count { gson.fromJson(it.personaJson, SyntheticPersona::class.java).id == "Sam" }
+        assertEquals("idempotent: the persona is stored once, not once per delivery", 1, stored)
+    }
+
+    @Test
+    fun `an already-expired synced persona is not adopted`() = runTest {
+        val dao = FakeHistoryDao()
+        val layer = PersonaRotationLayer(generator, dao)
+        val expired = persona("Expired Ed", createdAtOffsetMs = -10 * oneDay, activeUntilOffsetMs = -oneDay)
+
+        layer.adoptSyncedPersonaInternal(expired)
+
+        assertNull("a dead identity must not become active", layer.currentPersona.first())
+        assertTrue("nothing persisted for an expired adopt", dao.rows.isEmpty())
+    }
+}

--- a/app/src/test/java/com/fauxx/targeting/layer3/PersonaRotationRestoreTest.kt
+++ b/app/src/test/java/com/fauxx/targeting/layer3/PersonaRotationRestoreTest.kt
@@ -40,8 +40,11 @@ class PersonaRotationRestoreTest {
     }
 
     private fun layerWithHistory(entries: List<PersonaHistoryEntity>): PersonaRotationLayer {
+        // Restore reads history by insert order (id DESC) so a synced-adopted persona survives a
+        // restart (#234); these tests supply already-ordered lists with id == createdAt, so the
+        // pick is unchanged from the createdAt-DESC contract this test originally locked (#63).
         val dao: PersonaHistoryDao = mockk(relaxed = true) {
-            coEvery { getRecentPersonas(any()) } returns entries
+            coEvery { getRecentByInsertOrder(any()) } returns entries
         }
         return PersonaRotationLayer(generator, dao)
     }
@@ -108,7 +111,7 @@ class PersonaRotationRestoreTest {
     @Test
     fun `restore returns null when DAO query throws`() = runTest {
         val dao: PersonaHistoryDao = mockk {
-            coEvery { getRecentPersonas(any()) } throws RuntimeException("DB unavailable")
+            coEvery { getRecentByInsertOrder(any()) } throws RuntimeException("DB unavailable")
         }
         val layer = PersonaRotationLayer(generator, dao)
         assertNull(layer.restoreMostRecentActivePersona())

--- a/app/src/test/java/com/fauxx/util/FileShareTest.kt
+++ b/app/src/test/java/com/fauxx/util/FileShareTest.kt
@@ -1,0 +1,79 @@
+package com.fauxx.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Guards the log-export share path against issue #239: a multi-megabyte export must ride
+ * [Intent.EXTRA_STREAM] as a FileProvider URI, never [Intent.EXTRA_TEXT], or `startActivity`
+ * serializes the whole string into the ~1MB Binder transaction and crashes with
+ * `TransactionTooLargeException`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = android.app.Application::class)
+class FileShareTest {
+
+    @Test
+    fun `writeToCache writes the content to a cache file`() {
+        val context = RuntimeEnvironment.getApplication()
+        val file = FileShare.writeToCache(context.cacheDir, "action_log.html", "hello-body")
+        assertTrue(file.exists())
+        assertEquals("hello-body", file.readText())
+    }
+
+    @Test
+    fun `buildSendIntent puts the uri in EXTRA_STREAM and only the caption in EXTRA_TEXT`() {
+        val uri = Uri.parse("content://com.fauxx.fileprovider/cache/action_log.html")
+        val intent = FileShare.buildSendIntent(uri, "text/html", "action_log.html", "Fauxx action log")
+
+        assertEquals(Intent.ACTION_SEND, intent.action)
+        assertEquals("text/html", intent.type)
+        assertEquals(uri, intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
+        assertEquals("Fauxx action log", intent.getStringExtra(Intent.EXTRA_TEXT))
+        assertTrue(
+            "read permission must be granted to the receiving app",
+            intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0,
+        )
+    }
+
+    @Test
+    fun `sharing a multi-megabyte log keeps the payload out of the intent extras`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val big = "X".repeat(2_000_000)
+
+        val shared = FileShare.share(
+            context = activity,
+            content = big,
+            mimeType = "text/html",
+            fileName = "action_log.html",
+            chooserTitle = "Share",
+            caption = "Fauxx action log",
+        )
+
+        assertTrue("share should succeed when a handler exists", shared)
+
+        val chooser = shadowOf(activity).nextStartedActivity
+        assertNotNull("an activity should have been started", chooser)
+        val send = chooser.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java) ?: chooser
+
+        assertEquals(Intent.ACTION_SEND, send.action)
+        assertNotNull("the payload must ride EXTRA_STREAM", send.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
+        assertFalse(
+            "the megabyte payload must never be placed in EXTRA_TEXT (issue #239)",
+            send.getStringExtra(Intent.EXTRA_TEXT)?.contains(big) == true,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

First two bug fixes toward v0.5.2 (patch). Both have confirmed root causes and full local CI-gate coverage.

### #239 — crash exporting logs to HTML (`TransactionTooLargeException`)
The CSV/JSON/HTML log exports passed the whole export string through `Intent.EXTRA_TEXT`, so a multi-megabyte log overflowed the ~1MB Binder transaction limit and crashed `startActivity`. A new `com.fauxx.util.FileShare` writes the content to the cache dir and shares it as a `FileProvider` content URI in `EXTRA_STREAM`, keeping only a short caption in `EXTRA_TEXT`. `LogScreen` exports and `LogExportSheet`'s share option both route through it; per-entry share stays inline text.

### #234 — LAN sync reports success but personas don't converge
A persona pushed from a paired device was persisted to the `synced_personas` side table and shown as a transparency notice, but never adopted as the receiver's active persona — so "pushed to 1 peer(s)" left the phones on different personas. `PersonaRotationLayer.adoptSyncedPersona` now adopts a received persona on all channels immediately (a push is an explicit convergence event, not the staggered weekly change-point), wired through `SyncForegroundService`'s `onPersona` hook. Restore reads history by insert order (`getRecentByInsertOrder`, `id DESC`) so an adopted persona whose sender `createdAt` is older than a local one still wins after a restart; for local-only history this equals `createdAt` order, so the #63 restore behavior is unchanged.

## Testing
All gates green locally (`full` flavor):
- `:app:testFullDebugUnitTest` (full suite)
- `:app:koverVerifyFullDebug` (coverage ratchet)
- `:app:lintFullDebug` (0 errors)
- `:app:assembleFullDebug`

New tests: `FileShareTest` (3, incl. a ~2MB payload asserting it never lands in an Intent string extra) and `PersonaRotationAdoptTest` (4, incl. the restart-robustness regression).

## Notes
- No `version.properties` bump here; the bump + `502.txt` changelogs land at the v0.5.2 cut.

Closes #239
Closes #234
